### PR TITLE
Add USPS rate estimation endpoint

### DIFF
--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -12,6 +12,7 @@ require "friendly_shipping/rate"
 
 require "friendly_shipping/services/ship_engine"
 require "friendly_shipping/services/ups"
+require "friendly_shipping/services/usps"
 
 module FriendlyShipping
 end

--- a/lib/friendly_shipping/services/usps.rb
+++ b/lib/friendly_shipping/services/usps.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/usps/client'
+require 'friendly_shipping/services/usps/shipping_methods'
+require 'friendly_shipping/services/usps/serialize_rate_request'
+require 'friendly_shipping/services/usps/parse_rate_response'
+
+module FriendlyShipping
+  module Services
+    class Usps
+      include Dry::Monads::Result::Mixin
+
+      attr_reader :test, :login, :client
+
+      CARRIER = FriendlyShipping::Carrier.new(
+        id: 'usps',
+        name: 'United States Postal Service',
+        code: 'usps',
+        shipping_methods: SHIPPING_METHODS
+      )
+
+      TEST_URL = 'https://stg-secure.shippingapis.com/ShippingAPI.dll'
+      LIVE_URL = 'https://secure.shippingapis.com/ShippingAPI.dll'
+
+      RESOURCES = {
+        rates: 'RateV4',
+      }.freeze
+
+      def initialize(login:, test: true, client: Client)
+        @login = login
+        @test = test
+        @client = client
+      end
+
+      def carriers
+        Success([CARRIER])
+      end
+
+      # Get rate estimates from USPS
+      #
+      # @param [Physical::Shipment] shipment The shipment object we're trying to get results for
+      #   USPS returns rates on a package-by-package basis, so the options for obtaining rates are
+      #   set on the [Physical::Package.container.properties] hash. The possible options are:
+      #   @property [Symbol] box_name The type of box we want to get rates for. Has to be one of the keys
+      #      of FriendlyShipping::Services::Usps::CONTAINERS.
+      #   @property [Boolean] commercial_pricing Whether we prefer commercial pricing results or retail results
+      #   @property [Boolean] hold_for_pickup Whether we want a rate with Hold For Pickup Service
+      #
+      # @return [Result<Array<FriendlyShipping::Rate>>] When successfully parsing, an array of rates in a Success Monad.
+      #   When the parsing is not successful or USPS can't give us rates, a Failure monad containing something that
+      #   can be serialized into an error message using `to_s`.
+      def rate_estimates(shipment, _carriers)
+        rate_request_xml = SerializeRateRequest.call(shipment: shipment, login: login)
+        request = FriendlyShipping::Request.new(url: base_url, body: "API=#{RESOURCES[:rates]}&XML=#{CGI.escape rate_request_xml}")
+
+        client.post(request).bind do |response|
+          ParseRateResponse.call(response: response, request: request, shipment: shipment)
+        end
+      end
+
+      private
+
+      def base_url
+        test ? TEST_URL : LIVE_URL
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps.rb
+++ b/lib/friendly_shipping/services/usps.rb
@@ -45,12 +45,14 @@ module FriendlyShipping
       #      of FriendlyShipping::Services::Usps::CONTAINERS.
       #   @property [Boolean] commercial_pricing Whether we prefer commercial pricing results or retail results
       #   @property [Boolean] hold_for_pickup Whether we want a rate with Hold For Pickup Service
+      # @param [Physical::ShippingMethod] shipping_method The shipping method ("service" in USPS parlance) we want
+      #   to get rates for.
       #
       # @return [Result<Array<FriendlyShipping::Rate>>] When successfully parsing, an array of rates in a Success Monad.
       #   When the parsing is not successful or USPS can't give us rates, a Failure monad containing something that
       #   can be serialized into an error message using `to_s`.
-      def rate_estimates(shipment, _carriers)
-        rate_request_xml = SerializeRateRequest.call(shipment: shipment, login: login)
+      def rate_estimates(shipment, _carriers, shipping_method: nil)
+        rate_request_xml = SerializeRateRequest.call(shipment: shipment, login: login, shipping_method: shipping_method)
         request = FriendlyShipping::Request.new(url: base_url, body: "API=#{RESOURCES[:rates]}&XML=#{CGI.escape rate_request_xml}")
 
         client.post(request).bind do |response|

--- a/lib/friendly_shipping/services/usps/choose_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/choose_package_rate.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Usps
+      class ChoosePackageRate
+        class CannotDetermineRate < StandardError; end
+        # Some shipping rates use 'Flat Rate Boxes', indicating that
+        # they are available for ALL flat rate boxes.
+        FLAT_RATE_BOX = /Flat Rate Box/i.freeze
+
+        # Select the corresponding rate for a package from all the rates USPS returns to us
+        #
+        # @param [FriendlyShipping::ShippingMethod] shipping_method The shipping method we want to filter by
+        # @param [Physical::Package] package The package we want to match with a rate
+        # @param [Array<FriendlyShipping::Rate>] The rates we select from
+        #
+        # @return [FriendlyShipping::Rate] The rate that most closely matches our package
+        def self.call(shipping_method, package, rates)
+          # Remove all rates with the wrong shipping method
+          rates_with_this_shipping_method = rates.select { |r| r.shipping_method == shipping_method }
+
+          # Remove all the rates with the wrong box type
+          rates_with_this_package_type = rates_with_this_shipping_method.select do |r|
+            r.data[:box_name] == package.properties[:box_name] ||
+              r.data[:box_name] == :flat_rate_boxes && package.properties[:box_name]&.match?(FLAT_RATE_BOX)
+          end
+
+          # Filter by our package's `hold_for_pickup` option
+          rates_with_this_hold_for_pickup_option = rates_with_this_package_type.select do |r|
+            r.data[:hold_for_pickup] == !!package.properties[:hold_for_pickup]
+          end
+
+          # At this point we should be left with a single rate. If we are not, raise an error,
+          # as that means we're missing some code.
+          if rates_with_this_hold_for_pickup_option.length > 1
+            raise CannotDetermineRate
+          end
+
+          # As we only have one rate left, return that without the array.
+          rates_with_this_hold_for_pickup_option.first
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps/choose_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/choose_package_rate.rb
@@ -17,10 +17,10 @@ module FriendlyShipping
         #
         # @return [FriendlyShipping::Rate] The rate that most closely matches our package
         def self.call(shipping_method, package, rates)
-          # Remove all rates with the wrong shipping method
+          # Keep all rates with the requested shipping method
           rates_with_this_shipping_method = rates.select { |r| r.shipping_method == shipping_method }
 
-          # Remove all the rates with the wrong box type
+          # Keep only rates with the package type of this package
           rates_with_this_package_type = rates_with_this_shipping_method.select do |r|
             r.data[:box_name] == package.properties[:box_name] ||
               r.data[:box_name] == :flat_rate_boxes && package.properties[:box_name]&.match?(FLAT_RATE_BOX)

