### PR TITLE
Add support for UPS Address Validation (XAV) endpoint 

### DIFF
--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -9,6 +9,7 @@ require "friendly_shipping/carrier"
 require "friendly_shipping/shipping_method"
 require "friendly_shipping/label"
 require "friendly_shipping/rate"
+require "friendly_shipping/address_validation_result"
 
 require "friendly_shipping/services/ship_engine"
 require "friendly_shipping/services/ups"

--- a/lib/friendly_shipping/address_validation_result.rb
+++ b/lib/friendly_shipping/address_validation_result.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  class AddressValidationResult
+    attr_reader :suggestions,
+                :original_address,
+                :original_request,
+                :original_response
+
+    def initialize(
+      suggestions: [],
+      original_address: nil,
+      original_request: nil,
+      original_response: nil
+    )
+      @suggestions = suggestions
+      @original_address = original_address
+      @original_request = original_request
+      @original_response = original_response
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups.rb
+++ b/lib/friendly_shipping/services/ups.rb
@@ -61,9 +61,10 @@ module FriendlyShipping
 
       # Validate an address.
       # @param [Physical::Location] location The address we want to verify
-      # @return [Result<Physical::Location>] The response data from UPS encoded in a `Physical::Location`
-      #   object. Name and Company name are always nil, the address lines will be made conformant to what UPS
-      #   considers right. The returned location will have the address_type set if possible.
+      # @return [Result<FriendlyShipping::AddressValidationResult>] The response data from UPS encoded in a
+      #   `FriendlyShipping::AddressValidationResult` object. Name and Company name are always nil, the
+      #   address lines will be made conformant to what UPS considers right. The returned location will
+      #   have the address_type set if possible.
       def address_validation(location)
         address_validation_request_xml = SerializeAddressValidationRequest.call(location: location)
         url = base_url + RESOURCES[:address_validation]
@@ -73,14 +74,15 @@ module FriendlyShipping
         )
 
         client.post(request).bind do |response|
-          ParseAddressValidationResponse.call(response: response, _request: request, _location: location)
+          ParseAddressValidationResponse.call(response: response, request: request, location: location)
         end
       end
 
       # Find city and state for a given ZIP code
       # @param [Physical::Location] location A location object with country and ZIP code set
-      # @return [Result<Physical::Location>] The response data from UPS encoded in a `Physical::Location`
-      #   object. Country, City and ZIP code will be set, everything else nil.
+      # @return [Result<FriendlyShipping::AddressValidationResult>] The response data from UPS encoded in a
+      #   `FriendlyShipping::AddressValidationResult` object. Country, City and ZIP code will be set,
+      #   everything else nil.
       def city_state_lookup(location)
         city_state_lookup_request_xml = SerializeCityStateLookupRequest.call(location: location)
         url = base_url + RESOURCES[:city_state_lookup]
@@ -90,7 +92,7 @@ module FriendlyShipping
         )
 
         client.post(request).bind do |response|
-          ParseCityStateLookupResponse.call(response: response, _request: request, location: location)
+          ParseCityStateLookupResponse.call(response: response, request: request, location: location)
         end
       end
 

--- a/lib/friendly_shipping/services/ups.rb
+++ b/lib/friendly_shipping/services/ups.rb
@@ -3,6 +3,7 @@
 require 'dry/monads/result'
 require 'friendly_shipping/services/ups/client'
 require 'friendly_shipping/services/ups/serialize_access_request'
+require 'friendly_shipping/services/ups/serialize_city_state_lookup_request'
 require 'friendly_shipping/services/ups/serialize_address_validation_request'
 require 'friendly_shipping/services/ups/serialize_rating_service_selection_request'
 require 'friendly_shipping/services/ups/parse_rate_response'

--- a/lib/friendly_shipping/services/ups.rb
+++ b/lib/friendly_shipping/services/ups.rb
@@ -6,8 +6,9 @@ require 'friendly_shipping/services/ups/serialize_access_request'
 require 'friendly_shipping/services/ups/serialize_city_state_lookup_request'
 require 'friendly_shipping/services/ups/serialize_address_validation_request'
 require 'friendly_shipping/services/ups/serialize_rating_service_selection_request'
-require 'friendly_shipping/services/ups/parse_rate_response'
 require 'friendly_shipping/services/ups/parse_address_validation_response'
+require 'friendly_shipping/services/ups/parse_city_state_lookup_response'
+require 'friendly_shipping/services/ups/parse_rate_response'
 require 'friendly_shipping/services/ups/shipping_methods'
 
 module FriendlyShipping

