### PR TITLE
Add consignee to address classification request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /_yardoc/
 /coverage/
 /doc/
+/.idea/
 /pkg/
 /spec/reports/
 /tmp/

--- a/lib/friendly_shipping/services/ups/serialize_address_validation_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_address_validation_request.rb
@@ -22,6 +22,7 @@ module FriendlyShipping
               end
 
               xml.AddressKeyFormat do
+                xml.ConsigneeName(location.company_name.presence || location.name)
                 xml.AddressLine location.address1
                 xml.AddressLine location.address2
                 xml.PoliticalDivision2 location.city

--- a/spec/cassettes/ups/address_validation/correctable_address.yml
+++ b/spec/cassettes/ups/address_validation/correctable_address.yml
@@ -19,6 +19,7 @@ http_interactions:
             <RequestOption>3</RequestOption>
           </Request>
           <AddressKeyFormat>
+            <ConsigneeName>United Nations</ConsigneeName>
             <AddressLine>406 East 43nd Street</AddressLine>
             <AddressLine>South</AddressLine>
             <PoliticalDivision2>New York</PoliticalDivision2>
@@ -31,9 +32,9 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      - rest-client/2.1.0 (darwin18.7.0 x86_64) ruby/2.6.5p114
       Content-Length:
-      - '695'
+      - '726'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -44,7 +45,7 @@ http_interactions:
       message: '200'
     headers:
       Date:
-      - Mon, 07 Oct 2019 08:19:48 GMT
+      - Fri, 25 Oct 2019 17:45:21 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -71,6 +72,6 @@ http_interactions:
       string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><ValidAddressIndicator/><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>406
         W 43RD ST</AddressLine><Region>NEW YORK NY 10036-6322</Region><PoliticalDivision2>NEW
         YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10036</PostcodePrimaryLow><PostcodeExtendedLow>6322</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
-    http_version:
-  recorded_at: Mon, 07 Oct 2019 08:19:48 GMT
+    http_version: 
+  recorded_at: Fri, 25 Oct 2019 17:45:23 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/ups/address_validation/incomplete_address.yml
+++ b/spec/cassettes/ups/address_validation/incomplete_address.yml
@@ -19,6 +19,7 @@ http_interactions:
             <RequestOption>3</RequestOption>
           </Request>
           <AddressKeyFormat>
+            <ConsigneeName>United Nations</ConsigneeName>
             <AddressLine>East 43nd Street</AddressLine>
             <AddressLine>South</AddressLine>
             <PoliticalDivision2>New York</PoliticalDivision2>
@@ -31,9 +32,9 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      - rest-client/2.1.0 (darwin18.7.0 x86_64) ruby/2.6.5p114
       Content-Length:
-      - '691'
+      - '722'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -44,7 +45,7 @@ http_interactions:
       message: '200'
     headers:
       Date:
-      - Tue, 08 Oct 2019 09:21:17 GMT
+      - Fri, 25 Oct 2019 17:45:23 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -63,12 +64,14 @@ http_interactions:
       Apihttpstatus:
       - '200'
       Content-Length:
-      - '7019'
+      - '6984'
       Content-Type:
       - application/xml
     body:
       encoding: UTF-8
-      string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><AmbiguousAddressIndicator/><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>11-19
+      string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><AmbiguousAddressIndicator/><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>2-22
+        E 43RD ST</AddressLine><Region>NEW YORK NY 10017-4607</Region><PoliticalDivision2>NEW
+        YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4607</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>11-19
         E 43RD ST</AddressLine><Region>NEW YORK NY 10017-4601</Region><PoliticalDivision2>NEW
         YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4601</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>33-99
         E 43RD ST</AddressLine><Region>NEW YORK NY 10017-3812</Region><PoliticalDivision2>NEW
@@ -96,9 +99,7 @@ http_interactions:
         E 43RD ST</AddressLine><AddressLine>APT 5A-5B</AddressLine><Region>NEW YORK
         NY 10017-4017</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4017</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>151
         E 43RD ST</AddressLine><AddressLine>FRNT A-B</AddressLine><Region>NEW YORK
-        NY 10017-4017</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4017</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>153
-        E 43RD ST</AddressLine><AddressLine>APT 2A-2D</AddressLine><Region>NEW YORK
-        NY 10017-4015</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4015</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
+        NY 10017-4017</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>4017</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
     http_version: 
-  recorded_at: Tue, 08 Oct 2019 09:21:18 GMT
+  recorded_at: Fri, 25 Oct 2019 17:45:25 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/ups/address_validation/invalid_address.yml
+++ b/spec/cassettes/ups/address_validation/invalid_address.yml
@@ -19,6 +19,7 @@ http_interactions:
             <RequestOption>3</RequestOption>
           </Request>
           <AddressKeyFormat>
