### PR TITLE
Add Label Format to Physical Label object

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.4.1
+       - image: circleci/ruby:2.4
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-monads", "~> 1.0"
   spec.required_ruby_version = '>= 2.4'
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/friendly_shipping/label.rb
+++ b/lib/friendly_shipping/label.rb
@@ -1,13 +1,14 @@
 module FriendlyShipping
   class Label
-    attr_reader :id, :shipment_id, :tracking_number, :service_code, :label_href, :data
+    attr_reader :id, :shipment_id, :tracking_number, :service_code, :label_href, :data, :label_format
 
-    def initialize(id: nil, shipment_id: nil, tracking_number: nil, service_code: nil, label_href: nil, data: {})
+    def initialize(id: nil, shipment_id: nil, tracking_number: nil, service_code: nil, label_href: nil, label_format: nil, data: {})
       @id = id
       @shipment_id = shipment_id
       @tracking_number = tracking_number
       @service_code = service_code
       @label_href = label_href
+      @label_format = label_format
       @data = data
     end
   end

--- a/lib/friendly_shipping/services/ship_engine/parse_label_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_label_response.rb
@@ -17,6 +17,7 @@ module FriendlyShipping
               tracking_number: parsed_json['tracking_number'],
               service_code: parsed_json['service_code'],
               label_href: parsed_json['label_download']['href'],
+              label_format: parsed_json['label_format'].to_sym,
               data: parsed_json
             )
           ]

--- a/spec/fixtures/ship_engine/labels_success.json
+++ b/spec/fixtures/ship_engine/labels_success.json
@@ -1,0 +1,60 @@
+{
+  "label_id": "se-test-1146755",
+  "status": "processing",
+  "shipment_id": "se-1146755",
+  "ship_date": "2018-12-19T00:00:00Z",
+  "created_at": "2018-12-19T16:06:03.0908903Z",
+  "shipment_cost": {
+    "currency": "usd",
+    "amount": 0.0
+  },
+  "insurance_cost": {
+    "currency": "usd",
+    "amount": 0.0
+  },
+  "tracking_number": "9999999999999",
+  "is_return_label": false,
+  "rma_number": null,
+  "is_international": false,
+  "batch_id": "",
+  "carrier_id": "se-76432",
+  "service_code": "usps_priority_mail",
+  "package_code": "package",
+  "voided": false,
+  "voided_at": null,
+  "label_format": "pdf",
+  "label_layout": "4x6",
+  "trackable": true,
+  "carrier_code": "stamps_com",
+  "tracking_status": "unknown",
+  "label_download": {
+    "href": "https://api.shipengine.com/v1/downloads/10/vCALR7LTeUeaC8aj3_SrPA/testlabel-1146755.pdf"
+  },
+  "form_download": null,
+  "insurance_claim": null,
+  "packages": [
+    {
+      "package_code": "package",
+      "weight": {
+        "value": 49.37,
+        "unit": "ounce"
+      },
+      "dimensions": {
+        "unit": "inch",
+        "length": 0.0,
+        "width": 0.0,
+        "height": 0.0
+      },
+      "insured_value": {
+        "currency": "usd",
+        "amount": 0.00
+      },
+      "tracking_number": null,
+      "label_messages": {
+        "reference1": null,
+        "reference2": null,
+        "reference3": null
+      }
+    }
+  ]
+}

--- a/spec/friendly_shipping/services/ship_engine/parse_label_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_label_response_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::ParseLabelResponse, vcr: { cassette_name: 'shipengine/labels/success' } do
+  subject { described_class.new(response: response).call }
+  let(:response) { double(body: response_body) }
+  let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'labels_success.json')).read }
+
+  let(:label) { subject.first }
+
+  it "returns an Array of labels" do
+    expect(subject).to be_a Array
+    expect(label).to be_a FriendlyShipping::Label
+  end
+
+  it "contains correct data in the carrier" do
+    expect(label.id).to be_present
+    expect(label.shipment_id).to eq('se-1146755')
+    expect(label.tracking_number).to eq('9999999999999')
+    expect(label.service_code).to eq("usps_priority_mail")
+    expect(label.label_href).to start_with('https://')
+    expect(label.label_format).to eq(:pdf)
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe FriendlyShipping::Services::ShipEngine do
         it "has a valid URL" do
           expect(label.label_href).to start_with("https://")
         end
+
+        it "has the right format" do
+          expect(label.label_format).to eq(:pdf)
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,8 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+def gem_root
+  spec = Gem::Specification.find_by_name("friendly_shipping")
+  gem_root = spec.gem_dir
+end


### PR DESCRIPTION
This is more of a convenience method. Technically we could get that out
of the URL or out of the `data` hash, but we really should be using the
dedicated field from the API.