--- a/lib/friendly_shipping/services/ups/parse_address_validation_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_address_validation_response.rb
@@ -15,7 +15,8 @@ module FriendlyShipping
             else
               Success(
                 Physical::Location.new(
-                  address1: xml.at('AddressKeyFormat/AddressLine')&.text,
+                  address1: xml.xpath('//AddressKeyFormat/AddressLine')[0]&.text,
+                  address2: xml.xpath('//AddressKeyFormat/AddressLine')[1]&.text,
                   city: xml.at('AddressKeyFormat/PoliticalDivision2')&.text,
                   region: xml.at('AddressKeyFormat/PoliticalDivision1')&.text,
                   country: xml.at('AddressKeyFormat/CountryCode')&.text,

--- a/lib/friendly_shipping/services/ups/parse_address_validation_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_address_validation_response.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Ups
+      class ParseAddressValidationResponse
+        extend Dry::Monads::Result::Mixin
+
+        def self.call(_request:, response:, _location:)
+          parsing_result = ParseXMLResponse.call(response.body, 'AddressValidationResponse')
+
+          parsing_result.bind do |xml|
+            if xml.at('NoCandidatesIndicator')
+              Failure('Address is probably invalid. No similar valid addresses found.')
+            else
+              Success(
+                Physical::Location.new(
+                  address1: xml.at('AddressKeyFormat/AddressLine')&.text,
+                  city: xml.at('AddressKeyFormat/PoliticalDivision2')&.text,
+                  region: xml.at('AddressKeyFormat/PoliticalDivision1')&.text,
+                  country: xml.at('AddressKeyFormat/CountryCode')&.text,
+                  zip: xml.at('AddressKeyFormat/PostcodePrimaryLow')&.text,
+                  address_type: xml.at('AddressClassification/Description')&.text&.downcase
+                )
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups/parse_city_state_lookup_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_city_state_lookup_response.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Ups
+      class ParseCityStateLookupResponse
+        extend Dry::Monads::Result::Mixin
+
+        def self.call(_request:, response:, location:)
+          parsing_result = ParseXMLResponse.call(response.body, 'AddressValidationResponse')
+
+          parsing_result.fmap do |xml|
+            Physical::Location.new(
+              city: xml.at('AddressValidationResult/Address/City')&.text,
+              region: xml.at('AddressValidationResult/Address/StateProvinceCode')&.text,
+              country: location.country,
+              zip: xml.at('AddressValidationResult/Address/PostcodePrimaryLow')&.text,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups/serialize_address_validation_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_address_validation_request.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Ups
+      class SerializeAddressValidationRequest
+        attr_reader :location
+
+        REQUEST_ACTION = 'XAV'
+        REQUEST_OPTIONS = {
+          validation: 1,
+          classification: 2,
+          both: 3
+        }.freeze
+
+        def self.call(location:)
+          xml_builder = Nokogiri::XML::Builder.new do |xml|
+            xml.AddressValidationRequest do
+              xml.Request do
+                xml.RequestAction REQUEST_ACTION
+                xml.RequestOption REQUEST_OPTIONS[:both]
+              end
+
+              xml.AddressKeyFormat do
+                xml.AddressLine location.address1
+                xml.AddressLine location.address2
+                xml.PoliticalDivision2 location.city
+                xml.PoliticalDivision1 location.region.code
+                xml.PostcodePrimaryLow location.zip
+                xml.CountryCode location.country.code
+              end
+            end
+          end
+          xml_builder.to_xml
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups/serialize_city_state_lookup_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_city_state_lookup_request.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Ups
+      class SerializeCityStateLookupRequest
+        REQUEST_ACTION = 'AV'
+
+        def self.call(location:)
+          xml_builder = Nokogiri::XML::Builder.new do |xml|
+            xml.AddressValidationRequest do
+              xml.Request do
+                xml.RequestAction REQUEST_ACTION
+              end
+              xml.Address do
+                xml.PostalCode location.zip
+                xml.CountryCode location.country.code
+              end
+            end
+          end
+          xml_builder.to_xml
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/ups/address_validation/correctable_address.yml
+++ b/spec/cassettes/ups/address_validation/correctable_address.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/ups.app/xml/XAV
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <AccessRequest>
+          <AccessLicenseNumber><UPS_KEY></AccessLicenseNumber>
+          <UserId><UPS_LOGIN></UserId>
+          <Password><UPS_PASSWORD></Password>
+        </AccessRequest>
+        <?xml version="1.0"?>
+        <AddressValidationRequest>
+          <Request>
+            <RequestAction>XAV</RequestAction>
+            <RequestOption>3</RequestOption>
+          </Request>
+          <AddressKeyFormat>
+            <AddressLine>406 East 43nd Street</AddressLine>
+            <AddressLine>South</AddressLine>
+            <PoliticalDivision2>New York</PoliticalDivision2>
+            <PoliticalDivision1>NY</PoliticalDivision1>
+            <PostcodePrimaryLow>27777</PostcodePrimaryLow>
+            <CountryCode>US</CountryCode>
+          </AddressKeyFormat>
+        </AddressValidationRequest>
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '695'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: '200'
+    headers:
+      Date:
+      - Mon, 07 Oct 2019 08:19:48 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie, Set-Cookie2
+      Pragma:
+      - no-cache
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Apihttpstatus:
+      - '200'
+      Content-Length:
+      - '790'
+      Content-Type:
+      - application/xml
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><ValidAddressIndicator/><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>406
+        W 43RD ST</AddressLine><Region>NEW YORK NY 10036-6322</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10036</PostcodePrimaryLow><PostcodeExtendedLow>6322</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
+    http_version:
+  recorded_at: Mon, 07 Oct 2019 08:19:48 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/ups/address_validation/incomplete_address.yml
+++ b/spec/cassettes/ups/address_validation/incomplete_address.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/ups.app/xml/XAV
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <AccessRequest>
+          <AccessLicenseNumber><UPS_KEY></AccessLicenseNumber>
+          <UserId><UPS_LOGIN></UserId>
+          <Password><UPS_PASSWORD></Password>
+        </AccessRequest>
+        <?xml version="1.0"?>
+        <AddressValidationRequest>
+          <Request>
+            <RequestAction>XAV</RequestAction>
+            <RequestOption>3</RequestOption>
+          </Request>
+          <AddressKeyFormat>
+            <AddressLine>East 43nd Street</AddressLine>
+            <AddressLine>South</AddressLine>
+            <PoliticalDivision2>New York</PoliticalDivision2>
+            <PoliticalDivision1>NY</PoliticalDivision1>
+            <PostcodePrimaryLow>27777</PostcodePrimaryLow>
+            <CountryCode>US</CountryCode>
+          </AddressKeyFormat>
+        </AddressValidationRequest>
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '691'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: '200'
+    headers:
+      Date:
+      - Tue, 08 Oct 2019 09:21:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie, Set-Cookie2
+      Pragma:
+      - no-cache
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Apihttpstatus:
+      - '200'
+      Content-Length:
+      - '7019'
+      Content-Type:
+      - application/xml
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><AmbiguousAddressIndicator/><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>11-19
+        E 43RD ST</AddressLine><Region>NEW YORK NY 10017-4601</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4601</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>33-99
+        E 43RD ST</AddressLine><Region>NEW YORK NY 10017-3812</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>3812</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>126-128
+        E 43RD ST</AddressLine><Region>NEW YORK NY 10017-4019</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4019</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>132-142
+        E 43RD ST</AddressLine><Region>NEW YORK NY 10017-4019</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4019</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><ConsigneeName>UPS
+        STORE</ConsigneeName><AddressLine>132 E 43RD ST</AddressLine><Region>NEW YORK
+        NY 10017-4135</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4135</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>143
+        E 43RD ST</AddressLine><Region>NEW YORK NY 10017-4007</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4007</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>144-198
+        E 43RD ST</AddressLine><Region>NEW YORK NY 10017-4001</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4001</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>149-199
+        E 43RD ST</AddressLine><Region>NEW YORK NY 10017-4007</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4007</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>151
+        E 43RD ST</AddressLine><Region>NEW YORK NY 10017-4017</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4017</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>151
+        E 43RD ST</AddressLine><AddressLine>APT 2A-2B</AddressLine><Region>NEW YORK
+        NY 10017-4017</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4017</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>151
+        E 43RD ST</AddressLine><AddressLine>APT 3A-3B</AddressLine><Region>NEW YORK
+        NY 10017-4017</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4017</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>151
+        E 43RD ST</AddressLine><AddressLine>APT 4A-4B</AddressLine><Region>NEW YORK
+        NY 10017-4017</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4017</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>151
+        E 43RD ST</AddressLine><AddressLine>APT 5A-5B</AddressLine><Region>NEW YORK
+        NY 10017-4017</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4017</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>151
+        E 43RD ST</AddressLine><AddressLine>FRNT A-B</AddressLine><Region>NEW YORK
+        NY 10017-4017</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4017</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>153
+        E 43RD ST</AddressLine><AddressLine>APT 2A-2D</AddressLine><Region>NEW YORK
+        NY 10017-4015</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4015</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
+    http_version: 
+  recorded_at: Tue, 08 Oct 2019 09:21:18 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/ups/address_validation/invalid_address.yml
+++ b/spec/cassettes/ups/address_validation/invalid_address.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/ups.app/xml/XAV
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <AccessRequest>
+          <AccessLicenseNumber><UPS_KEY></AccessLicenseNumber>
+          <UserId><UPS_LOGIN></UserId>
+          <Password><UPS_PASSWORD></Password>
+        </AccessRequest>
+        <?xml version="1.0"?>
+        <AddressValidationRequest>
+          <Request>
+            <RequestAction>XAV</RequestAction>
+            <RequestOption>3</RequestOption>
+          </Request>
+          <AddressKeyFormat>
+            <AddressLine>Platform nine and a half</AddressLine>
+            <AddressLine>South</AddressLine>
+            <PoliticalDivision2>New York</PoliticalDivision2>
+            <PoliticalDivision1>NY</PoliticalDivision1>
+            <PostcodePrimaryLow>10017</PostcodePrimaryLow>
+            <CountryCode>US</CountryCode>
+          </AddressKeyFormat>
+        </AddressValidationRequest>
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '699'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: '200'
+    headers:
+      Date:
+      - Mon, 07 Oct 2019 08:18:48 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie, Set-Cookie2
+      Pragma:
+      - no-cache
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Apihttpstatus:
+      - '200'
+      Content-Length:
+      - '365'
+      Content-Type:
+      - application/xml
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><NoCandidatesIndicator/><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification></AddressValidationResponse>
+    http_version:
+  recorded_at: Mon, 07 Oct 2019 08:18:48 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/ups/address_validation/valid_address.yml
+++ b/spec/cassettes/ups/address_validation/valid_address.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/ups.app/xml/XAV
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <AccessRequest>
+          <AccessLicenseNumber><UPS_KEY></AccessLicenseNumber>
+          <UserId><UPS_LOGIN></UserId>
+          <Password><UPS_PASSWORD></Password>
+        </AccessRequest>
+        <?xml version="1.0"?>
+        <AddressValidationRequest>
+          <Request>
+            <RequestAction>XAV</RequestAction>
+            <RequestOption>3</RequestOption>
+          </Request>
+          <AddressKeyFormat>
+            <AddressLine>405 East 42nd Street</AddressLine>
+            <AddressLine>South</AddressLine>
+            <PoliticalDivision2>New York</PoliticalDivision2>
+            <PoliticalDivision1>NY</PoliticalDivision1>
+            <PostcodePrimaryLow>10017</PostcodePrimaryLow>
+            <CountryCode>US</CountryCode>
+          </AddressKeyFormat>
+        </AddressValidationRequest>
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '695'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: '200'
+    headers:
+      Date:
+      - Mon, 07 Oct 2019 08:18:47 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie, Set-Cookie2
+      Pragma:
+      - no-cache
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Apihttpstatus:
+      - '200'
+      Content-Length:
+      - '796'
+      Content-Type:
+      - application/xml
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><ValidAddressIndicator/><AddressClassification><Code>1</Code><Description>Commercial</Description></AddressClassification><AddressKeyFormat><AddressClassification><Code>1</Code><Description>Commercial</Description></AddressClassification><AddressLine>405
+        E 42ND ST</AddressLine><Region>NEW YORK NY 10017-3507</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>3507</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
+    http_version:
+  recorded_at: Mon, 07 Oct 2019 08:18:48 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/ups/city_state_lookup/failure.yml
+++ b/spec/cassettes/ups/city_state_lookup/failure.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/ups.app/xml/AV
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <AccessRequest>
+          <AccessLicenseNumber><UPS_KEY></AccessLicenseNumber>
+          <UserId><UPS_LOGIN></UserId>
+          <Password><UPS_PASSWORD></Password>
+        </AccessRequest>
+        <?xml version="1.0"?>
+        <AddressValidationRequest>
+          <Request>
+            <RequestAction>AV</RequestAction>
+          </Request>
+          <Address>
+            <PostalCode>00000</PostalCode>
+            <CountryCode>US</CountryCode>
+          </Address>
+        </AddressValidationRequest>
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '432'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: '200'
+    headers:
+      Date:
+      - Mon, 07 Oct 2019 14:23:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie, Set-Cookie2
+      Pragma:
+      - no-cache
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Apihttpstatus:
+      - '400'
+      Apierrorcode:
+      - '20008'
+      Apierrormsg:
+      - The field, PostalCode, contains invalid data, 00000
+      Content-Length:
+      - '412'
+      Content-Type:
+      - application/xml
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>0</ResponseStatusCode><ResponseStatusDescription>Failure</ResponseStatusDescription><Error><ErrorSeverity>Hard</ErrorSeverity><ErrorCode>20008</ErrorCode><ErrorDescription>The
+        field, PostalCode, contains invalid data, 00000</ErrorDescription></Error></Response></AddressValidationResponse>
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 14:23:08 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/ups/city_state_lookup/multiple_states.yml
+++ b/spec/cassettes/ups/city_state_lookup/multiple_states.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/ups.app/xml/AV
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <AccessRequest>
+          <AccessLicenseNumber><UPS_KEY></AccessLicenseNumber>
+          <UserId><UPS_LOGIN></UserId>
+          <Password><UPS_PASSWORD></Password>
+        </AccessRequest>
+        <?xml version="1.0"?>
+        <AddressValidationRequest>
+          <Request>
+            <RequestAction>AV</RequestAction>
+          </Request>
+          <Address>
+            <PostalCode>81137</PostalCode>
+            <CountryCode>US</CountryCode>
+          </Address>
+        </AddressValidationRequest>
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '432'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: '200'
+    headers:
+      Date:
+      - Tue, 08 Oct 2019 10:15:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie, Set-Cookie2
+      Pragma:
+      - no-cache
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Apihttpstatus:
+      - '200'
+      Content-Length:
+      - '2604'
+      Content-Type:
+      - application/xml
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><AddressValidationResult><Rank>1</Rank><Quality>0.9750</Quality><Address><City>IGNACIO</City><StateProvinceCode>CO</StateProvinceCode></Address><PostalCodeLowEnd>81137</PostalCodeLowEnd><PostalCodeHighEnd>81137</PostalCodeHighEnd></AddressValidationResult><AddressValidationResult><Rank>2</Rank><Quality>0.9750</Quality><Address><City>ALLISON</City><StateProvinceCode>CO</StateProvinceCode></Address><PostalCodeLowEnd>81137</PostalCodeLowEnd><PostalCodeHighEnd>81137</PostalCodeHighEnd></AddressValidationResult><AddressValidationResult><Rank>3</Rank><Quality>0.9750</Quality><Address><City>INDIAN
+        AGENCY</City><StateProvinceCode>CO</StateProvinceCode></Address><PostalCodeLowEnd>81137</PostalCodeLowEnd><PostalCodeHighEnd>81137</PostalCodeHighEnd></AddressValidationResult><AddressValidationResult><Rank>4</Rank><Quality>0.9750</Quality><Address><City>OXFORD</City><StateProvinceCode>CO</StateProvinceCode></Address><PostalCodeLowEnd>81137</PostalCodeLowEnd><PostalCodeHighEnd>81137</PostalCodeHighEnd></AddressValidationResult><AddressValidationResult><Rank>5</Rank><Quality>0.9750</Quality><Address><City>S
+        UTE INDIAN</City><StateProvinceCode>CO</StateProvinceCode></Address><PostalCodeLowEnd>81137</PostalCodeLowEnd><PostalCodeHighEnd>81137</PostalCodeHighEnd></AddressValidationResult><AddressValidationResult><Rank>6</Rank><Quality>0.9750</Quality><Address><City>SO
+        UTE INDIAN RES</City><StateProvinceCode>CO</StateProvinceCode></Address><PostalCodeLowEnd>81137</PostalCodeLowEnd><PostalCodeHighEnd>81137</PostalCodeHighEnd></AddressValidationResult><AddressValidationResult><Rank>7</Rank><Quality>0.9750</Quality><Address><City>SOUTH
+        UTE INDIAN RES</City><StateProvinceCode>CO</StateProvinceCode></Address><PostalCodeLowEnd>81137</PostalCodeLowEnd><PostalCodeHighEnd>81137</PostalCodeHighEnd></AddressValidationResult><AddressValidationResult><Rank>8</Rank><Quality>0.9750</Quality><Address><City>SOUTHERN
+        UTE INDIAN RESERVAT</City><StateProvinceCode>CO</StateProvinceCode></Address><PostalCodeLowEnd>81137</PostalCodeLowEnd><PostalCodeHighEnd>81137</PostalCodeHighEnd></AddressValidationResult><AddressValidationResult><Rank>9</Rank><Quality>0.9750</Quality><Address><City>TIFFANY</City><StateProvinceCode>CO</StateProvinceCode></Address><PostalCodeLowEnd>81137</PostalCodeLowEnd><PostalCodeHighEnd>81137</PostalCodeHighEnd></AddressValidationResult></AddressValidationResponse>
+    http_version: 
+  recorded_at: Tue, 08 Oct 2019 10:15:18 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/ups/city_state_lookup/success.yml
+++ b/spec/cassettes/ups/city_state_lookup/success.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/ups.app/xml/AV
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <AccessRequest>
+          <AccessLicenseNumber><UPS_KEY></AccessLicenseNumber>
+          <UserId><UPS_LOGIN></UserId>
+          <Password><UPS_PASSWORD></Password>
+        </AccessRequest>
+        <?xml version="1.0"?>
+        <AddressValidationRequest>
+          <Request>
+            <RequestAction>AV</RequestAction>
+          </Request>
+          <Address>
+            <PostalCode>27587</PostalCode>
+            <CountryCode>US</CountryCode>
+          </Address>
+        </AddressValidationRequest>
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '432'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: '200'
+    headers:
+      Date:
+      - Mon, 07 Oct 2019 14:07:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie, Set-Cookie2
+      Pragma:
+      - no-cache
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Apihttpstatus:
+      - '200'
+      Content-Length:
+      - '506'
+      Content-Type:
+      - application/xml
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><AddressValidationResult><Rank>1</Rank><Quality>0.9750</Quality><Address><City>WAKE
+        FOREST</City><StateProvinceCode>NC</StateProvinceCode></Address><PostalCodeLowEnd>27587</PostalCodeLowEnd><PostalCodeHighEnd>27587</PostalCodeHighEnd></AddressValidationResult></AddressValidationResponse>
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 14:07:10 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/ups/address_validation_no_candidates_response.xml
+++ b/spec/fixtures/ups/address_validation_no_candidates_response.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AddressValidationResponse>
+  <Response>
+    <TransactionReference />
+    <ResponseStatusCode>1</ResponseStatusCode>
+    <ResponseStatusDescription>Success</ResponseStatusDescription>
+  </Response>
+  <NoCandidatesIndicator />
+  <AddressClassification>
+    <Code>0</Code>
+    <Description>Unknown</Description>
+  </AddressClassification>
+</AddressValidationResponse>

--- a/spec/fixtures/ups/address_validation_response.xml
+++ b/spec/fixtures/ups/address_validation_response.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AddressValidationResponse>
+   <Response>
+      <TransactionReference />
+      <ResponseStatusCode>1</ResponseStatusCode>
+      <ResponseStatusDescription>Success</ResponseStatusDescription>
+   </Response>
+   <AddressClassification>
+      <Code>1</Code>
+      <Description>Commercial</Description>
+   </AddressClassification>
+   <AddressKeyFormat>
+      <AddressClassification>
+         <Code>1</Code>
+         <Description>Commercial</Description>
+      </AddressClassification>
+      <AddressLine>4025 ABBEY LN</AddressLine>
+      <AddressLine>STE 1</AddressLine>
+      <Region>ASTORIA OR 97103-2236</Region>
+      <PoliticalDivision2>ASTORIA</PoliticalDivision2>
+      <PoliticalDivision1>OR</PoliticalDivision1>
+      <PostcodePrimaryLow>97103</PostcodePrimaryLow>
+      <PostcodeExtendedLow>2236</PostcodeExtendedLow>
+      <CountryCode>US</CountryCode>
+   </AddressKeyFormat>
+</AddressValidationResponse>

--- a/spec/fixtures/ups/city_state_lookup_response.xml
+++ b/spec/fixtures/ups/city_state_lookup_response.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<AddressValidationResponse>
+  <Response>
+    <TransactionReference/>
+    <ResponseStatusCode>1</ResponseStatusCode>
+    <ResponseStatusDescription>Success</ResponseStatusDescription>
+  </Response>
+  <AddressValidationResult>
+    <Rank>1</Rank>
+    <Quality>1.0</Quality>
+    <Address>
+      <City>WAKE FOREST</City>
+      <StateProvinceCode>NC</StateProvinceCode>
+    </Address>
+    <PostalCodeLowEnd>27587</PostalCodeLowEnd>
+    <PostalCodeHighEnd>27587</PostalCodeHighEnd>
+  </AddressValidationResult>
+</AddressValidationResponse>

--- a/spec/friendly_shipping/address_validation_result_spec.rb
+++ b/spec/friendly_shipping/address_validation_result_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::AddressValidationResult do
+  let(:original_address) { FactoryBot.build(:physical_location) }
+  let(:suggested_address) { FactoryBot.build(:physical_location) }
+  let(:alternative_addresses) { FactoryBot.build_list(:physical_location, 3) }
+  let(:request) { double }
+  let(:response) { double }
+
+  subject do
+    described_class.new(
+      original_address: original_address,
+      suggestions: [suggested_address, alternative_addresses],
+      original_request: request,
+      original_response: response
+    )
+  end
+
+  it 'has all the right data' do
+    expect(subject.original_address).to eq(original_address)
+    expect(subject.suggestions).to eq([suggested_address, alternative_addresses])
+    expect(subject.original_request).to eq(request)
+    expect(subject.original_response).to eq(response)
+  end
+end

--- a/spec/friendly_shipping/services/ups/parse_address_validation_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_address_validation_response_spec.rb
@@ -8,20 +8,20 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseAddressValidationResponse d
   let(:response) { double(body: response_body) }
   let(:location) { double }
 
-  subject { described_class.call(_request: request, response: response, _location: location) }
+  subject { described_class.call(request: request, response: response, location: location) }
 
   context 'with a successful request' do
     it { is_expected.to be_success }
 
     it 'returns the address with address type' do
-      address = subject.value!
+      address = subject.value!.suggestions.first
       expect(address).to be_a(Physical::Location)
       expect(address.address1).to eq('4025 ABBEY LN')
       expect(address.address2).to eq('STE 1')
       expect(address.city).to eq('ASTORIA')
       expect(address.region.name).to eq('Oregon')
       expect(address.country.name).to eq('United States')
-      expect(address.zip).to eq('97103')
+      expect(address.zip).to eq('97103-2236')
       expect(address.address_type).to eq('commercial')
     end
   end

--- a/spec/friendly_shipping/services/ups/parse_address_validation_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_address_validation_response_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Ups::ParseAddressValidationResponse do
+  let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'address_validation_response.xml')).read }
+  let(:request) { double }
+  let(:response) { double(body: response_body) }
+  let(:location) { double }
+
+  subject { described_class.call(_request: request, response: response, _location: location) }
+
+  context 'with a successful request' do
+    it { is_expected.to be_success }
+
+    it 'returns the address with address type' do
+      address = subject.value!
+      expect(address).to be_a(Physical::Location)
+      expect(address.address1).to eq('4025 ABBEY LN')
+      expect(address.city).to eq('ASTORIA')
+      expect(address.region.name).to eq('Oregon')
+      expect(address.country.name).to eq('United States')
+      expect(address.zip).to eq('97103')
+      expect(address.address_type).to eq('commercial')
+    end
+  end
+
+  context 'with a no-candidates request' do
+    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'address_validation_no_candidates_response.xml')).read }
+
+    it { is_expected.to be_failure }
+
+    it 'has the correct error message' do
+      expect(subject.failure.to_s).to eq("Address is probably invalid. No similar valid addresses found.")
+    end
+  end
+end