--- a/lib/friendly_shipping/services/usps/client.rb
+++ b/lib/friendly_shipping/services/usps/client.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'dry/monads/result'
+require 'friendly_shipping/bad_request'
+require 'rest-client'
+
+module FriendlyShipping
+  module Services
+    class Usps
+      class Client
+        extend Dry::Monads::Result::Mixin
+        class <<self
+          # USPS allows both GET and POST request. We're using POST here as those request
+          # are less limited in size.
+          def post(request)
+            http_response = ::RestClient.post(request.url, request.body)
+
+            Success(convert_to_friendly_response(http_response))
+          rescue ::RestClient::Exception => e
+            Failure(e)
+          end
+
+          private
+
+          def convert_to_friendly_response(http_response)
+            FriendlyShipping::Response.new(
+              status: http_response.code,
+              body: http_response.body,
+              headers: http_response.headers
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps/machinable_package.rb
+++ b/lib/friendly_shipping/services/usps/machinable_package.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Usps
+      # USPS has certain size and weight requirements for packages to
+      # be considered machinable. Machinable packages are generally
+      # less expensive to ship. For more information see:
+      #   https://pe.usps.com/BusinessMail101?ViewName=Parcels
+      #
+      class MachinablePackage
+        attr_reader :package
+
+        MIN_LENGTH = Measured::Length(6, :inches)
+        MIN_WIDTH = Measured::Length(3, :inches)
+        MIN_HEIGHT = Measured::Length(0.25, :inches)
+
+        MAX_LENGTH = Measured::Length(27, :inches)
+        MAX_WIDTH = Measured::Length(17, :inches)
+        MAX_HEIGHT = Measured::Length(17, :inches)
+        MAX_WEIGHT = Measured::Weight(25, :pounds)
+
+        # @param [Physical::Package]
+        def initialize(package)
+          @package = package
+        end
+
+        def machinable?
+          at_least_minimum && at_most_maximum
+        end
+
+        private
+
+        def at_least_minimum
+          package.length >= MIN_LENGTH &&
+            package.width >= MIN_WIDTH &&
+            package.height >= MIN_HEIGHT
+        end
+
+        def at_most_maximum
+          package.length <= MAX_LENGTH &&
+            package.width <= MAX_WIDTH &&
+            package.height <= MAX_HEIGHT &&
+            package.weight <= MAX_WEIGHT
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps/machinable_package.rb
+++ b/lib/friendly_shipping/services/usps/machinable_package.rb
@@ -18,6 +18,7 @@ module FriendlyShipping
         MAX_LENGTH = Measured::Length(27, :inches)
         MAX_WIDTH = Measured::Length(17, :inches)
         MAX_HEIGHT = Measured::Length(17, :inches)
+
         MAX_WEIGHT = Measured::Weight(25, :pounds)
 
         # @param [Physical::Package]

--- a/lib/friendly_shipping/services/usps/parse_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/parse_package_rate.rb
@@ -3,7 +3,7 @@
 module FriendlyShipping
   module Services
     class Usps
-      class ParseRate
+      class ParsePackageRate
         # USPS returns all the info about a rate in a long string with a bit of gibberish.
         ESCAPING_AND_SYMBOLS = /&lt;\S*&gt;/.freeze
 

--- a/lib/friendly_shipping/services/usps/parse_rate.rb
+++ b/lib/friendly_shipping/services/usps/parse_rate.rb
@@ -108,7 +108,7 @@ module FriendlyShipping
             # constant above.
             box_name_match = service_name.match(/#{BOX_REGEX}/)
             box_name = if box_name_match
-                         box_name_match.named_captures.reject { |_k, v| v.nil? }.keys.last.to_sym
+                         box_name_match.named_captures.compact.keys.last.to_sym
                        end
 
             # Combine all the gathered information in a FriendlyShipping::Rate object.

--- a/lib/friendly_shipping/services/usps/parse_rate.rb
+++ b/lib/friendly_shipping/services/usps/parse_rate.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Usps
+      class ParseRate
+        # USPS returns all the info about a rate in a long string with a bit of gibberish.
+        ESCAPING_AND_SYMBOLS = /&lt;\S*&gt;/.freeze
+
+        # At the beginning of the long String, USPS keeps a copy of its own name. We know we're dealing with
+        # them though, so we can filter that out, too.
+        LEADING_USPS = /^USPS /.freeze
+
+        # This combines all the things we want to filter out.
+        SERVICE_NAME_SUBSTITUTIONS = /#{ESCAPING_AND_SYMBOLS}|#{LEADING_USPS}/.freeze
+
+        # Often we get a multitude of rates for the same service given some combination of
+        # Box type and (see below) and "Hold for Pickup" service. This creates a regular expression
+        # with groups named after the keys from the `Usps::CONTAINERS` constant.
+        # Unfortunately, the keys don't correspond directly to the codes we use when serializing the
+        # request.
+        BOX_REGEX = {
+          flat_rate_boxes: 'Flat Rate Boxes',
+          large_flat_rate_box: 'Large Flat Rate Box',
+          medium_flat_rate_box: 'Medium Flat Rate Box',
+          small_flat_rate_box: 'Small Flat Rate Box',
+          regional_rate_box_a: 'Regional Rate Box A',
+          regional_rate_box_b: 'Regional Rate Box B',
+          regional_rate_box_c: 'Regional Rate Box C',
+          flat_rate_envelope: 'Flat Rate Envelope',
+          legal_flat_rate_envelope: 'Legal Flat Rate Envelope',
+          padded_flat_rate_envelope: 'Padded Flat Rate Envelope',
+          gift_card_flat_rate_envelope: 'Gift Card Flat Rate Envelope',
+          window_flat_rate_envelope: 'Window Flat Rate Envelope',
+          small_flat_rate_envelope: 'Small Flat Rate Envelope',
+          large_envelope: 'Large Envelope',
+          parcel: 'Parcel',
+          postcards: 'Postcards'
+        }.map { |k, v| "(?<#{k}>#{v})" }.join("|").freeze
+
+        # We use this for identifying rates that use the Hold for Pickup service.
+        HOLD_FOR_PICKUP = /Hold for Pickup/i.freeze
+
+        # For most rate options, USPS will return how many business days it takes to deliver this
+        # package in the format "{1,2,3}-Day". We can filter this out using the below Regex.
+        DAYS_TO_DELIVERY = /(?<days>\d)-Day/.freeze
+
+        # When delivering to military ZIP codes, we don't actually get a timing estimate, but instead the string
+        # "Military". We use this to indicate that this rate is for a military zip code in the rates' data Hash.
+        MILITARY = /MILITARY/i.freeze
+
+        # The tags used in the rate node that we get information from.
+        SERVICE_CODE_TAG = 'CLASSID'
+        SERVICE_NAME_TAG = 'MailService'
+        RATE_TAG = 'Rate'
+        COMMERCIAL_RATE_TAG = 'CommercialRate'
+        CURRENCY = Money::Currency.new('USD').freeze
+
+        class << self
+          def call(rate_node, package)
+            # "A mail class identifier for the postage returned. Not necessarily unique within a <Package/>."
+            # (from the USPS docs). We save this on the data Hash, but do not use it for identifying shipping methods.
+            service_code = rate_node.attributes[SERVICE_CODE_TAG].value
+
+            # The long string discussed above.
+            service_name = rate_node.at(SERVICE_NAME_TAG).text
+
+            # Does this rate assume Hold for Pickup service?
+            hold_for_pickup = service_name.match?(HOLD_FOR_PICKUP)
+
+            # Is the destination a military ZIP code?
+            military = service_name.match?(MILITARY)
+
+            # If we get a days-to-delivery indication, save it in the `days_to_delivery` variable.
+            days_to_delivery_match = service_name.match(DAYS_TO_DELIVERY)
+            days_to_delivery = if days_to_delivery_match
+                                 days_to_delivery_match.named_captures.values.first.to_i
+                               end
+
+            # Clean up the long string
+            service_name.gsub!(SERVICE_NAME_SUBSTITUTIONS, '')
+
+            # Some USPS services only offer commercial pricing. Unfortunately, USPS then returns a retail rate of 0.
+            # In these cases, return the commercial rate instead of the normal rate.
+            # Some rates are available in both commercial and retail pricing - if we want the commercial pricing here,
+            # we need to specify the commercial_pricing property on the `Physical::Package`.
+            rate_value = if (package.properties[:commercial_pricing] || rate_node.at(RATE_TAG).text.to_d.zero?) && rate_node.at(COMMERCIAL_RATE_TAG)
+                           rate_node.at(COMMERCIAL_RATE_TAG).text.to_d
+                         else
+                           rate_node.at(RATE_TAG).text.to_d
+                         end
+
+            # The rate expressed as a RubyMoney objext
+            rate = Money.new(rate_value * CURRENCY.subunit_to_unit, CURRENCY)
+
+            # Which shipping method does this rate belong to? This is trickier than it sounds, because we match
+            # strings here, and we have a `Priority Mail` and `Priority Mail Express` shipping method.
+            # If we have multiple matches, we take the longest matching shipping method name so `Express` rates
+            # do not accidentally get marked as `Priority` only.
+            possible_shipping_methods = SHIPPING_METHODS.select do |sm|
+              service_name.tr('-', ' ').upcase.starts_with?(sm.service_code)
+            end.sort_by do |shipping_method|
+              shipping_method.name.length
+            end
+            shipping_method = possible_shipping_methods.last
+
+            # We find out the box name using a bit of Regex magic using named captures. See the `BOX_REGEX`
+            # constant above.
+            box_name_match = service_name.match(/#{BOX_REGEX}/)
+            box_name = if box_name_match
+                         box_name_match.named_captures.reject { |_k, v| v.nil? }.keys.last.to_sym
+                       end
+
+            # Combine all the gathered information in a FriendlyShipping::Rate object.
+            # Careful: This rate is only for one package within the shipment, and we get multiple
+            # rates per package for the different shipping method/box/hold for pickup combinations.
+            FriendlyShipping::Rate.new(
+              shipping_method: shipping_method,
+              amounts: { package.id => rate },
+              data: {
+                package: package,
+                box_name: box_name,
+                hold_for_pickup: hold_for_pickup,
+                days_to_delivery: days_to_delivery,
+                military: military,
+                full_mail_service: service_name,
+                service_code: service_code
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_rate_response.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/usps/parse_xml_response'
+require 'friendly_shipping/services/usps/parse_rate'
+require 'friendly_shipping/services/usps/choose_package_rate'
+
+module FriendlyShipping
+  module Services
+    class Usps
+      class ParseRateResponse
+        class << self
+          # Parse a response from USPS' rating API
+          #
+          # @param [FriendlyShipping::Request] request The request that was used to obtain this Response
+          # @param [FriendlyShipping::Response] response The response that USPS returned
+          # @param [Physical::Shipment] shipment The shipment object we're trying to get results for
+          # @return [Result<Array<FriendlyShipping::Rate>>] When successfully parsing, an array of rates in a Success Monad.
+          def call(request:, response:, shipment:)
+            # Filter out error responses and directly return a failure
+            parsing_result = ParseXMLResponse.call(response.body, 'RateV4Response')
+            parsing_result.fmap do |xml|
+              # Get all the possible rates for each package
+              rates_by_package = rates_from_response_node(xml, shipment)
+
+              SHIPPING_METHODS.map do |shipping_method|
+                # For every package ...
+                matching_rates = rates_by_package.map do |package, rates|
+                  # ... choose the rate that fits this package best.
+                  ChoosePackageRate.call(shipping_method, package, rates)
+                end.compact # Some shipping rates are not available for every shipping method.
+
+                # in this case, go to the next shipping method.
+                next if matching_rates.empty?
+
+                # return one rate for all packages with the amount keys being the package IDs.
+                FriendlyShipping::Rate.new(
+                  amounts: matching_rates.map(&:amounts).reduce({}, :merge),
+                  shipping_method: shipping_method,
+                  data: matching_rates.first.data,
+                  original_request: request,
+                  original_response: response
+                )
+              end.compact
+            end
+          end
+
+          private
+
+          PACKAGE_NODE_XPATH = '//Package'
+          SERVICE_NODE_NAME = 'Postage'
+
+          # Iterate over all packages and parse the rates for each package
+          #
+          # @param [Nokogiri::XML::Node] xml The XML document containing packages and rates
+          # @param [Physical::Shipment] shipment The shipment we're trying to get rates for
+          #
+          # @return [Hash<Physical::Package => Array<FriendlyShipping::Rate>>]
+          def rates_from_response_node(xml, shipment)
+            xml.xpath(PACKAGE_NODE_XPATH).each_with_object({}) do |package_node, result|
+              package_id = package_node['ID']
+              corresponding_package = shipment.packages.detect { |p| p.id == package_id }
+              result[corresponding_package] = package_node.xpath(SERVICE_NODE_NAME).map do |service_node|
+                ParseRate.call(service_node, corresponding_package)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_rate_response.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'friendly_shipping/services/usps/parse_xml_response'
-require 'friendly_shipping/services/usps/parse_rate'
+require 'friendly_shipping/services/usps/parse_package_rate'
 require 'friendly_shipping/services/usps/choose_package_rate'
 
 module FriendlyShipping
@@ -67,7 +67,7 @@ module FriendlyShipping
               raise BoxNotFoundError if corresponding_package.nil?
 
               result[corresponding_package] = package_node.xpath(SERVICE_NODE_NAME).map do |service_node|
-                ParseRate.call(service_node, corresponding_package)
+                ParsePackageRate.call(service_node, corresponding_package)
               end
             end
           end

--- a/lib/friendly_shipping/services/usps/parse_xml_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_xml_response.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Usps
+      class ParseXMLResponse
+        extend Dry::Monads::Result::Mixin
+        ERROR_ROOT_TAG = 'Error'
+
+        class << self
+          def call(response_body, expected_root_tag)
+            xml = Nokogiri.XML(response_body)
+            if xml.root.nil? || [expected_root_tag, ERROR_ROOT_TAG].include?(xml.root.name)
+              Failure('Invalid document')
+            end
+            if request_successful?(xml)
+              Success(xml)
+            else
+              Failure(error_message(xml))
+            end
+          rescue Nokogiri::XML::SyntaxError => e
+            Failure(e)
+          end
+
+          private
+
+          def request_successful?(xml)
+            xml.xpath('Error/Number')&.text.blank?
+          end
+
+          def error_message(xml)
+            number = xml.xpath('Error/Number')&.text
+            desc = xml.xpath('Error/Description')&.text
+            [number, desc].select(&:present?).join(': ').presence || 'USPS could not process the request.'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps/parse_xml_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_xml_response.rb
@@ -10,10 +10,10 @@ module FriendlyShipping
         class << self
           def call(response_body, expected_root_tag)
             xml = Nokogiri.XML(response_body)
-            if xml.root.nil? || [expected_root_tag, ERROR_ROOT_TAG].include?(xml.root.name)
+
+            if xml.root.nil? || ![expected_root_tag, ERROR_ROOT_TAG].include?(xml.root.name)
               Failure('Invalid document')
-            end
-            if request_successful?(xml)
+            elsif request_successful?(xml)
               Success(xml)
             else
               Failure(error_message(xml))

--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -16,12 +16,12 @@ module FriendlyShipping
           # @param [FriendlyShipping::ShippingMethod] service The shipping methods we want to get rates
           #   for. If empty, we get all of them
           # @return Array<[FriendlyShipping::Rate]> A set of Rates that this package may be sent with
-          def call(shipment:, login:, service: nil)
+          def call(shipment:, login:, shipping_method: nil)
             xml_builder = Nokogiri::XML::Builder.new do |xml|
               xml.RateV4Request('USERID' => login) do
                 shipment.packages.each do |package|
                   xml.Package('ID' => package.id) do
-                    xml.Service(service_code_by(service, package))
+                    xml.Service(service_code_by(shipping_method, package))
                     if package.properties[:first_class_mail_type]
                       xml.FirstClassMailType(FIRST_CLASS_MAIL_TYPES[package.properties[:first_class_mail_type]])
                     end
@@ -59,13 +59,13 @@ module FriendlyShipping
             end
           end
 
-          def service_code_by(service, package)
-            return 'ALL' unless service
+          def service_code_by(shipping_method, package)
+            return 'ALL' unless shipping_method
 
             if package.properties[:commercial_pricing]
-              "#{service.service_code} COMMERCIAL"
+              "#{shipping_method.service_code} COMMERCIAL"
             else
-              service.service_code
+              shipping_method.service_code
             end
           end
 

--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/usps/machinable_package'
+
+module FriendlyShipping
+  module Services
+    class Usps
+      class SerializeRateRequest
+        MAX_REGULAR_PACKAGE_SIDE = Measured::Length(12, :inches)
+
+        class << self
+          # @param [Physical::Shipment] shipment The shipment we want to get rates for
+          #   shipment.packages[0].properties[:box_code] Can be :rectangular, :variable,
+          #     or a flat rate container defined in CONTAINERS.
+          # @param [String] login The USPS login code
+          # @param [FriendlyShipping::ShippingMethod] service The shipping methods we want to get rates
+          #   for. If empty, we get all of them
+          # @return Array<[FriendlyShipping::Rate]> A set of Rates that this package may be sent with
+          def call(shipment:, login:, service: nil)
+            xml_builder = Nokogiri::XML::Builder.new do |xml|
+              xml.RateV4Request('USERID' => login) do
+                shipment.packages.each do |package|
+                  xml.Package('ID' => package.id) do
+                    xml.Service(service_code_by(service, package))
+                    if package.properties[:first_class_mail_type]
+                      xml.FirstClassMailType(FIRST_CLASS_MAIL_TYPES[package.properties[:first_class_mail_type]])
+                    end
+                    xml.ZipOrigination(shipment.origin.zip)
+                    xml.ZipDestination(shipment.destination.zip)
+                    xml.Pounds(0)
+                    xml.Ounces(ounces_for(package))
+                    size_code = size_code_for(package)
+                    container = CONTAINERS[package.properties[:box_name] || :rectangular]
+                    xml.Container(container)
+                    xml.Size(size_code)
+                    xml.Width("%0.2f" % package.width.convert_to(:inches).value.to_f)
+                    xml.Length("%0.2f" % package.length.convert_to(:inches).value.to_f)
+                    xml.Height("%0.2f" % package.height.convert_to(:inches).value.to_f)
+                    xml.Girth("%0.2f" % girth(package))
+                    xml.Machinable(machinable(package))
+                  end
+                end
+              end
+            end
+            xml_builder.to_xml
+          end
+
+          private
+
+          def machinable(package)
+            MachinablePackage.new(package).machinable? ? 'TRUE' : 'FALSE'
+          end
+
+          def size_code_for(package)
+            if package.dimensions.max <= MAX_REGULAR_PACKAGE_SIDE
+              'REGULAR'
+            else
+              'LARGE'
+            end
+          end
+
+          def service_code_by(service, package)
+            return 'ALL' unless service
+
+            if package.properties[:commercial_pricing]
+              "#{service.service_code} COMMERCIAL"
+            else
+              service.service_code
+            end
+          end
+
+          def ounces_for(package)
+            ounces = package.weight.convert_to(:ounces).value.to_f.round(2).ceil
+            ounces == 16 ? 15.999 : [ounces, 1].max
+          end
+
+          def strip_zip(zip)
+            zip.to_s.scan(/\d{5}/).first || zip
+          end
+
+          def girth(package)
+            width, length = package.dimensions.sort.first(2)
+            (width.scale(2) + length.scale(2)).convert_to(:inches).value.to_f
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -38,7 +38,7 @@ module FriendlyShipping
         'Retail Ground',
         'Media Mail',
         'Library Mail',
-      ].freeze.map do |shipping_method_name|
+      ].map do |shipping_method_name|
         FriendlyShipping::ShippingMethod.new(
           origin_countries: [Carmen::Country.coded('US')],
           name: shipping_method_name,

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Usps
+      CONTAINERS = {
+        variable: 'VARIABLE',
+        rectangular: 'RECTANGULAR',
+        large_flat_rate_box: 'LG FLAT RATE BOX',
+        medium_flat_rate_box: 'MD FLAT RATE BOX',
+        small_flat_rate_box: 'SM FLAT RATE BOX',
+        regional_rate_box_a: 'REGIONALRATEBOXA',
+        regional_rate_box_b: 'REGIONALRATEBOXB',
+        flat_rate_envelope: 'FLAT RATE ENVELOPE',
+        legal_flat_rate_envelope: 'LEGAL FLAT RATE ENVELOPE',
+        padded_flat_rate_envelope: 'PADDED FLAT RATE ENVELOPE',
+        gift_card_flat_rate_envelope: 'GIFT CARD FLAT RATE ENVELOPE',
+        window_flat_rate_envelope: 'WINDOW FLAT RATE ENVELOPE',
+        small_flat_rate_envelope: 'SM FLAT RATE ENVELOPE',
+        cubic_soft_pack: 'CUBIC SOFT PACK',
+        cubic_parcels: 'CUBIC_PARCELS'
+      }.freeze
+
+      FIRST_CLASS_MAIL_TYPES = {
+        letter: 'LETTER',
+        flat: 'FLAT',
+        parcel: 'PARCEL',
+        post_card: 'POSTCARD',
+        package_service: 'PACKAGESERVICE'
+      }.freeze
+
+      SHIPPING_METHODS = [
+        'First-Class',
+        'First-Class Package Service',
+        'Priority',
+        'Priority Mail Express',
+        'Standard Post',
+        'Retail Ground',
+        'Media Mail',
+        'Library Mail',
+      ].freeze.map do |shipping_method_name|
+        FriendlyShipping::ShippingMethod.new(
+          origin_countries: [Carmen::Country.coded('US')],
+          name: shipping_method_name,
+          service_code: shipping_method_name.tr('-', ' ').upcase,
+          domestic: true,
+          international: false
+        )
+      end.freeze
+    end
+  end
+end

--- a/spec/cassettes/usps/rate_estimates/failure.yml
+++ b/spec/cassettes/usps/rate_estimates/failure.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://stg-secure.shippingapis.com/ShippingAPI.dll
+    body:
+      encoding: UTF-8
+      string: API=RateV4&XML=%3C%3Fxml+version%3D%221.0%22%3F%3E%0A%3CRateV4Request+USERID%3D%22WRONG_LOGIN%22%3E%0A++%3CPackage+ID%3D%220%22%3E%0A++++%3CService%3EALL%3C%2FService%3E%0A++++%3CZipOrigination%3E27703%3C%2FZipOrigination%3E%0A++++%3CZipDestination%3E32821%3C%2FZipDestination%3E%0A++++%3CPounds%3E2.9263499295634094%3C%2FPounds%3E%0A++++%3COunces%3E46.82159887301455%3C%2FOunces%3E%0A++++%3CContainer%2F%3E%0A++++%3CSize%3ELARGE%3C%2FSize%3E%0A++++%3CWidth%3E19.69%3C%2FWidth%3E%0A++++%3CLength%3E15.75%3C%2FLength%3E%0A++++%3CHeight%3E23.62%3C%2FHeight%3E%0A++++%3CGirth%3E86.61%3C%2FGirth%3E%0A++++%3CMachinable%3EFALSE%3C%2FMachinable%3E%0A++%3C%2FPackage%3E%0A%3C%2FRateV4Request%3E%0A
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '690'
+      Host:
+      - stg-secure.shippingapis.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Backside-Transport:
+      - OK OK
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Host:
+      - 127.0.0.1:2048
+      Content-Type:
+      - text/xml
+      Ns-Client-Ip:
+      - 2.207.1.192
+      Via:
+      - 1.1 ApplicationError_XML_Firewall
+      X-Client-Ip:
+      - 56.0.71.6,56.0.71.6
+      X-Global-Transaction-Id:
+      - 5a3857615d248b0917c6221f
+      Client-Ip:
+      - 2.207.1.192
+      X-Archived-Client-Ip:
+      - 56.0.71.6
+      Date:
+      - Tue, 09 Jul 2019 12:39:37 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Connection:
+      - Keep-Alive
+      Ntcoent-Length:
+      - '208'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA02Oyw6CMBBF937FpHtpSVwYM5bga6eSoB9QYZQm0pIpVePXK5GFy3sW51zMXu0dHsTBercUaaIEkKt8bd1tKc6n3XQuMj3BLbNnjYfYXoj1XKmZWqU5yhHghkLFtuu/Fp3HvvFs32ZYcDX2HpkSgIK4MV2AGIidaQmMq6Vn6EwIT8812AD222amqk9Q/jux9JEr0ueyKNfH/WKx8UMG5chR/h5+ALNayFDQAAAA
+    http_version: 
+  recorded_at: Tue, 09 Jul 2019 12:39:37 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/usps/rate_estimates/success.yml
+++ b/spec/cassettes/usps/rate_estimates/success.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://stg-secure.shippingapis.com/ShippingAPI.dll
+    body:
+      encoding: UTF-8
+      string: API=RateV4&XML=%3C%3Fxml+version%3D%221.0%22%3F%3E%0A%3CRateV4Request+USERID%3D%22<USPS_LOGIN>%22%3E%0A++%3CPackage+ID%3D%220%22%3E%0A++++%3CService%3EALL%3C%2FService%3E%0A++++%3CZipOrigination%3E27703%3C%2FZipOrigination%3E%0A++++%3CZipDestination%3E32821%3C%2FZipDestination%3E%0A++++%3CPounds%3E0.24331917443849418%3C%2FPounds%3E%0A++++%3COunces%3E3.893106791015907%3C%2FOunces%3E%0A++++%3CContainer%2F%3E%0A++++%3CSize%3EREGULAR%3C%2FSize%3E%0A++++%3CWidth%3E4.00%3C%2FWidth%3E%0A++++%3CLength%3E8.00%3C%2FLength%3E%0A++++%3CHeight%3E2.00%3C%2FHeight%3E%0A++++%3CGirth%3E24.00%3C%2FGirth%3E%0A++++%3CMachinable%3ETRUE%3C%2FMachinable%3E%0A++%3C%2FPackage%3E%0A%3C%2FRateV4Request%3E%0A
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '690'
+      Host:
+      - stg-secure.shippingapis.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Backside-Transport:
+      - OK OK
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 09 Jul 2019 13:04:15 GMT
+      X-Global-Transaction-Id:
+      - '018fb36a5d2490cf2c064487'
+      Access-Control-Allow-Origin:
+      - "*"
+      Connection:
+      - Keep-Alive
+      Ntcoent-Length:
+      - '3554'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '617'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA8WXXW+bMBSG7/crLCbtLuYzfCgOVZePblKioqTZpN654GVWCSBDsna/fjZJ1Sii6CQd2xXm2Dp+zmv7NZCrp02KdkyUPM+GmokNDbEszhOerYfa6m7a87Wr8ANZ0Ip9cxasLPKsZCGJaPxI1wx9HQ81QwvJPS9uBV/zjFYyUWh5nmET/SSqRo1ZWb2825ZvmfWo4yiJ8m2WlKGBLce2zcD0iH4IkdttFrMytLEf2KbhegHRDyGy5L9ZuJjcrGbXC6LXb2RO458y7UPKwrvFakL0owC5zzMWOnJ69ZSTlpUqaDS7Xi5VVbasak55umRix2MWRoLnglfPSAXR5KkQrCyR2RvT5090UwzSalBui7q5rgb186Pv+Na+KXv1o25F8pq6Vje0XOwYRK/bquKapwHM6hIMfcnTBE1zgSIeP26L94CanUqIpimtkIJAk2zH0rxgjbB93Aep6v1jWJDSQHhbHcHu4GdsTVO43h4I2fwvyEDVQSW43Z7EiCYJk6ww2V1sgZi7PZNvMgN9BVRD+86xLkNvAvKw34dYR/s+uBAIzaiQs7xK+Tl/aoI0AxxAKM12g7uUcs4Svt0AMB1sgzDdTjBhp8iDMTpONwt+hs162AVtzaAT0rOsyccG6ELwO0G94T8qNKICSgvdAu037qW033mW5L/+Luop6ZSLsuqNUip9/uUz/tCHemjBKjn2fPQmQAc78gP9XYAq/iaM6TnNMu6ts/W+xAZEu1MzUm5H90scURGztDm3B8l96scz/iCoOGygtuyu/Gc6za4fVlK2VNfRr9ofXJprpOINAAA=
+    http_version: 
+  recorded_at: Tue, 09 Jul 2019 13:04:15 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/usps/rates_api_response_large_box.xml
+++ b/spec/fixtures/usps/rates_api_response_large_box.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RateV4Response>
+  <Package ID="0">
+    <ZipOrigination>27703</ZipOrigination>
+    <ZipDestination>00901</ZipDestination>
+    <Pounds>0</Pounds>
+    <Ounces>12</Ounces>
+    <Container>LG FLAT RATE BOX</Container>
+    <Size>REGULAR</Size>
+    <Zone>7</Zone>
+    <Postage CLASSID="22">
+      <MailService>Priority Mail 3-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Large Flat Rate Box</MailService>
+      <Rate>19.95</Rate>
+      <CommercialRate>17.60</CommercialRate>
+    </Postage>
+  </Package>
+</RateV4Response>

--- a/spec/fixtures/usps/rates_api_response_regional_multiple.xml
+++ b/spec/fixtures/usps/rates_api_response_regional_multiple.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RateV4Response>
+  <Package ID="0">
+    <ZipOrigination>27703</ZipOrigination>
+    <ZipDestination>45342</ZipDestination>
+    <Pounds>0</Pounds>
+    <Ounces>29</Ounces>
+    <Container>REGIONALRATEBOXA</Container>
+    <Size>REGULAR</Size>
+    <Zone>4</Zone>
+    <Postage CLASSID="47">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box A</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>8.12</CommercialRate>
+    </Postage>
+  </Package>
+  <Package ID="1">
+    <ZipOrigination>27703</ZipOrigination>
+    <ZipDestination>45342</ZipDestination>
+    <Pounds>0</Pounds>
+    <Ounces>12</Ounces>
+    <Container>REGIONALRATEBOXB</Container>
+    <Size>REGULAR</Size>
+    <Zone>4</Zone>
+    <Postage CLASSID="49">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box B</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>9.40</CommercialRate>
+    </Postage>
+  </Package>
+</RateV4Response>

--- a/spec/fixtures/usps/rates_api_response_regional_single.xml
+++ b/spec/fixtures/usps/rates_api_response_regional_single.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RateV4Response>
+  <Package ID="0">
+    <ZipOrigination>27703</ZipOrigination>
+    <ZipDestination>45342</ZipDestination>
+    <Pounds>0</Pounds>
+    <Ounces>12</Ounces>
+    <Container>REGIONALRATEBOXB</Container>
+    <Size>REGULAR</Size>
+    <Zone>4</Zone>
+    <Postage CLASSID="49">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box B</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>9.40</CommercialRate>
+    </Postage>
+  </Package>
+</RateV4Response>

--- a/spec/fixtures/usps/usps_rates_api_response.xml
+++ b/spec/fixtures/usps/usps_rates_api_response.xml
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RateV4Response>
+    <Package ID="0">
+        <ZipOrigination>90210</ZipOrigination>
+        <ZipDestination>10017</ZipDestination>
+        <Pounds>0</Pounds>
+        <Ounces>8.8</Ounces>
+        <Size>REGULAR</Size>
+        <Machinable>TRUE</Machinable>
+        <Zone>8</Zone>
+        <Postage CLASSID="3">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt;</MailService>
+            <Rate>36.60</Rate>
+            <CommercialRate>30.00</CommercialRate>
+            <CommercialPlusRate>22.37</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="2">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Hold For Pickup</MailService>
+            <Rate>36.60</Rate>
+            <CommercialRate>30.00</CommercialRate>
+            <CommercialPlusRate>22.37</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="55">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Boxes</MailService>
+            <Rate>44.95</Rate>
+            <CommercialRate>44.95</CommercialRate>
+            <CommercialPlusRate>44.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="56">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Boxes Hold For Pickup</MailService>
+            <Rate>44.95</Rate>
+            <CommercialRate>44.95</CommercialRate>
+            <CommercialPlusRate>44.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="13">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Envelope</MailService>
+            <Rate>19.99</Rate>
+            <CommercialRate>18.11</CommercialRate>
+            <CommercialPlusRate>14.85</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="27">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Envelope Hold For Pickup</MailService>
+            <Rate>19.99</Rate>
+            <CommercialRate>18.11</CommercialRate>
+            <CommercialPlusRate>14.85</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="30">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Legal Flat Rate Envelope</MailService>
+            <Rate>19.99</Rate>
+            <CommercialRate>18.11</CommercialRate>
+            <CommercialPlusRate>14.85</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="31">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Legal Flat Rate Envelope Hold For Pickup</MailService>
+            <Rate>19.99</Rate>
+            <CommercialRate>18.11</CommercialRate>
+            <CommercialPlusRate>14.85</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="62">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Padded Flat Rate Envelope</MailService>
+            <Rate>19.99</Rate>
+            <CommercialRate>18.11</CommercialRate>
+            <CommercialPlusRate>14.85</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="63">
+            <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Padded Flat Rate Envelope Hold For Pickup</MailService>
+            <Rate>19.99</Rate>
+            <CommercialRate>18.11</CommercialRate>
+            <CommercialPlusRate>14.85</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="1">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt;</MailService>
+            <Rate>7.15</Rate>
+            <CommercialRate>6.51</CommercialRate>
+            <CommercialPlusRate>6.25</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="33">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>6.51</CommercialRate>
+            <CommercialPlusRate>6.25</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="22">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Large Flat Rate Box</MailService>
+            <Rate>17.90</Rate>
+            <CommercialRate>15.80</CommercialRate>
+            <CommercialPlusRate>14.80</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="34">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Large Flat Rate Box Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>15.80</CommercialRate>
+            <CommercialPlusRate>14.80</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="17">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Medium Flat Rate Box</MailService>
+            <Rate>12.65</Rate>
+            <CommercialRate>11.30</CommercialRate>
+            <CommercialPlusRate>10.65</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="35">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Medium Flat Rate Box Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>11.30</CommercialRate>
+            <CommercialPlusRate>10.65</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="28">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Small Flat Rate Box</MailService>
+            <Rate>5.95</Rate>
+            <CommercialRate>5.25</CommercialRate>
+            <CommercialPlusRate>5.20</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="36">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Small Flat Rate Box Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>5.25</CommercialRate>
+            <CommercialPlusRate>5.20</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="47">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box A</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>9.97</CommercialRate>
+        </Postage>
+        <Postage CLASSID="48">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box A Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>9.97</CommercialRate>
+        </Postage>
+        <Postage CLASSID="49">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box B</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>16.28</CommercialRate>
+        </Postage>
+        <Postage CLASSID="50">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box B Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>16.28</CommercialRate>
+        </Postage>
+        <Postage CLASSID="58">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box C</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>47.43</CommercialRate>
+        </Postage>
+        <Postage CLASSID="59">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box C Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>47.43</CommercialRate>
+        </Postage>
+        <Postage CLASSID="16">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Envelope</MailService>
+            <Rate>5.75</Rate>
+            <CommercialRate>5.05</CommercialRate>
+            <CommercialPlusRate>4.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="37">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Envelope Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>5.05</CommercialRate>
+            <CommercialPlusRate>4.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="44">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Legal Flat Rate Envelope</MailService>
+            <Rate>5.90</Rate>
+            <CommercialRate>5.25</CommercialRate>
+            <CommercialPlusRate>4.99</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="45">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Legal Flat Rate Envelope Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>5.25</CommercialRate>
+            <CommercialPlusRate>4.99</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="29">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Padded Flat Rate Envelope</MailService>
+            <Rate>6.10</Rate>
+            <CommercialRate>5.70</CommercialRate>
+            <CommercialPlusRate>5.35</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="46">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Padded Flat Rate Envelope Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>5.70</CommercialRate>
+            <CommercialPlusRate>5.35</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="38">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Gift Card Flat Rate Envelope</MailService>
+            <Rate>5.75</Rate>
+            <CommercialRate>5.05</CommercialRate>
+            <CommercialPlusRate>4.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="39">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Gift Card Flat Rate Envelope Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>5.05</CommercialRate>
+            <CommercialPlusRate>4.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="42">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Small Flat Rate Envelope</MailService>
+            <Rate>5.75</Rate>
+            <CommercialRate>5.05</CommercialRate>
+            <CommercialPlusRate>4.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="43">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Small Flat Rate Envelope Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>5.05</CommercialRate>
+            <CommercialPlusRate>4.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="40">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Window Flat Rate Envelope</MailService>
+            <Rate>5.75</Rate>
+            <CommercialRate>5.05</CommercialRate>
+            <CommercialPlusRate>4.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="41">
+            <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Window Flat Rate Envelope Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>5.05</CommercialRate>
+            <CommercialPlusRate>4.95</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="0">
+            <MailService>First-Class Mail&amp;lt;sup&amp;gt;&amp;#174;&amp;lt;/sup&amp;gt; Parcel</MailService>
+            <Rate>3.40</Rate>
+        </Postage>
+        <Postage CLASSID="0">
+            <MailService>First-Class Mail&amp;lt;sup&amp;gt;&amp;#174;&amp;lt;/sup&amp;gt; Large Envelope</MailService>
+            <Rate>2.66</Rate>
+        </Postage>
+        <Postage CLASSID="0">
+            <MailService>First-Class Mail&amp;lt;sup&amp;gt;&amp;#174;&amp;lt;/sup&amp;gt; Postcards</MailService>
+            <Rate>0.34</Rate>
+        </Postage>
+        <Postage CLASSID="61">
+            <MailService>First-Class&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Package Service</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>2.76</CommercialRate>
+            <CommercialPlusRate>4.05</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="53">
+            <MailService>First-Class&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Package Service Hold For Pickup</MailService>
+            <Rate>0.00</Rate>
+            <CommercialRate>2.76</CommercialRate>
+            <CommercialPlusRate>4.05</CommercialPlusRate>
+        </Postage>
+        <Postage CLASSID="4">
+            <MailService>Standard Post&amp;lt;sup&amp;gt;&amp;#174;&amp;lt;/sup&amp;gt;</MailService>
+            <Rate>6.73</Rate>
+        </Postage>
+        <Postage CLASSID="6">
+            <MailService>Media Mail Parcel</MailService>
+            <Rate>2.69</Rate>
+        </Postage>
+        <Postage CLASSID="7">
+            <MailService>Library Mail Parcel</MailService>
+            <Rate>2.56</Rate>
+        </Postage>
+    </Package>
+</RateV4Response>

--- a/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe FriendlyShipping::Services::Usps::ChoosePackageRate do
+  let(:shipping_method) do
+    FriendlyShipping::Services::Usps::SHIPPING_METHODS.detect do |shipping_method|
+      shipping_method.name == shipping_method_name
+    end
+  end
+  let(:shipping_method_name) { 'Priority Mail Express' }
+  let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package]) }
+  let(:package_id) { '0' }
+  let(:package) { FactoryBot.build(:physical_package, id: package_id) }
+  let(:xml) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'usps_rates_api_response.xml')).read }
+  let(:rate_nodes) { Nokogiri::XML(xml).xpath('//Postage') }
+  let(:rates) { rate_nodes.map { |node| FriendlyShipping::Services::Usps::ParseRate.call(node, package) } }
+
+  subject { described_class.call(shipping_method, package, rates) }
+
+  it { is_expected.to be_a(FriendlyShipping::Rate) }
+end

