### PR TITLE
Add Rate estimating

### DIFF
--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rest-client", "~> 2.0"
   spec.add_runtime_dependency "dry-monads", "~> 1.0"
   spec.add_runtime_dependency "data_uri", "~> 0.0.3"
+  spec.add_runtime_dependency "money", ">= 6.0.0"
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_development_dependency "bundler"

--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -7,6 +7,7 @@ require "friendly_shipping/carrier"
 require "friendly_shipping/services/ship_engine"
 require "friendly_shipping/shipping_method"
 require "friendly_shipping/label"
+require "friendly_shipping/rate"
 
 module FriendlyShipping
 end

--- a/lib/friendly_shipping/rate.rb
+++ b/lib/friendly_shipping/rate.rb
@@ -1,0 +1,41 @@
+module FriendlyShipping
+  class Rate
+    class NoAmountsGiven < StandardError; end
+    attr_reader :shipping_method,
+                :amounts,
+                :remote_service_id,
+                :delivery_date,
+                :warnings,
+                :errors,
+                :data,
+                :original_request,
+                :original_response
+
+    def initialize(
+      shipping_method:,
+      amounts:,
+      remote_service_id: nil,
+      delivery_date: nil,
+      warnings: [],
+      errors: [],
+      data: {},
+      original_request: nil,
+      original_response: nil
+    )
+      @remote_service_id = remote_service_id
+      @shipping_method = shipping_method
+      @amounts = amounts
+      @delivery_date = delivery_date
+      @warnings = warnings
+      @errors = errors
+      @data = data
+      @original_request = original_request
+      @original_response = original_response
+    end
+
+    def total_amount
+      raise NoAmountsGiven if amounts.empty?
+      amounts.map { |_name, amount| amount }.sum
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ship_engine.rb
+++ b/lib/friendly_shipping/services/ship_engine.rb
@@ -3,8 +3,10 @@ require 'dry/monads/result'
 require 'friendly_shipping/services/ship_engine/client'
 require 'friendly_shipping/services/ship_engine/parse_carrier_response'
 require 'friendly_shipping/services/ship_engine/serialize_label_shipment'
+require 'friendly_shipping/services/ship_engine/serialize_rate_estimate_request'
 require 'friendly_shipping/services/ship_engine/parse_label_response'
 require 'friendly_shipping/services/ship_engine/parse_void_response'
+require 'friendly_shipping/services/ship_engine/parse_rate_estimate_response'
 
 module FriendlyShipping
   module Services
@@ -28,6 +30,17 @@ module FriendlyShipping
         )
         client.get(request).fmap do |response|
           ParseCarrierResponse.new(response: response).call
+        end
+      end
+
+      def rate_estimates(shipment, carriers)
+        request = FriendlyShipping::Request.new(
+          url: API_BASE + 'rates/estimate',
+          body: SerializeRateEstimateRequest.(shipment: shipment, carriers: carriers).to_json,
+          headers: request_headers
+        )
+        client.post(request).fmap do |response|
+          ParseRateEstimateResponse.(response: response, request: request, carriers: carriers)
         end
       end
 

--- a/lib/friendly_shipping/services/ship_engine/parse_carrier_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_carrier_response.rb
@@ -11,29 +11,34 @@ module FriendlyShipping
         def call
           parsed_json = JSON.parse(@response.body)
           parsed_json['carriers'].map do |carrier_data|