--- a/spec/friendly_shipping/services/ups/parse_address_validation_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_address_validation_response_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseAddressValidationResponse d
       address = subject.value!
       expect(address).to be_a(Physical::Location)
       expect(address.address1).to eq('4025 ABBEY LN')
+      expect(address.address2).to eq('STE 1')
       expect(address.city).to eq('ASTORIA')
       expect(address.region.name).to eq('Oregon')
       expect(address.country.name).to eq('United States')

--- a/spec/friendly_shipping/services/ups/parse_city_state_lookup_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_city_state_lookup_response_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseCityStateLookupResponse do
   let(:response) { double(body: response_body) }
   let(:location) { Physical::Location.new(country: 'US') }
 
-  subject { described_class.call(response: response, _request: request, location: location) }
+  subject { described_class.call(response: response, request: request, location: location) }
 
   it { is_expected.to be_success }
 
   it 'has correct data' do
-    result_data = subject.value!
+    result_data = subject.value!.suggestions.first
     expect(result_data.city).to eq('WAKE FOREST')
     expect(result_data.region.code).to eq('NC')
   end

--- a/spec/friendly_shipping/services/ups/parse_city_state_lookup_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_city_state_lookup_response_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Ups::ParseCityStateLookupResponse do
+  let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'city_state_lookup_response.xml')).read }
+  let(:request) { double }
+  let(:response) { double(body: response_body) }
+  let(:location) { Physical::Location.new(country: 'US') }
+
+  subject { described_class.call(response: response, _request: request, location: location) }
+
+  it { is_expected.to be_success }
+
+  it 'has correct data' do
+    result_data = subject.value!
+    expect(result_data.city).to eq('WAKE FOREST')
+    expect(result_data.region.code).to eq('NC')
+  end
+end

