### PR TITLE
Do not send package code when not necessary

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -53,10 +53,10 @@ module FriendlyShipping
             if package.container.properties[:usps_label_messages]
               package_hash.merge!(label_messages: package.container.properties[:usps_label_messages])
             end
-            package_code = package.container.properties[:usps_package_code] || "package"
-            package_hash.merge!(package_code: package_code)
-
-            if package_code == 'package'
+            package_code = package.container.properties[:usps_package_code]
+            if package_code
+              package_hash.merge!(package_code: package_code)
+            else
               package_hash.merge!(
                 dimensions: {
                   unit: 'inch',

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
           ),
           packages:[
             {
-              package_code: "package",
               weight: {
                 value: 1.0,
                 unit: "ounce"


### PR DESCRIPTION
The `package` package code is not binding. Let's omit it unless the
calling code specifies a package code.