### PR TITLE
Implement ShipEngine 'void' call

### DIFF
--- a/lib/friendly_shipping/rest_client.rb
+++ b/lib/friendly_shipping/rest_client.rb
@@ -32,6 +32,22 @@ module FriendlyShipping
           Failure(error)
         end
       end
+
+      def put(path, payload, headers)
+        Success(
+          ::RestClient.put(
+            path,
+            payload,
+            headers
+          )
+        )
+      rescue ::RestClient::ExceptionWithResponse => error
+        if error.to_s == '400 Bad Request'
+          Failure(BadRequest.new(error))
+        else
+          Failure(error)
+        end
+      end
     end
   end
 end

--- a/lib/friendly_shipping/rest_client.rb
+++ b/lib/friendly_shipping/rest_client.rb
@@ -13,7 +13,7 @@ module FriendlyShipping
             headers
           )
         )
-      rescue ::RestClient::ExceptionWithResponse => error
+      rescue ::RestClient::Exception => error
         Failure(error)
       end
 
@@ -25,8 +25,8 @@ module FriendlyShipping
             headers
           )
         )
-      rescue ::RestClient::ExceptionWithResponse => error
-        if error.to_s == '400 Bad Request'
+      rescue ::RestClient::Exception => error
+        if error.http_code == 400
           Failure(BadRequest.new(error))
         else
           Failure(error)
@@ -41,8 +41,8 @@ module FriendlyShipping
             headers
           )
         )
-      rescue ::RestClient::ExceptionWithResponse => error
-        if error.to_s == '400 Bad Request'
+      rescue ::RestClient::Exception => error
+        if error.http_code == 400
           Failure(BadRequest.new(error))
         else
           Failure(error)

--- a/lib/friendly_shipping/services/ship_engine.rb
+++ b/lib/friendly_shipping/services/ship_engine.rb
@@ -1,8 +1,10 @@
 
+require 'dry/monads/result'
 require 'friendly_shipping/rest_client'
 require 'friendly_shipping/services/ship_engine/parse_carrier_response'
 require 'friendly_shipping/services/ship_engine/serialize_label_shipment'
 require 'friendly_shipping/services/ship_engine/parse_label_response'
+require 'friendly_shipping/services/ship_engine/parse_void_response'
 
 module FriendlyShipping
   module Services
@@ -30,6 +32,13 @@ module FriendlyShipping
         path = API_BASE + API_PATHS[:labels]
         FriendlyShipping::RestClient.post(path, payload, request_headers).fmap do |response|
           ParseLabelResponse.new(response: response).call
+        end
+      end
+
+      def void(label)
+        path = "#{API_BASE}labels/#{label.id}/void"
+        FriendlyShipping::RestClient.put(path, '', request_headers).bind do |response|
+          ParseVoidResponse.new(response: response).call
         end
       end
 

--- a/lib/friendly_shipping/services/ship_engine/parse_void_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_void_response.rb
@@ -1,0 +1,23 @@
+require 'friendly_shipping/bad_request'
+
+module FriendlyShipping
+  module Services
+    class ShipEngine
+      class ParseVoidResponse
+        include Dry::Monads::Result::Mixin
+
+        attr_reader :response
+
+        def initialize(response:)
+          @response = response
+        end
+
+        def call
+          parsed_json = JSON.parse(response.body)
+          approved, message = parsed_json["approved"], parsed_json["message"]
+          approved ? Success(message) : Failure(message)
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/version.rb
+++ b/lib/friendly_shipping/version.rb
@@ -1,3 +1,3 @@
 module FriendlyShipping
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/friendly_shipping/rest_client_spec.rb
+++ b/spec/friendly_shipping/rest_client_spec.rb
@@ -24,10 +24,23 @@ RSpec.describe FriendlyShipping::RestClient do
       expect(result).to be_success
     end
 
-
     it 'wraps exceptions in Failures' do
       expect(::RestClient).to receive(:post).with('https://example.com', 'body', { "X-Token" => "s3cr3t"}).and_raise(RestClient::ExceptionWithResponse)
       result = described_class.post('https://example.com', 'body', { "X-Token" => "s3cr3t"})
+      expect(result).to be_failure
+    end
+  end
+
+  describe '.put' do
+    it 'forwards the arguments to RestClient and returns a Success' do
+      expect(::RestClient).to receive(:put).with('https://example.com', 'body', { "X-Token" => "s3cr3t"}).and_return(response)
+      result = described_class.put('https://example.com', 'body', { "X-Token" => "s3cr3t"})
+      expect(result).to be_success
+    end
+
+    it 'wraps exceptions in Failures' do
+      expect(::RestClient).to receive(:put).with('https://example.com', 'body', { "X-Token" => "s3cr3t"}).and_raise(RestClient::ExceptionWithResponse)
+      result = described_class.put('https://example.com', 'body', { "X-Token" => "s3cr3t"})
       expect(result).to be_failure
     end
   end

--- a/spec/friendly_shipping/services/ship_engine/parse_void_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_void_response_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::ParseVoidResponse do
+  subject { described_class.new(response: response).call }
+  let(:response) { double(body: response_body) }
+  let(:response_body) do
+    {
+      "approved": true,
+      "message": "Request for refund submitted. This label has been voided."
+    }.to_json
+  end
+
+  context 'for a successful response' do
+    it { is_expected.to be_success }
+
+    it 'wraps the message' do
+      expect(subject.value!).to eq("Request for refund submitted. This label has been voided.")
+    end
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine_spec.rb
@@ -190,4 +190,45 @@ RSpec.describe FriendlyShipping::Services::ShipEngine do
       end
     end
   end
+
+  describe 'void' do
+    let(:label) { FriendlyShipping::Label.new(id: label_id) }
+
+    subject { service.void(label) }
+
+    let(:label_id) { "se-123456" }
+    let(:response) { instance_double('RestClient::Response', body: response_body.to_json) }
+
+    before do
+      expect(::RestClient).to receive(:put).
+        with("https://api.shipengine.com/v1/labels/se-123456/void", "", service.send(:request_headers)).
+        and_return(response)
+    end
+
+    context 'with a voidable label' do
+      let(:response_body) do
+        {
+          "approved": true,
+          "message": "Request for refund submitted.  This label has been voided."
+        }
+      end
+
+      it 'returns a success Monad' do
+        expect(subject).to be_success
+      end
+    end
+
+    context 'with an unvoidable label' do
+      let(:response_body) do
+        {
+          "approved": false,
+          "message": "Could not void this label for some reason"
+        }
+      end
+
+      it 'returns a failure Monad' do
+        expect(subject).to be_failure
+      end
+    end
+  end
 end


### PR DESCRIPTION
This implements the 'void' call to ShipEngine. It's structurally a
little bit different to the other calls, mostly because errors look
slightly different as in the other calls.