### PR TITLE
Add Ups#address_classification API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The following methods are supported:
 
 - `#carriers` - List all configured carriers (always returns UPS)
 - `#rate_estimates(physical_shipment)` - Get rate estimates for a shipment
+- `#address_classification(physical_location)` - Determine whether an address is commercial or residential.
 - `#address_validation(physical_location)` - Perform a detailed address validation and determine whether an address is commercial or residential.
 - `#city_state_lookup(physical_location)` - Lookup City and State for a given ZIP code.
 

--- a/lib/friendly_shipping/services/ups.rb
+++ b/lib/friendly_shipping/services/ups.rb
@@ -6,6 +6,7 @@ require 'friendly_shipping/services/ups/serialize_access_request'
 require 'friendly_shipping/services/ups/serialize_city_state_lookup_request'
 require 'friendly_shipping/services/ups/serialize_address_validation_request'
 require 'friendly_shipping/services/ups/serialize_rating_service_selection_request'
+require 'friendly_shipping/services/ups/parse_address_classification_response'
 require 'friendly_shipping/services/ups/parse_address_validation_response'
 require 'friendly_shipping/services/ups/parse_city_state_lookup_response'
 require 'friendly_shipping/services/ups/parse_rate_response'
@@ -81,6 +82,23 @@ module FriendlyShipping
 
         client.post(request).bind do |response|
           ParseAddressValidationResponse.call(response: response, request: request)
+        end
+      end
+
+      # Classify an address.
+      # @param [Physical::Location] location The address we want to classify
+      # @return [Result<ApiResult<String>>] Either `"commercial"`, `"residential"`, or `"unknown"`
+      def address_classification(location, debug: false)
+        address_validation_request_xml = SerializeAddressValidationRequest.call(location: location)
+        url = base_url + RESOURCES[:address_validation]
+        request = FriendlyShipping::Request.new(
+          url: url,
+          body: access_request_xml + address_validation_request_xml,
+          debug: debug
+        )
+
+        client.post(request).bind do |response|
+          ParseAddressClassificationResponse.call(response: response, request: request)
         end
       end
 

--- a/lib/friendly_shipping/services/ups/parse_address_classification_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_address_classification_response.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Ups
+      class ParseAddressClassificationResponse
+        extend Dry::Monads::Result::Mixin
+
+        def self.call(request:, response:)
+          parsing_result = ParseXMLResponse.call(response.body, 'AddressValidationResponse')
+
+          parsing_result.bind do |xml|
+            address_type = xml.at('AddressClassification/Description')&.text&.downcase
+            Success(
+              FriendlyShipping::ApiResult.new(
+                address_type,
+                original_request: request,
+                original_response: response
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/ups/address_validation_ambiguous_address_response.xml
+++ b/spec/fixtures/ups/address_validation_ambiguous_address_response.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AddressValidationResponse>
+  <Response>
+    <TransactionReference/>
+    <ResponseStatusCode>1</ResponseStatusCode>
+    <ResponseStatusDescription>Success</ResponseStatusDescription>
+  </Response>
+  <AmbiguousAddressIndicator/>
+  <AddressClassification>
+    <Code>1</Code>
+    <Description>Commercial</Description>
+  </AddressClassification>
+  <AddressKeyFormat>
+    <AddressClassification>
+      <Code>0</Code>
+      <Description>Unknown</Description>
+    </AddressClassification>
+    <AddressLine>2000 COASTAL GRAND CIR</AddressLine>
+    <AddressLine>STE 105-115</AddressLine>
+    <Region>MYRTLE BEACH SC 29577-9600</Region>
+    <PoliticalDivision2>MYRTLE BEACH</PoliticalDivision2>
+    <PoliticalDivision1>SC</PoliticalDivision1>
+    <PostcodePrimaryLow>29577</PostcodePrimaryLow>
+    <PostcodeExtendedLow>9600</PostcodeExtendedLow>
+    <CountryCode>US</CountryCode>
+  </AddressKeyFormat>
+</AddressValidationResponse>

--- a/spec/friendly_shipping/services/ups/parse_address_classification_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_address_classification_response_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Ups::ParseAddressClassificationResponse do
+  let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'address_validation_response.xml')).read }
+  let(:request) { double(debug: false) }
+  let(:response) { double(body: response_body) }
+
+  subject { described_class.call(request: request, response: response) }
+
+  context 'with a successful request' do
+    it { is_expected.to be_success }
+
+    it 'returns the address type' do
+      address_type = subject.value!.data
+      expect(address_type).to eq('commercial')
+    end
+  end
+
+  context 'with a no-candidates request' do
+    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'address_validation_no_candidates_response.xml')).read }
+
+    it { is_expected.to be_success }
+
+    it 'returns unknown address type' do
+      address_type = subject.value!.data
+      expect(address_type).to eq('unknown')
+    end
+  end
+
+  context 'with an ambiguous address request' do
+    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'address_validation_ambiguous_address_response.xml')).read }
+
+    it { is_expected.to be_success }
+
+    it 'returns the address type' do
+      address_type = subject.value!.data
+      expect(address_type).to eq('commercial')
+    end
+  end
+end


### PR DESCRIPTION
This new endpoint returns just the address classification from the XAV endpoint. No validation information is returned. This is necessary because the address validation endpoint returns a failure when no address candidates are found (or when an ambiguous address is used), but the UPS API will often return an address classification even when there are no candidates (or an ambiguous address). We need the ability to retrieve and use the address classification in these situations.