--- a/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe FriendlyShipping::Services::Usps::ChoosePackageRate do
   let(:shipping_method_name) { 'Priority Mail Express' }
   let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package]) }
   let(:package_id) { '0' }
-  let(:package) { FactoryBot.build(:physical_package, id: package_id) }
+  let(:package) { FactoryBot.build(:physical_package, id: package_id, container: container) }
+  let(:container) { FactoryBot.build(:physical_box, properties: properties) }
+  let(:properties) { {} }
   let(:xml) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'usps_rates_api_response.xml')).read }
   let(:rate_nodes) { Nokogiri::XML(xml).xpath('//Postage') }
   let(:rates) { rate_nodes.map { |node| FriendlyShipping::Services::Usps::ParseRate.call(node, package) } }
@@ -17,4 +19,35 @@ RSpec.describe FriendlyShipping::Services::Usps::ChoosePackageRate do
   subject { described_class.call(shipping_method, package, rates) }
 
   it { is_expected.to be_a(FriendlyShipping::Rate) }
+
+  it 'has the right attributes' do
+    expect(subject.shipping_method).to eq(shipping_method)
+    expect(subject.total_amount.to_f).to eq(36.6)
+    expect(subject.data[:box_name]).to be_nil
+    expect(subject.data[:hold_for_pickup]).to be false
+  end
+
+  context 'if requesting a hold_for_pickup rate' do
+    let(:properties) { { hold_for_pickup: true } }
+
+    it 'has the right attributes' do
+      expect(subject.shipping_method).to eq(shipping_method)
+      expect(subject.total_amount.to_f).to eq(36.6)
+      expect(subject.data[:box_name]).to be_nil
+      expect(subject.data[:hold_for_pickup]).to be true
+    end
+  end
+
+  context 'if requesting a rate for a special box type' do
+    # There are no rates for Priority Mail Express and Large Flat Rate Box
+    let(:shipping_method_name) { 'Priority' }
+    let(:properties) { { box_name: :large_flat_rate_box } }
+
+    it 'has the right attributes' do
+      expect(subject.shipping_method).to eq(shipping_method)
+      expect(subject.total_amount.to_f).to eq(17.9)
+      expect(subject.data[:box_name]).to eq(:large_flat_rate_box)
+      expect(subject.data[:hold_for_pickup]).to be false
+    end
+  end
 end

