### PR TITLE
Allow specifying a carrier ID from calling code

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -9,7 +9,7 @@ module FriendlyShipping
         end
 
         def call
-          {
+          shipment_hash = {
             label_format: shipment.options[:label_format].presence || "pdf",
             label_download_type: shipment.options[:label_download_type].presence || "url",
             shipment: {
@@ -19,6 +19,10 @@ module FriendlyShipping
               packages: serialize_packages(shipment.packages)
             }
           }
+          if shipment.options[:carrier_id]
+            shipment_hash[:shipment].merge!(carrier_id: shipment.options[:carrier_id])
+          end
+          shipment_hash
         end
 
         private

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -144,4 +144,16 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
       )
     end
   end
+
+  context 'if passing a carrier id' do
+    let(:shipment_options) { {carrier_id: 'se-12345'} }
+
+    it 'includes the carrier ID' do
+      is_expected.to match(
+        hash_including(
+          shipment: hash_including(carrier_id: 'se-12345')
+        )
+      )
+    end
+  end
 end


### PR DESCRIPTION
As ShipEngine is a meta-Shipping provider, they allow specifying a
carrier ID in their request. This PR enables passing the carrier ID as
part of the Physical::Shipment options hash.