--- a/spec/friendly_shipping/services/ups/serialize_address_snippet_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_address_snippet_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeAddressSnippet do
   end
 
   let(:location) do
-    FactoryBot.build(:physical_location, company_name: 'A very nice company', phone: "0998877665")
+    FactoryBot.build(:physical_location, company_name: 'A very nice company', phone: "0998877665", zip: '00001')
   end
 
   it 'adds a address to the context' do
@@ -25,7 +25,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeAddressSnippet do
     expect(subject.at_xpath('//ShipTo/Address/AddressLine1').text).to eq('11 Lovely Street')
     expect(subject.at_xpath('//ShipTo/Address/AddressLine2').text).to eq('South')
     expect(subject.at_xpath('//ShipTo/Address/City').text).to eq('Herndon')
-    expect(subject.at_xpath('//ShipTo/Address/PostalCode').text).to eq('10073')
+    expect(subject.at_xpath('//ShipTo/Address/PostalCode').text).to eq('00001')
     expect(subject.at_xpath('//ShipTo/Address/StateProvinceCode').text).to eq('IL')
     expect(subject.at_xpath('//ShipTo/Address/CountryCode').text).to eq('US')
     expect(subject.at_xpath('//ShipTo/Address/ResidentialAddressIndicator')).to be_present