-            FriendlyShipping::Carrier.new(
+            carrier = FriendlyShipping::Carrier.new(
               id: carrier_data['carrier_id'],
               name: carrier_data['friendly_name'],
               code: carrier_data['carrier_code'],
-              shipping_methods: parse_shipping_methods(carrier_data['services']),
               balance: carrier_data['balance'],
               data: carrier_data
             )
+
+            carrier_data['services'].each do |method_hash|
+              shipping_method = parse_shipping_method(carrier, method_hash)
+              carrier.shipping_methods << shipping_method
+            end
+
+            carrier
           end
         end
 
         private
 
-        def parse_shipping_methods(shipping_methods_data)
-          shipping_methods_data.map do |shipping_method_data|
+        def parse_shipping_method(carrier, shipping_method_data)
             FriendlyShipping::ShippingMethod.new(
+              carrier: carrier,
               name: shipping_method_data["name"],
               service_code: shipping_method_data["service_code"],
               domestic: shipping_method_data["domestic"],
               international: shipping_method_data["international"],
               multi_package: shipping_method_data["is_multi_package_supported"]
             )
-          end
         end
       end
     end

--- a/lib/friendly_shipping/services/ship_engine/parse_rate_estimate_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_rate_estimate_response.rb
@@ -1,0 +1,46 @@
+require 'json'
+require 'money'
+
+module FriendlyShipping
+  module Services
+    class ShipEngine
+      class ParseRateEstimateResponse
+        class << self
+          def call(response:, carriers:, request:)
+            parsed_json = JSON.parse(response.body)
+            parsed_json.map do |rate|
+              carrier = carriers.detect { |c| c.id == rate['carrier_id'] }
+              next unless carrier
+              shipping_method = carrier.shipping_methods.detect { |sm| sm.service_code == rate['service_code'] }
+              next unless shipping_method
+              amounts = get_amounts(rate)
+              FriendlyShipping::Rate.new(
+                shipping_method: shipping_method,
+                amounts: amounts,
+                remote_service_id: rate['rate_id'],
+                delivery_date: Time.parse(rate['estimated_delivery_date']),
+                warnings: rate['warning_messages'],
+                errors: rate['error_messages'],
+                original_request: request,
+                original_response: response
+              )
+            end.compact
+          end
+
+          private
+
+          def get_amounts(rate_hash)
+            [:shipping, :other, :insurance, :confirmation].map do |name|
+              currency = Money::Currency.new(rate_hash["#{name}_amount"]["currency"])
+              amount = rate_hash["#{name}_amount"]["amount"] * currency.subunit_to_unit
+              [
+                name,
+                Money.new(amount, currency)
+              ]
+            end.to_h
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ship_engine/serialize_rate_estimate_request.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_rate_estimate_request.rb
@@ -1,0 +1,25 @@
+module FriendlyShipping
+  module Services
+    class ShipEngine
+      class SerializeRateEstimateRequest
+        def self.call(shipment:, carriers:)
+          {
+            carrier_ids: carriers.map(&:id),
+            from_country_code: shipment.origin.country.alpha_2_code,
+            from_postal_code: shipment.origin.zip,
+            to_country_code: shipment.destination.country.alpha_2_code,
+            to_postal_code: shipment.destination.zip,
+            to_city_locality: shipment.destination.city,
+            to_state_province: shipment.destination.region.code,
+            weight: {
+              value: shipment.packages.map { |p| p.weight.convert_to(:pound).value.to_f }.sum,
+              unit: 'pound'
+            },
+            confirmation: 'none',
+            address_residential_indicator: shipment.destination.residential? ? "yes" : "no"
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/shipping_method.rb
+++ b/lib/friendly_shipping/shipping_method.rb
@@ -1,13 +1,14 @@
 module FriendlyShipping
   class ShippingMethod
-    attr_reader :name, :service_code
+    attr_reader :name, :service_code, :carrier
 
-    def initialize(name: nil, service_code: nil, domestic: nil, international: nil, multi_package: nil)
+    def initialize(name: nil, service_code: nil, domestic: nil, international: nil, multi_package: nil, carrier: nil)
       @name = name
       @service_code = service_code
       @domestic = domestic
       @international = international
       @multi_package = multi_package
+      @carrier = carrier
     end
 
     def domestic?

--- a/spec/cassettes/shipengine/rate_estimates/success.yml
+++ b/spec/cassettes/shipengine/rate_estimates/success.yml
@@ -1,0 +1,521 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.shipengine.com/v1/carriers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Type:
+      - application/json
+      Api-Key:
+      - "<SHIPENGINE_API_KEY>"
+      Host:
+      - api.shipengine.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 31 May 2019 13:52:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '12936'
+      Connection:
+      - keep-alive
+      X-Shipengine-Requestid:
+      - 480b7869-9077-4e68-a28e-afbf22e03b1a
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"carriers\": [\r\n    {\r\n      \"carrier_id\": \"se-76432\",\r\n
+        \     \"carrier_code\": \"stamps_com\",\r\n      \"account_number\": \"mswimm-1717e.\",\r\n
+        \     \"requires_funded_amount\": true,\r\n      \"balance\": 230.6200,\r\n
+        \     \"nickname\": \"CS Stamps\",\r\n      \"friendly_name\": \"Stamps.com\",\r\n
+        \     \"primary\": true,\r\n      \"has_multi_package_supporting_services\":
+        false,\r\n      \"supports_label_messages\": true,\r\n      \"services\":
+        [\r\n        {\r\n          \"carrier_id\": \"se-76432\",\r\n          \"carrier_code\":
+        \"stamps_com\",\r\n          \"service_code\": \"usps_first_class_mail\",\r\n
+        \         \"name\": \"USPS First Class Mail\",\r\n          \"domestic\":
+        true,\r\n          \"international\": false,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-76432\",\r\n
+        \         \"carrier_code\": \"stamps_com\",\r\n          \"service_code\":
+        \"usps_media_mail\",\r\n          \"name\": \"USPS Media Mail\",\r\n          \"domestic\":
+        true,\r\n          \"international\": false,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-76432\",\r\n
+        \         \"carrier_code\": \"stamps_com\",\r\n          \"service_code\":
+        \"usps_parcel_select\",\r\n          \"name\": \"USPS Parcel Select Ground\",\r\n
+        \         \"domestic\": true,\r\n          \"international\": false,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-76432\",\r\n
+        \         \"carrier_code\": \"stamps_com\",\r\n          \"service_code\":
+        \"usps_priority_mail\",\r\n          \"name\": \"USPS Priority Mail\",\r\n
+        \         \"domestic\": true,\r\n          \"international\": false,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-76432\",\r\n
+        \         \"carrier_code\": \"stamps_com\",\r\n          \"service_code\":
+        \"usps_priority_mail_express\",\r\n          \"name\": \"USPS Priority Mail
+        Express\",\r\n          \"domestic\": true,\r\n          \"international\":
+        false,\r\n          \"is_multi_package_supported\": false\r\n        },\r\n
+        \       {\r\n          \"carrier_id\": \"se-76432\",\r\n          \"carrier_code\":
+        \"stamps_com\",\r\n          \"service_code\": \"usps_first_class_mail_international\",\r\n
+        \         \"name\": \"USPS First Class Mail Intl\",\r\n          \"domestic\":
+        false,\r\n          \"international\": true,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-76432\",\r\n
+        \         \"carrier_code\": \"stamps_com\",\r\n          \"service_code\":
+        \"usps_priority_mail_international\",\r\n          \"name\": \"USPS Priority
+        Mail Intl\",\r\n          \"domestic\": false,\r\n          \"international\":
+        true,\r\n          \"is_multi_package_supported\": false\r\n        },\r\n
+        \       {\r\n          \"carrier_id\": \"se-76432\",\r\n          \"carrier_code\":
+        \"stamps_com\",\r\n          \"service_code\": \"usps_priority_mail_express_international\",\r\n
+        \         \"name\": \"USPS Priority Mail Express Intl\",\r\n          \"domestic\":
+        false,\r\n          \"international\": true,\r\n          \"is_multi_package_supported\":
+        false\r\n        }\r\n      ],\r\n      \"packages\": [\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"cubic\",\r\n          \"name\": \"Cubic\",\r\n
+        \         \"description\": \"Cubic\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"flat_rate_envelope\",\r\n          \"name\":
+        \"Flat Rate Envelope\",\r\n          \"description\": \"USPS flat rate envelope.
+        A special cardboard envelope provided by the USPS that clearly indicates \\\"Flat
+        Rate\\\".\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n
+        \         \"package_code\": \"flat_rate_legal_envelope\",\r\n          \"name\":
+        \"Flat Rate Legal Envelope\",\r\n          \"description\": \"Flat Rate Legal
+        Envelope\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n
+        \         \"package_code\": \"flat_rate_padded_envelope\",\r\n          \"name\":
+        \"Flat Rate Padded Envelope\",\r\n          \"description\": \"Flat Rate Padded
+        Envelope\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n
+        \         \"package_code\": \"large_envelope_or_flat\",\r\n          \"name\":
+        \"Large Envelope or Flat\",\r\n          \"description\": \"Large envelope
+        or flat. Has one dimension that is between 11 1/2\\\" and 15\\\" long, 6 1/18\\\"
+        and 12\\\" high, or 1/4\\\" and 3/4\\\" thick.\"\r\n        },\r\n        {\r\n
+        \         \"package_id\": null,\r\n          \"package_code\": \"large_flat_rate_box\",\r\n
+        \         \"name\": \"Large Flat Rate Box\",\r\n          \"description\":
+        \"Large Flat Rate Box\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"large_package\",\r\n          \"name\":
+        \"Large Package (any side > 12\\\")\",\r\n          \"description\": \"Large
+        package. Longest side plus the distance around the thickest part is over 84\\\"
+        and less than or equal to 108\\\".\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"letter\",\r\n          \"name\": \"Letter\",\r\n
+        \         \"description\": \"Letter\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"medium_flat_rate_box\",\r\n          \"name\":
+        \"Medium Flat Rate Box\",\r\n          \"description\": \"USPS flat rate box.
+        A special 11\\\" x 8 1/2\\\" x 5 1/2\\\" or 14\\\" x 3.5\\\" x 12\\\" USPS
+        box that clearly indicates \\\"Flat Rate Box\\\"\"\r\n        },\r\n        {\r\n
+        \         \"package_id\": null,\r\n          \"package_code\": \"package\",\r\n
+        \         \"name\": \"Package\",\r\n          \"description\": \"Package.
+        Longest side plus the distance around the thickest part is less than or equal
+        to 84\\\"\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n
+        \         \"package_code\": \"regional_rate_box_a\",\r\n          \"name\":
+        \"Regional Rate Box A\",\r\n          \"description\": \"Regional Rate Box
+        A\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n          \"package_code\":
+        \"regional_rate_box_b\",\r\n          \"name\": \"Regional Rate Box B\",\r\n
+        \         \"description\": \"Regional Rate Box B\"\r\n        },\r\n        {\r\n
+        \         \"package_id\": null,\r\n          \"package_code\": \"small_flat_rate_box\",\r\n
+        \         \"name\": \"Small Flat Rate Box\",\r\n          \"description\":
+        \"Small Flat Rate Box\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"thick_envelope\",\r\n          \"name\":
+        \"Thick Envelope\",\r\n          \"description\": \"Thick envelope. Envelopes
+        or flats greater than 3/4\\\" at the thickest point.\"\r\n        }\r\n      ],\r\n
+        \     \"options\": [\r\n        {\r\n          \"name\": \"non_machinable\",\r\n
+        \         \"default_value\": \"false\",\r\n          \"description\": \"\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    {\r\n      \"carrier_id\": \"se-91692\",\r\n
+        \     \"carrier_code\": \"endicia\",\r\n      \"account_number\": \"1304176\",\r\n
+        \     \"requires_funded_amount\": true,\r\n      \"balance\": 1000.36,\r\n
+        \     \"nickname\": \"CandleScience Endicia\",\r\n      \"friendly_name\":
+        \"Endicia\",\r\n      \"primary\": true,\r\n      \"has_multi_package_supporting_services\":
+        false,\r\n      \"supports_label_messages\": true,\r\n      \"services\":
+        [\r\n        {\r\n          \"carrier_id\": \"se-91692\",\r\n          \"carrier_code\":
+        \"endicia\",\r\n          \"service_code\": \"usps_first_class_mail\",\r\n
+        \         \"name\": \"USPS First Class Mail\",\r\n          \"domestic\":
+        true,\r\n          \"international\": false,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-91692\",\r\n
+        \         \"carrier_code\": \"endicia\",\r\n          \"service_code\": \"usps_media_mail\",\r\n
+        \         \"name\": \"USPS Media Mail\",\r\n          \"domestic\": true,\r\n
+        \         \"international\": false,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-91692\",\r\n
+        \         \"carrier_code\": \"endicia\",\r\n          \"service_code\": \"usps_parcel_select\",\r\n
+        \         \"name\": \"USPS Parcel Select Ground\",\r\n          \"domestic\":
+        true,\r\n          \"international\": false,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-91692\",\r\n
+        \         \"carrier_code\": \"endicia\",\r\n          \"service_code\": \"usps_priority_mail\",\r\n
+        \         \"name\": \"USPS Priority Mail\",\r\n          \"domestic\": true,\r\n
+        \         \"international\": false,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-91692\",\r\n
+        \         \"carrier_code\": \"endicia\",\r\n          \"service_code\": \"usps_priority_mail_express\",\r\n
+        \         \"name\": \"USPS Priority Mail Express\",\r\n          \"domestic\":
+        true,\r\n          \"international\": false,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-91692\",\r\n
+        \         \"carrier_code\": \"endicia\",\r\n          \"service_code\": \"usps_first_class_package_international\",\r\n
+        \         \"name\": \"USPS First Class Package Intl\",\r\n          \"domestic\":
+        false,\r\n          \"international\": true,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-91692\",\r\n
+        \         \"carrier_code\": \"endicia\",\r\n          \"service_code\": \"usps_first_class_mail_international\",\r\n
+        \         \"name\": \"USPS First Class Mail Intl\",\r\n          \"domestic\":
+        false,\r\n          \"international\": true,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-91692\",\r\n
+        \         \"carrier_code\": \"endicia\",\r\n          \"service_code\": \"usps_priority_mail_international\",\r\n
+        \         \"name\": \"USPS Priority Mail Intl\",\r\n          \"domestic\":
+        false,\r\n          \"international\": true,\r\n          \"is_multi_package_supported\":
+        false\r\n        },\r\n        {\r\n          \"carrier_id\": \"se-91692\",\r\n
+        \         \"carrier_code\": \"endicia\",\r\n          \"service_code\": \"usps_priority_mail_express_international\",\r\n
+        \         \"name\": \"USPS Priority Mail Express Intl\",\r\n          \"domestic\":
+        false,\r\n          \"international\": true,\r\n          \"is_multi_package_supported\":
+        false\r\n        }\r\n      ],\r\n      \"packages\": [\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"cubic\",\r\n          \"name\": \"Cubic\",\r\n
+        \         \"description\": \"Cubic\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"flat_rate_envelope\",\r\n          \"name\":
+        \"Flat Rate Envelope\",\r\n          \"description\": \"USPS flat rate envelope.
+        A special cardboard envelope provided by the USPS that clearly indicates \\\"Flat
+        Rate\\\".\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n
+        \         \"package_code\": \"flat_rate_legal_envelope\",\r\n          \"name\":
+        \"Flat Rate Legal Envelope\",\r\n          \"description\": \"Flat Rate Legal
+        Envelope\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n
+        \         \"package_code\": \"flat_rate_padded_envelope\",\r\n          \"name\":
+        \"Flat Rate Padded Envelope\",\r\n          \"description\": \"Flat Rate Padded
+        Envelope\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n
+        \         \"package_code\": \"large_envelope_or_flat\",\r\n          \"name\":
+        \"Large Envelope or Flat\",\r\n          \"description\": \"Large envelope
+        or flat. Has one dimension that is between 11 1/2\\\" and 15\\\" long, 6 1/18\\\"
+        and 12\\\" high, or 1/4\\\" and 3/4\\\" thick.\"\r\n        },\r\n        {\r\n
+        \         \"package_id\": null,\r\n          \"package_code\": \"large_flat_rate_box\",\r\n
+        \         \"name\": \"Large Flat Rate Box\",\r\n          \"description\":
+        \"Large Flat Rate Box\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"large_package\",\r\n          \"name\":
+        \"Large Package (any side > 12\\\")\",\r\n          \"description\": \"Large
+        package. Longest side plus the distance around the thickest part is over 84\\\"
+        and less than or equal to 108\\\".\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"letter\",\r\n          \"name\": \"Letter\",\r\n
+        \         \"description\": \"Letter\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"medium_flat_rate_box\",\r\n          \"name\":
+        \"Medium Flat Rate Box\",\r\n          \"description\": \"USPS flat rate box.
+        A special 11\\\" x 8 1/2\\\" x 5 1/2\\\" or 14\\\" x 3.5\\\" x 12\\\" USPS
+        box that clearly indicates \\\"Flat Rate Box\\\"\"\r\n        },\r\n        {\r\n
+        \         \"package_id\": null,\r\n          \"package_code\": \"package\",\r\n
+        \         \"name\": \"Package\",\r\n          \"description\": \"Package.
+        Longest side plus the distance around the thickest part is less than or equal
+        to 84\\\"\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n
+        \         \"package_code\": \"regional_rate_box_a\",\r\n          \"name\":
+        \"Regional Rate Box A\",\r\n          \"description\": \"Regional Rate Box
+        A\"\r\n        },\r\n        {\r\n          \"package_id\": null,\r\n          \"package_code\":
+        \"regional_rate_box_b\",\r\n          \"name\": \"Regional Rate Box B\",\r\n
+        \         \"description\": \"Regional Rate Box B\"\r\n        },\r\n        {\r\n
+        \         \"package_id\": null,\r\n          \"package_code\": \"small_flat_rate_box\",\r\n
+        \         \"name\": \"Small Flat Rate Box\",\r\n          \"description\":
+        \"Small Flat Rate Box\"\r\n        },\r\n        {\r\n          \"package_id\":
+        null,\r\n          \"package_code\": \"thick_envelope\",\r\n          \"name\":
+        \"Thick Envelope\",\r\n          \"description\": \"Thick envelope. Envelopes
+        or flats greater than 3/4\\\" at the thickest point.\"\r\n        }\r\n      ],\r\n
+        \     \"options\": [\r\n        {\r\n          \"name\": \"non_machinable\",\r\n
+        \         \"default_value\": \"false\",\r\n          \"description\": \"\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Fri, 31 May 2019 13:52:55 GMT
+- request:
+    method: post
+    uri: https://api.shipengine.com/v1/rates/estimate
+    body:
+      encoding: UTF-8
+      string: '{"carrier_ids":["se-76432","se-91692"],"from_country_code":"US","from_postal_code":"78756","to_country_code":"US","to_postal_code":"91521","to_city_locality":"Herndon","to_state_province":"IL","weight":{"value":5.852699859126819,"unit":"pound"},"confirmation":"none","address_residential_indicator":"no"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Type:
+      - application/json
+      Api-Key:
+      - "<SHIPENGINE_API_KEY>"
+      Content-Length:
+      - '304'
+      Host:
+      - api.shipengine.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 31 May 2019 13:52:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '18991'
+      Connection:
+      - keep-alive
+      X-Shipengine-Requestid:
+      - 1dd819f8-df30-4598-a946-c063800e781d
+    body:
+      encoding: UTF-8
+      string: "[\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        5.35\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"package\",\r\n    \"delivery_days\": 7,\r\n
+        \   \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\": \"2019-06-07T00:00:00Z\",\r\n
+        \   \"carrier_delivery_days\": \"6\",\r\n    \"ship_date\": \"2019-05-31T00:00:00Z\",\r\n
+        \   \"negotiated_rate\": false,\r\n    \"service_type\": \"USPS Media Mail\",\r\n
+        \   \"service_code\": \"usps_media_mail\",\r\n    \"trackable\": true,\r\n
+        \   \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\": \"CS Stamps\",\r\n
+        \   \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        17.68\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"package\",\r\n    \"delivery_days\": 7,\r\n
+        \   \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\": \"2019-06-07T00:00:00Z\",\r\n
+        \   \"carrier_delivery_days\": \"6\",\r\n    \"ship_date\": \"2019-05-31T00:00:00Z\",\r\n
+        \   \"negotiated_rate\": false,\r\n    \"service_type\": \"USPS Parcel Select
+        Ground\",\r\n    \"service_code\": \"usps_parcel_select\",\r\n    \"trackable\":
+        true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        17.93\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"package\",\r\n    \"delivery_days\": 4,\r\n
+        \   \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\": \"2019-06-04T00:00:00Z\",\r\n
+        \   \"carrier_delivery_days\": \"3\",\r\n    \"ship_date\": \"2019-05-31T00:00:00Z\",\r\n
+        \   \"negotiated_rate\": false,\r\n    \"service_type\": \"USPS Priority Mail\",\r\n
+        \   \"service_code\": \"usps_priority_mail\",\r\n    \"trackable\": true,\r\n
+        \   \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\": \"CS Stamps\",\r\n
+        \   \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        12.8\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"medium_flat_rate_box\",\r\n    \"delivery_days\":
+        4,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-04T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"3\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail\",\r\n    \"service_code\": \"usps_priority_mail\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        7.5\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"small_flat_rate_box\",\r\n    \"delivery_days\":
+        4,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-04T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"3\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail\",\r\n    \"service_code\": \"usps_priority_mail\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        17.6\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"large_flat_rate_box\",\r\n    \"delivery_days\":
+        4,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-04T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"3\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail\",\r\n    \"service_code\": \"usps_priority_mail\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        6.95\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"flat_rate_envelope\",\r\n    \"delivery_days\":
+        4,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-04T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"3\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail\",\r\n    \"service_code\": \"usps_priority_mail\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        7.55\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"flat_rate_padded_envelope\",\r\n    \"delivery_days\":
+        4,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-04T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"3\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail\",\r\n    \"service_code\": \"usps_priority_mail\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        9.95\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"regional_rate_box_a\",\r\n    \"delivery_days\":
+        4,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-04T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"3\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail\",\r\n    \"service_code\": \"usps_priority_mail\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        16.1\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"regional_rate_box_b\",\r\n    \"delivery_days\":
+        4,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-04T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"3\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail\",\r\n    \"service_code\": \"usps_priority_mail\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        7.25\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"flat_rate_legal_envelope\",\r\n    \"delivery_days\":
+        4,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-04T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"3\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail\",\r\n    \"service_code\": \"usps_priority_mail\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        58.61\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"package\",\r\n    \"delivery_days\": 2,\r\n
+        \   \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\": \"2019-06-03T00:00:00Z\",\r\n
+        \   \"carrier_delivery_days\": \"1-2\",\r\n    \"ship_date\": \"2019-05-31T00:00:00Z\",\r\n
+        \   \"negotiated_rate\": false,\r\n    \"service_type\": \"USPS Priority Mail
+        Express\",\r\n    \"service_code\": \"usps_priority_mail_express\",\r\n    \"trackable\":
+        true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        22.68\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"flat_rate_envelope\",\r\n    \"delivery_days\":
+        2,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-03T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"1-2\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail Express\",\r\n    \"service_code\": \"usps_priority_mail_express\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        23.18\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"flat_rate_padded_envelope\",\r\n    \"delivery_days\":
+        2,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-03T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"1-2\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail Express\",\r\n    \"service_code\": \"usps_priority_mail_express\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-76432\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        22.8\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": \"flat_rate_legal_envelope\",\r\n    \"delivery_days\":
+        2,\r\n    \"guaranteed_service\": false,\r\n    \"estimated_delivery_date\":
+        \"2019-06-03T00:00:00Z\",\r\n    \"carrier_delivery_days\": \"1-2\",\r\n    \"ship_date\":
+        \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\": false,\r\n    \"service_type\":
+        \"USPS Priority Mail Express\",\r\n    \"service_code\": \"usps_priority_mail_express\",\r\n
+        \   \"trackable\": true,\r\n    \"carrier_code\": \"stamps_com\",\r\n    \"carrier_nickname\":
+        \"CS Stamps\",\r\n    \"carrier_friendly_name\": \"Stamps.com\",\r\n    \"validation_status\":
+        \"unknown\",\r\n    \"warning_messages\": [],\r\n    \"error_messages\": []\r\n
+        \ },\r\n  {\r\n    \"rate_type\": \"check\",\r\n    \"carrier_id\": \"se-91692\",\r\n
+        \   \"shipping_amount\": {\r\n      \"currency\": \"usd\",\r\n      \"amount\":
+        5.35\r\n    },\r\n    \"insurance_amount\": {\r\n      \"currency\": \"usd\",\r\n
+        \     \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\": {\r\n
+        \     \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": null,\r\n    \"delivery_days\": 0,\r\n    \"guaranteed_service\":
+        false,\r\n    \"estimated_delivery_date\": \"2019-05-31T00:00:00Z\",\r\n    \"carrier_delivery_days\":
+        \"0\",\r\n    \"ship_date\": \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\":
+        false,\r\n    \"service_type\": \"USPS Media Mail\",\r\n    \"service_code\":
+        \"usps_media_mail\",\r\n    \"trackable\": true,\r\n    \"carrier_code\":
+        \"endicia\",\r\n    \"carrier_nickname\": \"CandleScience Endicia\",\r\n    \"carrier_friendly_name\":
+        \"Endicia\",\r\n    \"validation_status\": \"unknown\",\r\n    \"warning_messages\":
+        [],\r\n    \"error_messages\": []\r\n  },\r\n  {\r\n    \"rate_type\": \"check\",\r\n
+        \   \"carrier_id\": \"se-91692\",\r\n    \"shipping_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 17.68\r\n    },\r\n    \"insurance_amount\":
+        {\r\n      \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\":
+        {\r\n      \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\":
+        {\r\n      \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": null,\r\n    \"delivery_days\": 0,\r\n    \"guaranteed_service\":
+        false,\r\n    \"estimated_delivery_date\": \"2019-05-31T00:00:00Z\",\r\n    \"carrier_delivery_days\":
+        \"0\",\r\n    \"ship_date\": \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\":
+        false,\r\n    \"service_type\": \"USPS Parcel Select Ground\",\r\n    \"service_code\":
+        \"usps_parcel_select\",\r\n    \"trackable\": true,\r\n    \"carrier_code\":
+        \"endicia\",\r\n    \"carrier_nickname\": \"CandleScience Endicia\",\r\n    \"carrier_friendly_name\":
+        \"Endicia\",\r\n    \"validation_status\": \"unknown\",\r\n    \"warning_messages\":
+        [],\r\n    \"error_messages\": []\r\n  },\r\n  {\r\n    \"rate_type\": \"check\",\r\n
+        \   \"carrier_id\": \"se-91692\",\r\n    \"shipping_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 17.93\r\n    },\r\n    \"insurance_amount\":
+        {\r\n      \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\":
+        {\r\n      \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\":
+        {\r\n      \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": null,\r\n    \"delivery_days\": 3,\r\n    \"guaranteed_service\":
+        false,\r\n    \"estimated_delivery_date\": \"2019-06-03T00:00:00Z\",\r\n    \"carrier_delivery_days\":
+        \"3\",\r\n    \"ship_date\": \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\":
+        false,\r\n    \"service_type\": \"USPS Priority Mail\",\r\n    \"service_code\":
+        \"usps_priority_mail\",\r\n    \"trackable\": true,\r\n    \"carrier_code\":
+        \"endicia\",\r\n    \"carrier_nickname\": \"CandleScience Endicia\",\r\n    \"carrier_friendly_name\":
+        \"Endicia\",\r\n    \"validation_status\": \"unknown\",\r\n    \"warning_messages\":
+        [],\r\n    \"error_messages\": []\r\n  },\r\n  {\r\n    \"rate_type\": \"check\",\r\n
+        \   \"carrier_id\": \"se-91692\",\r\n    \"shipping_amount\": {\r\n      \"currency\":
+        \"usd\",\r\n      \"amount\": 58.61\r\n    },\r\n    \"insurance_amount\":
+        {\r\n      \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"confirmation_amount\":
+        {\r\n      \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"other_amount\":
+        {\r\n      \"currency\": \"usd\",\r\n      \"amount\": 0.0\r\n    },\r\n    \"zone\":
+        6,\r\n    \"package_type\": null,\r\n    \"delivery_days\": 1,\r\n    \"guaranteed_service\":
+        false,\r\n    \"estimated_delivery_date\": \"2019-06-01T00:00:00Z\",\r\n    \"carrier_delivery_days\":
+        \"1\",\r\n    \"ship_date\": \"2019-05-31T00:00:00Z\",\r\n    \"negotiated_rate\":
+        false,\r\n    \"service_type\": \"USPS Priority Mail Express\",\r\n    \"service_code\":
+        \"usps_priority_mail_express\",\r\n    \"trackable\": true,\r\n    \"carrier_code\":
+        \"endicia\",\r\n    \"carrier_nickname\": \"CandleScience Endicia\",\r\n    \"carrier_friendly_name\":
+        \"Endicia\",\r\n    \"validation_status\": \"unknown\",\r\n    \"warning_messages\":
+        [],\r\n    \"error_messages\": []\r\n  }\r\n]"
+    http_version: 
+  recorded_at: Fri, 31 May 2019 13:52:57 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/ship_engine/rate_estimates_success.json
+++ b/spec/fixtures/ship_engine/rate_estimates_success.json
@@ -1,0 +1,705 @@
+[
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 5.35
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "package",
+    "delivery_days": 7,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-07T00:00:00Z",
+    "carrier_delivery_days": "6",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Media Mail",
+    "service_code": "usps_media_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 17.68
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "package",
+    "delivery_days": 7,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-07T00:00:00Z",
+    "carrier_delivery_days": "6",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Parcel Select Ground",
+    "service_code": "usps_parcel_select",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 17.93
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "package",
+    "delivery_days": 4,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-04T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 12.8
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "medium_flat_rate_box",
+    "delivery_days": 4,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-04T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 7.5
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "small_flat_rate_box",
+    "delivery_days": 4,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-04T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 17.6
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "large_flat_rate_box",
+    "delivery_days": 4,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-04T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 6.95
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "flat_rate_envelope",
+    "delivery_days": 4,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-04T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 7.55
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "flat_rate_padded_envelope",
+    "delivery_days": 4,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-04T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 9.95
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "regional_rate_box_a",
+    "delivery_days": 4,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-04T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 16.1
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "regional_rate_box_b",
+    "delivery_days": 4,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-04T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 7.25
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "flat_rate_legal_envelope",
+    "delivery_days": 4,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-04T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 58.61
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "package",
+    "delivery_days": 2,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-03T00:00:00Z",
+    "carrier_delivery_days": "1-2",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail Express",
+    "service_code": "usps_priority_mail_express",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 22.68
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "flat_rate_envelope",
+    "delivery_days": 2,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-03T00:00:00Z",
+    "carrier_delivery_days": "1-2",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail Express",
+    "service_code": "usps_priority_mail_express",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 23.18
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "flat_rate_padded_envelope",
+    "delivery_days": 2,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-03T00:00:00Z",
+    "carrier_delivery_days": "1-2",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail Express",
+    "service_code": "usps_priority_mail_express",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-76432",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 22.8
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": "flat_rate_legal_envelope",
+    "delivery_days": 2,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-03T00:00:00Z",
+    "carrier_delivery_days": "1-2",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail Express",
+    "service_code": "usps_priority_mail_express",
+    "trackable": true,
+    "carrier_code": "stamps_com",
+    "carrier_nickname": "CS Stamps",
+    "carrier_friendly_name": "Stamps.com",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-91692",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 5.35
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": null,
+    "delivery_days": 0,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-05-31T00:00:00Z",
+    "carrier_delivery_days": "0",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Media Mail",
+    "service_code": "usps_media_mail",
+    "trackable": true,
+    "carrier_code": "endicia",
+    "carrier_nickname": "CandleScience Endicia",
+    "carrier_friendly_name": "Endicia",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-91692",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 17.68
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": null,
+    "delivery_days": 0,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-05-31T00:00:00Z",
+    "carrier_delivery_days": "0",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Parcel Select Ground",
+    "service_code": "usps_parcel_select",
+    "trackable": true,
+    "carrier_code": "endicia",
+    "carrier_nickname": "CandleScience Endicia",
+    "carrier_friendly_name": "Endicia",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-91692",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 17.93
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": null,
+    "delivery_days": 3,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-03T00:00:00Z",
+    "carrier_delivery_days": "3",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail",
+    "service_code": "usps_priority_mail",
+    "trackable": true,
+    "carrier_code": "endicia",
+    "carrier_nickname": "CandleScience Endicia",
+    "carrier_friendly_name": "Endicia",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  },
+  {
+    "rate_type": "check",
+    "carrier_id": "se-91692",
+    "shipping_amount": {
+      "currency": "usd",
+      "amount": 58.61
+    },
+    "insurance_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "confirmation_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "other_amount": {
+      "currency": "usd",
+      "amount": 0.0
+    },
+    "zone": 6,
+    "package_type": null,
+    "delivery_days": 1,
+    "guaranteed_service": false,
+    "estimated_delivery_date": "2019-06-01T00:00:00Z",
+    "carrier_delivery_days": "1",
+    "ship_date": "2019-05-31T00:00:00Z",
+    "negotiated_rate": false,
+    "service_type": "USPS Priority Mail Express",
+    "service_code": "usps_priority_mail_express",
+    "trackable": true,
+    "carrier_code": "endicia",
+    "carrier_nickname": "CandleScience Endicia",
+    "carrier_friendly_name": "Endicia",
+    "validation_status": "unknown",
+    "warning_messages": [],
+    "error_messages": []
+  }
+]

--- a/spec/friendly_shipping/rate_spec.rb
+++ b/spec/friendly_shipping/rate_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Rate do
+  subject do
+    described_class.new(
+      shipping_method: FriendlyShipping::ShippingMethod.new,
+      amounts: { shipping: Money.new(1000, 'USD')}
+    )
+  end
+  it { is_expected.to respond_to(:shipping_method) }
+  it { is_expected.to respond_to(:remote_service_id) }
+  it { is_expected.to respond_to(:delivery_date) }
+  it { is_expected.to respond_to(:warnings) }
+  it { is_expected.to respond_to(:errors) }
+  it { is_expected.to respond_to(:data) }
+
+  describe '#total_amount' do
+    subject do
+      described_class.new(
+        shipping_method: FriendlyShipping::ShippingMethod.new,
+        amounts: amounts
+      ).total_amount
+    end
+
+    context 'if no amounts given' do
+      let(:amounts) { [] }
+
+      it 'raises an exception' do
+        expect { subject }.to raise_exception { FriendlyShipping::Rate::NoAmountsGiven }
+      end
+    end
+
+    context 'if amounts given' do
+      let(:amounts) { {shipping: Money.new(1200, "USD"), other: Money.new(300, "USD")} }
+
+      it { is_expected.to eq(Money.new(1500, "USD")) }
+    end
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine/parse_rate_estimate_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_rate_estimate_response_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::ParseRateEstimateResponse do
+  let(:carrier_json) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'carriers.json')).read }
+  let(:request) { double }
+  let(:response) { double(body: response_body) }
+  let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'rate_estimates_success.json')).read }
+  let(:carriers) { FriendlyShipping::Services::ShipEngine::ParseCarrierResponse.new(response: double(body: carrier_json)).call }
+  let(:rate) { subject.first }
+
+  subject { described_class.call(request: request, response: response, carriers: carriers) }
+
+  it "returns an Array of FriendlyShipping::Rate" do
+    expect(subject).to be_a Array
+    expect(rate).to be_a FriendlyShipping::Rate
+  end
+
+  it "contains correct data" do
+    expect(rate.shipping_method).to be_a(FriendlyShipping::ShippingMethod)
+    carrier = rate.shipping_method.carrier
+    expect(carrier).to eq(carriers.first)
+    expect(rate.amounts.keys).to contain_exactly(:confirmation, :insurance, :other, :shipping)
+    expect(rate.total_amount).to eq(Money.new(535, 'USD'))
+    expect(rate.delivery_date).to eq(Time.new(2019, 06, 07, 00, 00, 00, "+00:00"))
+    expect(rate.warnings).to eq([])
+    expect(rate.errors).to eq([])
+    expect(rate.original_request).to eq(request)
+    expect(rate.original_response).to eq(response)
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine/serialize_rate_estimate_request_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_rate_estimate_request_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeRateEstimateRequest do
+  let(:container) { FactoryBot.build(:physical_box, weight: Measured::Weight(0, :g)) }
+  let(:item) { FactoryBot.build(:physical_item, weight: Measured::Weight(1, :ounce)) }
+  let(:package) { FactoryBot.build(:physical_package, items: [item], void_fill_density: Measured::Weight(0, :g), container: container) }
+  let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package]) }
+  let(:carrier) { FriendlyShipping::Carrier.new(id: 'se-123456') }
+  subject { described_class.call(shipment: shipment, carriers: [carrier]) }
+
+  it do
+    is_expected.to match(hash_including(
+      carrier_ids: ["se-123456"],
+      from_country_code: "US",
+      from_postal_code: shipment.origin.zip,
+      to_country_code: "US",
+      to_postal_code: shipment.destination.zip,
+      to_city_locality: "Herndon",
+      to_state_province: "IL",
+      weight: {value: 0.0625, unit: "pound"},
+      confirmation: "none",
+      address_residential_indicator: "no"
+    ))
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine_spec.rb
@@ -23,6 +23,24 @@ RSpec.describe FriendlyShipping::Services::ShipEngine do
     end
   end
 
+  describe 'rate_estimates' do
+    let(:package) { FactoryBot.build(:physical_package) }
+    let(:origin) { FactoryBot.build(:physical_location, zip: '78756') }
+    let(:destination) { FactoryBot.build(:physical_location, zip: '91521') }
+    let(:shipment) { FactoryBot.build(:physical_shipment, origin: origin, destination: destination) }
+    let(:carriers) { service.carriers.value! }
+
+    subject { service.rate_estimates(shipment, carriers) }
+
+    it 'returns Physical::Rate objects wrapped in a Success Monad', vcr: { cassette_name: 'shipengine/rate_estimates/success' } do
+      aggregate_failures do
+        is_expected.to be_success
+        expect(subject.value!).to be_a(Array)
+        expect(subject.value!.first).to be_a(FriendlyShipping::Rate)
+      end
+    end
+  end
+
   describe 'labels' do
     let(:package) { FactoryBot.build(:physical_package) }
     let(:shipment) { FactoryBot.build(:physical_shipment, service_code: "usps_priority_mail", packages: [package]) }


### PR DESCRIPTION
This adds a `FriendlyShipping::Rate` object and support for estimating rates through ShipEngine. These rates, as they are estimates, do not have a `rate_id`. There is another endpoint that persists the estimates on ShipEngine's sind, and the rate object and possible the parser should be able to handle that as well. 