--- a/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ChoosePackageRate do
   let(:properties) { {} }
   let(:xml) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'usps_rates_api_response.xml')).read }
   let(:rate_nodes) { Nokogiri::XML(xml).xpath('//Postage') }
-  let(:rates) { rate_nodes.map { |node| FriendlyShipping::Services::Usps::ParseRate.call(node, package) } }
+  let(:rates) { rate_nodes.map { |node| FriendlyShipping::Services::Usps::ParsePackageRate.call(node, package) } }
 
   subject { described_class.call(shipping_method, package, rates) }
 

--- a/spec/friendly_shipping/services/usps/machinable_package_spec.rb
+++ b/spec/friendly_shipping/services/usps/machinable_package_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Usps::MachinablePackage do
+  subject { described_class.new(package) }
+  let(:package) { Physical::Package.new(weight: weight, dimensions: dimensions) }
+
+  describe '#machinable?' do
+    let(:weight) { Measured::Weight(3, :ounces) }
+    let(:dimensions) { [8, 4, 2].map { |e| Measured::Length(e, :inches) } }
+
+    it { is_expected.to be_machinable }
+
+    context 'with oversize package' do
+      let(:dimensions) { [30, 20, 20].map { |e| Measured::Length(e, :inches) } }
+
+      it { is_expected.to_not be_machinable }
+    end
+
+    context 'with overweight package' do
+      let(:weight) { Measured::Weight(50, :pounds) }
+
+      it { is_expected.to_not be_machinable }
+    end
+  end
+end