--- a/spec/friendly_shipping/services/ups/serialize_address_validation_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_address_validation_request_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe FriendlyShipping::Services::Ups::SerializeAddressValidationRequest do
-  let(:location) { FactoryBot.build(:physical_location) }
+  let(:location) { FactoryBot.build(:physical_location, zip: 10123) }
 
   describe '#to_xml' do
     subject { Nokogiri::XML(described_class.call(location: location)) }
@@ -16,7 +16,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeAddressValidationReques
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/AddressLine[2]').text).to eq('South')
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PoliticalDivision1').text).to eq('IL')
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PoliticalDivision2').text).to eq('Herndon')
-      expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PostcodePrimaryLow').text).to eq('10077')
+      expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PostcodePrimaryLow').text).to eq('10123')
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/CountryCode').text).to eq('US')
     end
   end

--- a/spec/friendly_shipping/services/ups/serialize_address_validation_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_address_validation_request_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe FriendlyShipping::Services::Ups::SerializeAddressValidationRequest do
-  let(:location) { FactoryBot.build(:physical_location, zip: 10123) }
+  let(:location) { FactoryBot.build(:physical_location, zip: '10123') }
 
   describe '#to_xml' do
     subject { Nokogiri::XML(described_class.call(location: location)) }

--- a/spec/friendly_shipping/services/ups/serialize_address_validation_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_address_validation_request_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Ups::SerializeAddressValidationRequest do
+  let(:location) { FactoryBot.build(:physical_location) }
+
+  describe '#to_xml' do
+    subject { Nokogiri::XML(described_class.call(location: location)) }
+
+    it 'has the right data in the right places' do
+      expect(subject.at_xpath('//AddressValidationRequest')).to be_present
+      expect(subject.at_xpath('//AddressValidationRequest/Request/RequestAction').text).to eq('XAV')
+      expect(subject.at_xpath('//AddressValidationRequest/Request/RequestOption').text).to eq('3')
+      expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/AddressLine[1]').text).to eq('11 Lovely Street')
+      expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/AddressLine[2]').text).to eq('South')
+      expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PoliticalDivision1').text).to eq('IL')
+      expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PoliticalDivision2').text).to eq('Herndon')
+      expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PostcodePrimaryLow').text).to eq('10077')
+      expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/CountryCode').text).to eq('US')
+    end
+  end
+end

