### PR TITLE
Use at least physical 0.4.0

### DIFF
--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-monads", "~> 1.0"
   spec.add_runtime_dependency "money", ">= 6.0.0"
   spec.add_runtime_dependency "nokogiri", ">= 1.6"
-  spec.add_runtime_dependency "physical", "~> 0.3.0"
+  spec.add_runtime_dependency "physical", "~> 0.4"
   spec.add_runtime_dependency "rest-client", "~> 2.0"
   spec.required_ruby_version = '>= 2.4'
 

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
   let(:container) { FactoryBot.build(:physical_box, weight: Measured::Weight(0, :g)) }
   let(:item) { FactoryBot.build(:physical_item, weight: Measured::Weight(1, :ounce)) }
-  let(:package) { FactoryBot.build(:physical_package, items: [item], void_fill_density: Measured::Weight(0, :g), container: container) }
+  let(:package) { FactoryBot.build(:physical_package, items: [item], void_fill_density: Measured::Density(0, :g_ml), container: container) }
   let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package], options: shipment_options) }
   let(:shipment_options) { { label_format: 'zpl' } }
   subject { described_class.new(shipment: shipment).call }
@@ -49,9 +49,9 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
               ),
               dimensions: hash_including(
                 unit: "inch",
-                length: 15.75,
-                width: 19.69,
-                height: 23.62,
+                length: 7.87,
+                width: 5.91,
+                height: 11.81,
               )
             )
           )

--- a/spec/friendly_shipping/services/ship_engine/serialize_rate_estimate_request_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_rate_estimate_request_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeRateEstimateRequest do
   let(:container) { FactoryBot.build(:physical_box, weight: Measured::Weight(0, :g)) }
   let(:item) { FactoryBot.build(:physical_item, weight: Measured::Weight(1, :ounce)) }
-  let(:package) { FactoryBot.build(:physical_package, items: [item], void_fill_density: Measured::Weight(0, :g), container: container) }
+  let(:package) { FactoryBot.build(:physical_package, items: [item], void_fill_density: Measured::Density(0, :g_ml), container: container) }
   let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package]) }
   let(:carrier) { FriendlyShipping::Carrier.new(id: 'se-123456') }
   subject { described_class.call(shipment: shipment, carriers: [carrier]) }


### PR DESCRIPTION
Physical changed its box factory to be a more plausible shipping box
in db56257cb815ef5411acdadfc4fa4354e5072630 and now accepts
`void_fill_density` in `Measured::Density` only.