--- a/spec/friendly_shipping/services/usps/machinable_package_spec.rb
+++ b/spec/friendly_shipping/services/usps/machinable_package_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe FriendlyShipping::Services::Usps::MachinablePackage do
       it { is_expected.to_not be_machinable }
     end
 
+    context 'with only one dimension too large' do
+      let(:dimensions) { [16, 16, 30].map { |e| Measured::Length(e, :inches) } }
+
+      it { is_expected.not_to be_machinable }
+    end
+
+    context 'with one dimension too small' do
+      let(:dimensions) { [5, 3, 0.25].map { |e| Measured::Length(e, :inches) } }
+
+      it { is_expected.to_not be_machinable }
+    end
+
     context 'with overweight package' do
       let(:weight) { Measured::Weight(50, :pounds) }
 

--- a/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe FriendlyShipping::Services::Usps::ParseRate do
+RSpec.describe FriendlyShipping::Services::Usps::ParsePackageRate do
   let(:package) { FactoryBot.build(:physical_package) }
   let(:mail_service) { "Priority Mail Express 1-Day&lt;sup&gt;&#8482;&lt;/sup&gt;" }
   let(:rate) { "26.40" }

--- a/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Usps::ParseRateResponse do
+  let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'usps_rates_api_response.xml')).read }
+  let(:response) { double(body: response_body) }
+  let(:request) { FriendlyShipping::Request.new(url: 'http://www.example.com') }
+  let(:packages) do
+    [
+      FactoryBot.build(:physical_package, id: '0'),
+    ]
+  end
+  let(:shipment) { FactoryBot.build(:physical_shipment, packages: packages) }
+
+  subject { described_class.call(request: request, response: response, shipment: shipment) }
+
+  it { is_expected.to be_success }
+
+  it 'returns rates along with the response' do
+    expect(subject.value!.length).to eq(4)
+    expect(subject.value!.map(&:total_amount)).to contain_exactly(*[
+      276, 673, 715, 3660
+    ].map { |cents| Money.new(cents, 'USD') })
+    expect(subject.value!.map(&:shipping_method).map(&:name)).to contain_exactly(
+      "First-Class Package Service",
+      "Priority",
+      "Priority Mail Express",
+      "Standard Post"
+    )
+  end
+
+  context 'with response for one regional rate box' do
+    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'rates_api_response_regional_single.xml')).read }
+    let(:packages) do
+      [
+        FactoryBot.build(:physical_package, id: '0', container: container),
+      ]
+    end
+    let(:container) { FactoryBot.build(:physical_box, properties: { box_name: :regional_rate_box_b } ) }
+
+    it 'returns regional rate' do
+      expect(subject).to be_success
+      expect(subject.value!.length).to eq(1)
+      expect(subject.value!.first.total_amount.to_f).to eq(9.4)
+      expect(subject.value!.first.data[:full_mail_service]).to eq('Priority Mail 2-Day Regional Rate Box B')
+    end
+  end
+
+  context 'with response for multiple regional rate boxes' do
+    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'rates_api_response_regional_multiple.xml')).read }
+    let(:packages) do
+      [
+        FactoryBot.build(:physical_package, id: '0', container: regional_rate_box_a),
+        FactoryBot.build(:physical_package, id: '1', container: regional_rate_box_b),
+      ]
+    end
+    let(:regional_rate_box_a) { FactoryBot.build(:physical_box, properties: { box_name: :regional_rate_box_a } ) }
+    let(:regional_rate_box_b) { FactoryBot.build(:physical_box, properties: { box_name: :regional_rate_box_b } ) }
+
+    it 'returns regional rates' do
+      expect(subject).to be_success
+      expect(subject.value!.length).to eq(1)
+
+      expect(subject.value!.map(&:total_amount).map(&:cents)).to contain_exactly(812 + 940)
+      expect(subject.value!.map(&:shipping_method).map(&:name)).to contain_exactly(
+        "Priority"
+      )
+    end
+  end
+
+  context 'with response containing large flat rates' do
+    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'rates_api_response_large_box.xml')).read }
+    let(:packages) do
+      [
+        FactoryBot.build(:physical_package, id: '0', container: container),
+      ]
+    end
+    let(:container) { FactoryBot.build(:physical_box, properties: { box_name: :large_flat_rate_box, commercial_pricing: true } ) }
+
+    it 'returns flat rate' do
+      expect(subject).to be_success
+      expect(subject.value!.length).to eq(1)
+      expect(subject.value!.first.total_amount.to_f).to eq(17.6)
+      expect(subject.value!.first.data[:full_mail_service]).to eq('Priority Mail 3-Day Large Flat Rate Box')
+    end
+  end
+end

