### PR TITLE
Do not mark commercial addresses as residential for UPS

### DIFF
--- a/lib/friendly_shipping/services/ups/serialize_address_snippet.rb
+++ b/lib/friendly_shipping/services/ups/serialize_address_snippet.rb
@@ -40,9 +40,9 @@ module FriendlyShipping
 
               # Quote residential rates by default. If UPS doesn't know if the address is residential or
               # commercial, it will quote a residential rate by default. Even with this flag being set,
-              # if UPS knows the address is commercial it will quote a commercial rate.
+              # if UPS knows the address is commercial it will often quote a commercial rate.
               #
-              xml.ResidentialAddressIndicator
+              xml.ResidentialAddressIndicator unless location.commercial?
             end
           end
         end

--- a/spec/friendly_shipping/services/ups/serialize_address_snippet_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_address_snippet_spec.rb
@@ -62,4 +62,20 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeAddressSnippet do
       expect(subject.at_xpath('//ShipTo/CompanyName').text).to eq("Stephanie's Specialty Soaps and Mor")
     end
   end
+
+  context 'with commercial address' do
+    let(:location) { FactoryBot.build(:physical_location, address_type: 'commercial') }
+
+    it 'does not include residential address indicator' do
+      expect(subject.at_xpath('//ShipTo/Address/ResidentialAddressIndicator')).to_not be_present
+    end
+  end
+
+  context 'with unknown address' do
+    let(:location) { FactoryBot.build(:physical_location, address_type: 'unknown') }
+
+    it 'includes residential address indicator' do
+      expect(subject.at_xpath('//ShipTo/Address/ResidentialAddressIndicator')).to be_present
+    end
+  end
 end


### PR DESCRIPTION
Previously, the UPS API would return a commercial rate if the
destination address was commercial, even if the residential flag was
included in the API call. That appears to no longer be the case. Now,
UPS will sometimes return a commercial rate if it knows the address
is commercial, but other times it won't. Therefore, we need to
conditionally include the residential flag based on the address type.

Co-Authored-By: Matthew Bass <matt@candlescience.com>