+            <ConsigneeName>Hogwarts School of Wizardry</ConsigneeName>
             <AddressLine>Platform nine and a half</AddressLine>
             <AddressLine>South</AddressLine>
             <PoliticalDivision2>New York</PoliticalDivision2>
@@ -31,9 +32,9 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      - rest-client/2.1.0 (darwin18.7.0 x86_64) ruby/2.6.5p114
       Content-Length:
-      - '699'
+      - '743'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -44,7 +45,7 @@ http_interactions:
       message: '200'
     headers:
       Date:
-      - Mon, 07 Oct 2019 08:18:48 GMT
+      - Fri, 25 Oct 2019 17:45:21 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -69,6 +70,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><NoCandidatesIndicator/><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification></AddressValidationResponse>
-    http_version:
-  recorded_at: Mon, 07 Oct 2019 08:18:48 GMT
+    http_version: 
+  recorded_at: Fri, 25 Oct 2019 17:45:21 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/ups/address_validation/valid_address.yml
+++ b/spec/cassettes/ups/address_validation/valid_address.yml
@@ -19,6 +19,7 @@ http_interactions:
             <RequestOption>3</RequestOption>
           </Request>
           <AddressKeyFormat>
+            <ConsigneeName>United Nations</ConsigneeName>
             <AddressLine>405 East 42nd Street</AddressLine>
             <AddressLine>South</AddressLine>
             <PoliticalDivision2>New York</PoliticalDivision2>
@@ -31,9 +32,9 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      - rest-client/2.1.0 (darwin18.7.0 x86_64) ruby/2.6.5p114
       Content-Length:
-      - '695'
+      - '726'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -44,7 +45,7 @@ http_interactions:
       message: '200'
     headers:
       Date:
-      - Mon, 07 Oct 2019 08:18:47 GMT
+      - Fri, 25 Oct 2019 17:45:20 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -71,6 +72,6 @@ http_interactions:
       string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><ValidAddressIndicator/><AddressClassification><Code>1</Code><Description>Commercial</Description></AddressClassification><AddressKeyFormat><AddressClassification><Code>1</Code><Description>Commercial</Description></AddressClassification><AddressLine>405
         E 42ND ST</AddressLine><Region>NEW YORK NY 10017-3507</Region><PoliticalDivision2>NEW
         YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10017</PostcodePrimaryLow><PostcodeExtendedLow>3507</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
-    http_version:
-  recorded_at: Mon, 07 Oct 2019 08:18:48 GMT
+    http_version: 
+  recorded_at: Fri, 25 Oct 2019 17:45:20 GMT
 recorded_with: VCR 5.0.0

--- a/spec/friendly_shipping/services/ups/serialize_address_validation_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_address_validation_request_spec.rb
@@ -12,12 +12,21 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeAddressValidationReques
       expect(subject.at_xpath('//AddressValidationRequest')).to be_present
       expect(subject.at_xpath('//AddressValidationRequest/Request/RequestAction').text).to eq('XAV')
       expect(subject.at_xpath('//AddressValidationRequest/Request/RequestOption').text).to eq('3')
+      expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/ConsigneeName').text).to eq('Company')
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/AddressLine[1]').text).to eq('11 Lovely Street')
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/AddressLine[2]').text).to eq('South')
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PoliticalDivision1').text).to eq('IL')
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PoliticalDivision2').text).to eq('Herndon')
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/PostcodePrimaryLow').text).to eq('10123')
       expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/CountryCode').text).to eq('US')
+    end
+
+    context 'with location that has no company name' do
+      let(:location) { FactoryBot.build(:physical_location, company_name: nil) }
+
+      it 'uses name as consignee fallback' do
+        expect(subject.at_xpath('//AddressValidationRequest/AddressKeyFormat/ConsigneeName').text).to eq('Jane Doe')
+      end
     end
   end
 end

--- a/spec/friendly_shipping/services/ups_spec.rb
+++ b/spec/friendly_shipping/services/ups_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe FriendlyShipping::Services::Ups do
         # All returned addresses need to have a first address line
         expect(suggested_addresses.map(&:address1).compact.length).to eq(15)
         # In this particular request, the last suggested address has a second address line.
-        expect(suggested_addresses.last.address2).to eq("APT 2A-2D")
+        expect(suggested_addresses.last.address2).to eq("FRNT A-B")
       end
     end
   end


### PR DESCRIPTION
This adds the `<ConsigneeName />` element to the UPS address validation request serializer. The consignee name is critical to include to get accurate address classifications.