--- a/spec/friendly_shipping/services/usps/parse_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_rate_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Usps::ParseRate do
+  let(:package) { FactoryBot.build(:physical_package) }
+  let(:mail_service) { "Priority Mail Express 1-Day&lt;sup&gt;&#8482;&lt;/sup&gt;" }
+  let(:rate) { "26.40" }
+  let(:commercial_rate) { nil }
+  let(:commercial_plus_rate) { nil }
+  let(:class_id) { '0' }
+
+  subject { described_class.call(node, package) }
+
+  let(:node) do
+    serialized = Nokogiri::XML::Builder.new do |xml|
+      xml.Postage('CLASSID' => class_id) do
+        xml.MailService mail_service
+        xml.Rate rate
+        xml.CommercialRate commercial_rate if commercial_rate
+        xml.CommercialPlusRate commercial_plus_rate if commercial_plus_rate
+      end
+    end.to_xml
+    Nokogiri::XML(serialized).xpath('Postage').first
+  end
+
+  it 'parses correctly' do
+    expect(subject.total_amount.to_f).to eq(26.4)
+    expect(subject.amounts.keys).to eq([package.id])
+    expect(subject.shipping_method.name).to eq("Priority Mail Express")
+    expect(subject.data[:days_to_delivery]).to eq(1)
+    expect(subject.data[:service_code]).to eq('0')
+  end
+
+  context 'with a non-express Priority Mail rate' do
+    let(:mail_service) { "Priority Mail 2-Day&lt;sup&gt;&#8482;&lt;/sup&gt;" }
+
+    it 'has the correct shipping method' do
+      expect(subject.shipping_method.name).to eq('Priority')
+    end
+  end
+
+  context 'Priority Mail in a Flat Rate Box' do
+    let(:class_id) { "1" }
+    let(:mail_service) { "Priority Mail 2-Day&lt;sup&gt;&#8482;&lt;/sup&gt; Large Flat Rate Box" }
+
+    it 'contains the box code in the rate data' do
+      expect(subject.data[:box_name]).to eq(:large_flat_rate_box)
+    end
+  end
+
+  context 'First-Class Mail' do
+    let(:mail_service) { "First-Class Mail&lt;sup&gt;&#174;&lt;/sup&gt; Parcel" }
+
+    it 'finds a shipping method' do
+      expect(subject.shipping_method.name).to eq('First-Class')
+      expect(subject.data[:box_name]).to eq(:parcel)
+    end
+  end
+
+  context 'If Rate is 0' do
+    let(:rate) { '0.0' }
+    let(:commercial_rate) { '4.50' }
+
+    it 'will use the commercial rate instead of the normal rate' do
+      expect(subject.total_amount.to_f).to eq(4.5)
+    end
+  end
+end

