### PR TITLE
Updates Physical usage to 0.3

### DIFF
--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "physical", "~> 0.2.0"
+  spec.add_runtime_dependency "physical", "~> 0.3.0"
   spec.add_runtime_dependency "rest-client", "~> 2.0"
   spec.add_runtime_dependency "dry-monads", "~> 1.0"
   spec.add_runtime_dependency "data_uri", "~> 0.0.3"

--- a/lib/friendly_shipping/version.rb
+++ b/lib/friendly_shipping/version.rb
@@ -1,3 +1,3 @@
 module FriendlyShipping
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
               ),
               dimensions: hash_including(
                 unit: "inch",
-                length: 23.62,
+                length: 15.75,
                 width: 19.69,
-                height: 15.75,
+                height: 23.62,
               )
             )
           )


### PR DESCRIPTION
Physical in version 0.3 does not sort the dimensions of cuboids any
longer and thus will keep their order, which makes for much more
predictable code. This is in line with the behaviour of Physical 0.1.