--- a/spec/friendly_shipping/services/ups/serialize_city_state_lookup_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_city_state_lookup_request_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Ups::SerializeCityStateLookupRequest do
+  let(:location) { Physical::Location.new(zip: '27587', country: 'US') }
+
+  describe '#to_xml' do
+    subject { Nokogiri::XML(described_class.call(location: location)) }
+
+    it 'has the right data in the right places' do
+      expect(subject.at_xpath('//AddressValidationRequest')).to be_present
+      expect(subject.at_xpath('//AddressValidationRequest/Request/RequestAction').text).to eq('AV')
+      expect(subject.at_xpath('//AddressValidationRequest/Address/PostalCode').text).to eq('27587')
+      expect(subject.at_xpath('//AddressValidationRequest/Address/CountryCode').text).to eq('US')
+    end
+  end
+end

--- a/spec/friendly_shipping/services/ups_spec.rb
+++ b/spec/friendly_shipping/services/ups_spec.rb
@@ -54,4 +54,66 @@ RSpec.describe FriendlyShipping::Services::Ups do
       end
     end
   end
+
+  describe 'address_validation' do
+    subject { service.address_validation(address) }
+
+    context 'with a valid address', vcr: { cassette_name: 'ups/address_validation/valid_address' } do
+      let(:address) do
+        FactoryBot.build(
+          :physical_location,
+          name: "Dag Hammerskjöld",
+          company_name: "United Nations",
+          address1: "405 East 42nd Street",
+          city: "New York",
+          region: "NY",
+          zip: "10017"
+        )
+      end
+
+      it 'returns the address, upcased, in UPS standard form' do
+        expect(subject).to be_success
+        result_address = subject.value!
+        expect(result_address.address1).to eq('405 E 42ND ST')
+      end
+    end
+
+    context 'with an entirely invalid address', vcr: { cassette_name: 'ups/address_validation/invalid_address' } do
+      let(:address) do
+        FactoryBot.build(
+          :physical_location,
+          name: "Wat Wetlands",
+          company_name: "Hogwarts School of Wizardry",
+          address1: "Platform nine and a half",
+          city: "New York",
+          region: "NY",
+          zip: "10017"
+        )
+      end
+
+      it 'returns a failure indicating the address could not be validated' do
+        expect(subject).to be_failure
+      end
+    end
+
+    context 'with a slightly invalid address', vcr: { cassette_name: 'ups/address_validation/correctable_address' } do
+      let(:address) do
+        FactoryBot.build(
+          :physical_location,
+          name: "Dag Hammerskjöld",
+          company_name: "United Nations",
+          address1: "406 East 43nd Street",
+          city: "New York",
+          region: "NY",
+          zip: "27777"
+        )
+      end
+
+      it 'returns a corrected address' do
+        is_expected.to be_success
+        corrected_address = subject.value!
+        expect(corrected_address.zip).to eq('10036')
+      end
+    end
+  end
 end