--- a/spec/friendly_shipping/services/usps/parse_xml_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_xml_response_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Usps::ParseXMLResponse do
+  let(:response) do
+    Nokogiri::XML::Builder.new do |xml|
+      xml.Error do
+        xml.Number '0'
+        xml.source 'WebtoolsAMS'
+        xml.Description 'Something went wrong'
+      end
+    end.to_xml
+  end
+
+  subject(:parser) { described_class.call(response, 'SomeTag') }
+
+  it { is_expected.to be_failure }
+
+  it 'has the correct error message' do
+    expect(subject.failure.to_s).to eq('0: Something went wrong')
+  end
+end

--- a/spec/friendly_shipping/services/usps/parse_xml_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_xml_response_spec.rb
@@ -13,11 +13,28 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseXMLResponse do
     end.to_xml
   end
 
-  subject(:parser) { described_class.call(response, 'SomeTag') }
+  subject(:parser) { described_class.call(response, 'RateV4Response') }
 
   it { is_expected.to be_failure }
 
   it 'has the correct error message' do
     expect(subject.failure.to_s).to eq('0: Something went wrong')
+  end
+
+  context 'with a successful response' do
+    let(:response) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'rates_api_response_regional_single.xml')).read }
+
+    it { is_expected.to be_success }
+
+    it 'contains an XML document with the requested root' do
+      expect(subject.value!).to be_a(Nokogiri::XML::Document)
+      expect(subject.value!.root.name).to eq('RateV4Response')
+    end
+
+    context 'when requesting the wrong root tag' do
+      subject(:parser) { described_class.call(response, 'Wat') }
+
+      it { is_expected.to be_failure }
+    end
   end
 end

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
   let(:container) { FactoryBot.build(:physical_box, dimensions: dimensions, weight: weight, properties: properties) }
   let(:package) { FactoryBot.build(:physical_package, container: container, items: [], void_fill_density: Measured::Weight(0, :g)) }
   let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package]) }
