### PR TITLE
Extract shipping method to separate argument in labels API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following methods are supported:
 
 - `#carriers` - List all configured carriers
 - `#rate_estimates(physical_shipment, carriers: [friendly_shipping_carrier])` - Get rate estimates for a shipment
-- `#labels(physical_shipment)` - Get labels for a shipments. Currently only supports USPS labels, other services are untested. The API of this method is still subject to change.
+- `#labels(physical_shipment, shipping_method:)` - Get labels for a shipments. Currently only supports USPS labels, other services are untested.
 - `#void(physical_label)` - Void a label and get the cost refunded
 
 #### UPS (United Parcel Service)

--- a/lib/friendly_shipping/services/ship_engine.rb
+++ b/lib/friendly_shipping/services/ship_engine.rb
@@ -65,13 +65,16 @@ module FriendlyShipping
       # @param [Physical::Shipment] shipment The shipment object we're trying to get labels for
       #   Note: Some ShipEngine carriers, notably USPS, only support one package per shipment, and that's
       #   all that the integration supports at this point.
+      # @param [FriendlyShipping::ShippingMethod] shipping_method The shipping method we want to use.
+      #   Specifically, the "#service_code" will be serialized. If a carrier is set, it's `#id` will
+      #   also be sent to ShipEngine.
       #
       # @return [Result<ApiResult<Array<FriendlyShipping::Label>>>] The label returned.
       #
-      def labels(shipment)
+      def labels(shipment, shipping_method:)
         request = FriendlyShipping::Request.new(
           url: API_BASE + API_PATHS[:labels],
-          body: SerializeLabelShipment.new(shipment: shipment).call.merge(test_label: test).to_json,
+          body: SerializeLabelShipment.new(shipment: shipment, shipping_method: shipping_method, test: test).to_json,
           headers: request_headers
         )
         client.post(request).fmap do |response|

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
   let(:item) { FactoryBot.build(:physical_item, weight: Measured::Weight(1, :ounce)) }
   let(:package) { FactoryBot.build(:physical_package, items: [item], void_fill_density: Measured::Density(0, :g_ml), container: container) }
   let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package], options: shipment_options) }
+  let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: 'usps_priority_mail') }
   let(:shipment_options) { { label_format: 'zpl' } }
-  subject { described_class.new(shipment: shipment).call }
+  subject { described_class.new(shipment: shipment, shipping_method: shipping_method, test: true).call }
 
   it do
     is_expected.to match(
@@ -147,7 +148,13 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
   end
 
   context 'if passing a carrier id' do
-    let(:shipment_options) { { carrier_id: 'se-12345' } }
+    let(:carrier) { FriendlyShipping::Carrier.new(id: 'se-12345') }
+    let(:shipping_method) do
+      FriendlyShipping::ShippingMethod.new(
+        service_code: 'usps_priority_mail',
+        carrier: carrier
+      )
+    end
 
     it 'includes the carrier ID' do
       is_expected.to match(

--- a/spec/friendly_shipping/services/ship_engine_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine_spec.rb
@@ -59,9 +59,10 @@ RSpec.describe FriendlyShipping::Services::ShipEngine do
 
   describe 'labels' do
     let(:package) { FactoryBot.build(:physical_package) }
-    let(:shipment) { FactoryBot.build(:physical_shipment, service_code: "usps_priority_mail", packages: [package]) }
+    let(:shipment) { FactoryBot.build(:physical_shipment, packages: [package]) }
+    let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: "usps_priority_mail") }
 
-    subject(:labels) { service.labels(shipment) }
+    subject(:labels) { service.labels(shipment, shipping_method: shipping_method) }
 
     context 'with a successful request', vcr: { cassette_name: 'shipengine/labels/success' } do
       it { is_expected.to be_a Dry::Monads::Success }
@@ -90,7 +91,6 @@ RSpec.describe FriendlyShipping::Services::ShipEngine do
       let(:shipment) do
         FactoryBot.build(
           :physical_shipment,
-          service_code: "usps_priority_mail",
           packages: [package],
           options: { label_download_type: "inline", label_format: "zpl" }
         )
@@ -152,7 +152,6 @@ RSpec.describe FriendlyShipping::Services::ShipEngine do
       let(:shipment) do
         FactoryBot.build(
           :physical_shipment,
-          service_code: "usps_priority_mail",
           packages: [package],
           options: { label_download_type: "inline", label_format: "zpl" }
         )


### PR DESCRIPTION
When generating a label, at the time we generate it the shipping method
service code is not a property of the shipment (yet). I believe this is
a clearer API that reads better: Having a shipment, and then specifying
explicitly which shipping method to use. Bonus: That shipping method has
a `carrier` property which we can use rather than adding yet another
optional string.