### PR TITLE
Update USPS specs for Physical 0.4

### DIFF
--- a/lib/friendly_shipping/version.rb
+++ b/lib/friendly_shipping/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
   let(:weight) { Measured::Weight.new(14.025, :ounces) }
   let(:properties) { {} }
   let(:container) { FactoryBot.build(:physical_box, dimensions: dimensions, weight: weight, properties: properties) }
-  let(:package) { FactoryBot.build(:physical_package, container: container, items: [], void_fill_density: Measured::Weight(0, :g)) }
+  let(:package) { FactoryBot.build(:physical_package, container: container, items: [], void_fill_density: Measured::Density(0, :g_ml)) }
   let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package]) }
   let(:shipping_method) { nil }
   subject(:parser) { described_class.call(shipment: shipment, login: 'fake', shipping_method: shipping_method) }


### PR DESCRIPTION
Physical 0.4 changes how `Physical::Packages` `void_fill_weight` is initialized. This PR incorporates this change in the USPS serializer spec and bumps the version again so the latest `friendly_shipping` gem actually has a passing build.