### PR TITLE
Physical 0.2

### DIFF
--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "physical", "~> 0.1.2"
+  spec.add_runtime_dependency "physical", "~> 0.2.0"
   spec.add_runtime_dependency "rest-client", "~> 2.0"
   spec.add_runtime_dependency "dry-monads", "~> 1.0"
   spec.add_runtime_dependency "data_uri", "~> 0.0.3"

--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -61,7 +61,7 @@ module FriendlyShipping
                 dimensions: {
                   unit: 'inch',
                   width: package.container.width.convert_to(:inches).value.to_f.round(2),
-                  length: package.container.depth.convert_to(:inches).value.to_f.round(2),
+                  length: package.container.length.convert_to(:inches).value.to_f.round(2),
                   height: package.container.height.convert_to(:inches).value.to_f.round(2)
                 }
               )

--- a/lib/friendly_shipping/version.rb
+++ b/lib/friendly_shipping/version.rb
@@ -1,3 +1,3 @@
 module FriendlyShipping
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
-  let(:container) { FactoryBot.build(:physical_box, weight: 0) }
-  let(:item) { FactoryBot.build(:physical_item, weight: 1, weight_unit: :ounce) }
-  let(:package) { FactoryBot.build(:physical_package, items: [item], void_fill_density: 0, container: container) }
+  let(:container) { FactoryBot.build(:physical_box, weight: Measured::Weight(0, :g)) }
+  let(:item) { FactoryBot.build(:physical_item, weight: Measured::Weight(1, :ounce)) }
+  let(:package) { FactoryBot.build(:physical_package, items: [item], void_fill_density: Measured::Weight(0, :g), container: container) }
   let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package], options: shipment_options) }
   let(:shipment_options) { {label_format: 'zpl'} }
   subject { described_class.new(shipment: shipment).call }
@@ -39,27 +39,27 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
             country_code: "US",
             address_residential_indicator: "No"
           ),
-          packages:[
-            {
-              weight: {
+          packages: array_including(
+            hash_including(
+              weight: hash_including(
                 value: 1.0,
                 unit: "ounce"
-              },
-              dimensions: {
+              ),
+              dimensions: hash_including(
                 unit: "inch",
-                width: 15.75,
-                height: 19.69,
-                length: 23.62
-              }
-            }
-          ]
+                length: 23.62,
+                width: 19.69,
+                height: 15.75,
+              )
+            )
+          )
         )
       )
     )
   end
 
   context 'if the container is a special USPS thing' do
-    let(:container) { FactoryBot.build(:physical_box, weight: 0, properties: { usps_package_code: "large_flat_rate_box" }) }
+    let(:container) { FactoryBot.build(:physical_box, weight: Measured::Weight(0, :g), properties: { usps_package_code: "large_flat_rate_box" }) }
 
     it 'does not include the dimensions array' do
       is_expected.to match(
@@ -90,7 +90,7 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
     let(:container) do
       FactoryBot.build(
         :physical_box,
-        weight: 0,
+        weight: Measured::Weight(0, :g),
         properties: {
           usps_label_messages: {
             reference1: "There's such a chill"
@@ -116,7 +116,7 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
     let(:container) do
       FactoryBot.build(
         :physical_box,
-        weight: 0,
+        weight: Measured::Weight(0, :g),
         properties: {
           usps_label_messages: {
             reference1: "There's such a chill",


### PR DESCRIPTION
This updates the `physical` dependency to version 0.2. Physical's API changes are mostly in package construction, not in package consumption, so the changes are almost exclusively in our specs.

