### PR TITLE
Allow 1 lb packages to qualify for USPS First Class labels

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -44,12 +44,7 @@ module FriendlyShipping
 
         def serialize_packages(packages)
           packages.map do |package|
-            package_hash = {
-              weight: {
-                value: package.weight.convert_to(:ounce).value.to_f,
-                unit: "ounce"
-              }
-            }
+            package_hash = serialize_weight(package.weight)
             if package.container.properties[:usps_label_messages]
               package_hash.merge!(label_messages: package.container.properties[:usps_label_messages])
             end
@@ -68,6 +63,17 @@ module FriendlyShipping
             end
             package_hash
           end
+        end
+        
+        def serialize_weight(weight)
+          ounces = weight.convert_to(:ounce).value.to_f
+          {
+            weight: {
+              # Max weight for USPS First Class is 15.9 oz, not 16 oz
+              value: ounces.between?(15.9, 16) ? 15.9 : ounces,
+              unit: "ounce"
+            }
+          }
         end
       end
     end

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -155,4 +155,26 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
       )
     end
   end
+  
+  context 'if weight is between 15.9 and 16 oz' do
+    let(:item) { FactoryBot.build(:physical_item, weight: Measured::Weight(15.95, :ounce)) }
+    
+    # Max weight for USPS First Class is 15.9 oz, not 16 oz
+    it 'returns weight as 15.9 oz' do
+      is_expected.to match(
+        hash_including(
+          shipment: hash_including(
+            packages: array_including(
+              hash_including(
+                weight: hash_including(
+                  value: 15.9,
+                  unit: "ounce"
+                )
+              )
+            )
+          )
+        )
+      )
+    end
+  end
 end


### PR DESCRIPTION
Max weight for USPS First Class packages is 15.9 oz, not 16 oz as would be expected. When generating a First Class shipping label, Ship Engine rejects all packages heavier than 15.9 oz.

Whenever we have a package that is close to or exactly 1 lb (for example, 15.91 oz) we should still be able to ship that package First Class. This change ensures Ship Engine won't reject creating the label due to the package being considered too heavy.