--- a/spec/friendly_shipping/services/ups_spec.rb
+++ b/spec/friendly_shipping/services/ups_spec.rb
@@ -55,6 +55,32 @@ RSpec.describe FriendlyShipping::Services::Ups do
     end
   end
 
+  describe 'city_state_lookup' do
+    subject { service.city_state_lookup(location) }
+
+    context 'with a good ZIP code', vcr: { cassette_name: 'ups/city_state_lookup/success' } do
+      let(:location) { Physical::Location.new(zip: '27587', country: 'US') }
+
+      it { is_expected.to be_success }
+
+      it 'has correct data' do
+        result_data = subject.value!
+        expect(result_data.city).to eq('WAKE FOREST')
+        expect(result_data.region.code).to eq('NC')
+      end
+    end
+
+    context 'with a bad ZIP code', vcr: { cassette_name: 'ups/city_state_lookup/failure' } do
+      let(:location) { Physical::Location.new(zip: '00000', country: 'US') }
+
+      it { is_expected.to be_failure }
+
+      it 'has a nice error message' do
+        expect(subject.failure.to_s).to eq('Failure: The field, PostalCode, contains invalid data, 00000')
+      end
+    end
+  end
+
   describe 'address_validation' do
     subject { service.address_validation(address) }
 


### PR DESCRIPTION
This adds support for UPS' address validation endpoint.

The API is still experimental. I would like to also support ambiguous addresses (where UPS returns multiple candidates), but I do not know a CA or NY address that would be ambiguous for testing. @pelargir do you have an address that we could use for that, or know how to mangle that of the UN building so it becomes ambiguous? 

In that case we should probably wrap an Array of addresses into the `Success` we return. For consistency, we should then also wrap the single address returned for unambiguous addresses into an Array. What do you think?