-  let(:service) { nil }
-  subject(:parser) { described_class.call(shipment: shipment, login: 'fake', service: service) }
+  let(:shipping_method) { nil }
+  subject(:parser) { described_class.call(shipment: shipment, login: 'fake', shipping_method: shipping_method) }
 
   let(:node) { Nokogiri::XML(subject).xpath('//RateV4Request/Package') }
 
@@ -52,20 +52,20 @@ RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
   end
 
   context 'with priority shipping method' do
-    let(:service) do
+    let(:shipping_method) do
       FriendlyShipping::Services::Usps::SHIPPING_METHODS.detect do |shipping_method|
         shipping_method.name == 'Priority'
       end
     end
 
-    it 'uses correct service' do
+    it 'uses correct shipping_method' do
       expect(node.at_xpath('Service').text).to eq('PRIORITY')
     end
 
     context 'with commercial_pricing true' do
       let(:properties) { { commercial_pricing: true } }
 
-      it 'uses correct service' do
+      it 'uses correct shipping_method' do
         expect(node.at_xpath('Service').text).to eq('PRIORITY COMMERCIAL')
       end
     end

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
+  let(:dimensions) { [10, 21.321539, 24].map { |e| Measured::Length(e, :cm) } }
+  let(:weight) { Measured::Weight.new(14.025, :ounces) }
+  let(:properties) { {} }
+  let(:container) { FactoryBot.build(:physical_box, dimensions: dimensions, weight: weight, properties: properties) }
+  let(:package) { FactoryBot.build(:physical_package, container: container, items: [], void_fill_density: Measured::Weight(0, :g)) }
+  let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package]) }
+  let(:service) { nil }
+  subject(:parser) { described_class.call(shipment: shipment, login: 'fake', service: service) }
+
+  let(:node) { Nokogiri::XML(subject).xpath('//RateV4Request/Package') }
+
+  it 'serializes the request' do
+    expect(node.at_xpath('Service').text).to eq('ALL')
+    expect(node.at_xpath('Container').text).to eq('RECTANGULAR')
+    expect(node.at_xpath('Size').text).to eq('REGULAR')
+    expect(node.at_xpath('Width').text).to eq('8.39')
+    expect(node.at_xpath('Length').text).to eq('3.94')
+    expect(node.at_xpath('Height').text).to eq('9.45')
+    expect(node.at_xpath('Girth').text).to eq('24.66')
+    expect(node.at_xpath('Pounds').text).to eq('0')
+    expect(node.at_xpath('Ounces').text).to eq('15')
+    expect(node.at_xpath('Machinable').text).to eq('FALSE')
+  end
+
+  context 'with regional rate box name' do
+    let(:properties) { { box_name: :regional_rate_box_a } }
+
+    it 'uses correct container' do
+      expect(node.at_xpath('Container').text).to eq('REGIONALRATEBOXA')
+    end
+  end
+
+  context 'with large flat rate box name' do
+    let(:properties) { { box_name: :large_flat_rate_box } }
+
+    it 'uses correct container' do
+      expect(node.at_xpath('Container').text).to eq('LG FLAT RATE BOX')
+    end
+  end
+
+  context 'with package weight that ceils to exactly 16 oz' do
+    let(:weight) { Measured::Weight(15.6, :ounces) }
+
+    it 'returns 15.999 oz' do
+      expect(node.at_xpath('Ounces').text).to eq('15.999')
+    end
+  end
+
+  context 'with priority shipping method' do
+    let(:service) do
+      FriendlyShipping::Services::Usps::SHIPPING_METHODS.detect do |shipping_method|
+        shipping_method.name == 'Priority'
+      end
+    end
+
+    it 'uses correct service' do
+      expect(node.at_xpath('Service').text).to eq('PRIORITY')
+    end
+
+    context 'with commercial_pricing true' do
+      let(:properties) { { commercial_pricing: true } }
+
+      it 'uses correct service' do
+        expect(node.at_xpath('Service').text).to eq('PRIORITY COMMERCIAL')
+      end
+    end
+  end
+end

--- a/spec/friendly_shipping/services/usps_spec.rb
+++ b/spec/friendly_shipping/services/usps_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Usps do
+  subject(:service) { described_class.new(login: ENV['USPS_LOGIN']) }
+
+  describe 'carriers' do
+    subject { service.carriers }
+    let(:usps) { FriendlyShipping::Carrier.new(code: 'usps', id: 'usps', name: 'United States Postal Service') }
+
+    it { is_expected.to be_success }
+
+    it 'contains UPS only' do
+      expect(subject.value!).to eq([usps])
+    end
+  end
+
+  describe 'SHIPPING_METHODS' do
+    it 'contains all valid shipping methods' do
+      described_class::SHIPPING_METHODS.each do |shipping_method|
+        expect(shipping_method.name).to be_present
+        expect(shipping_method.service_code).to be_present
+        expect(shipping_method.origin_countries).not_to be_empty
+        expect(shipping_method.international? || shipping_method.domestic?).to be true
+      end
+    end
+  end
+
+  describe 'rate_estimates' do
+    let(:package) { FactoryBot.build(:physical_package) }
+    let(:destination) { FactoryBot.build(:physical_location, region: "FL", zip: '32821') }
+    let(:origin) { FactoryBot.build(:physical_location, region: "NC", zip: '27703') }
+    let(:dimensions) { [8, 4, 2].map { |e| Measured::Length(e, :inches) } }
+    let(:packages) do
+      [
+        FactoryBot.build(:physical_package, container: nil, dimensions: dimensions, id: '0'),
+      ]
+    end
+    let(:shipment) { FactoryBot.build(:physical_shipment, packages: packages, origin: origin, destination: destination) }
+    let(:carriers) { service.carriers.value! }
+
+    subject { service.rate_estimates(shipment, carriers) }
+
+    it 'returns Physical::Rate objects wrapped in a Success Monad', vcr: { cassette_name: 'usps/rate_estimates/success' } do
+      aggregate_failures do
+        is_expected.to be_success
+        expect(subject.value!).to be_a(Array)
+        expect(subject.value!.first).to be_a(FriendlyShipping::Rate)
+      end
+    end
+
+    context 'if the login is wrong', vcr: { cassette_name: 'usps/rate_estimates/failure' } do
+      let(:service) { described_class.new(login: 'WRONG_LOGIN') }
+
+      it 'returns a Failure with the correct error message' do
+        aggregate_failures do
+          is_expected.to be_failure
+          expect(subject.failure.to_s).to eq("80040B1A: Authorization failure.  Perhaps username and/or password is incorrect.")
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ VCR.configure do |c|
   c.filter_sensitive_data('<UPS_LOGIN>') { ENV['UPS_LOGIN'] }
   c.filter_sensitive_data('<UPS_KEY>') { ENV['UPS_KEY'] }
   c.filter_sensitive_data('<UPS_PASSWORD>') { ENV['UPS_PASSWORD'] }
+  c.filter_sensitive_data('<USPS_LOGIN>') { ENV['USPS_LOGIN'] }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This adds the capability of estimating USPS rates directly from USPS.
There is pretty complicated code, because the USPS rating API has a lot
of functionality and an interesting data model.

When requesting rates for a shipment, USPS will return all possible
rates for each package. This means that we need to match the response's
rates to each of the packages, and then sum the rates for all the
packages to get rates for the entire shipment.

Compared to previous API implementations, we're using USPS' endpoint
with POST requests rather than GET requests because that makes VCR
cassette matching easier and probably also allows longer a longer
request payload.
