### PR TITLE
Remove original request/response from rates and labels

### DIFF
--- a/lib/friendly_shipping/label.rb
+++ b/lib/friendly_shipping/label.rb
@@ -10,9 +10,7 @@ module FriendlyShipping
                 :data,
                 :label_format,
                 :shipment_cost,
-                :label_data,
-                :original_request,
-                :original_response
+                :label_data
 
     # @param [Integer] id The label's ID
     # @param [Integer] shipment_id The label's shipment ID
@@ -23,8 +21,6 @@ module FriendlyShipping
     # @param [String] label_data The raw label data
     # @param [Float] shipment_cost The cost of the shipment
     # @param [Hash] data Additional data related to the label
-    # @param [FriendlyShipping::Request] original_request The HTTP request used to obtain the label
-    # @param [FriendlyShipping::Response] original_response The HTTP response for the label
     def initialize(
       id: nil,
       shipment_id: nil,
@@ -34,9 +30,7 @@ module FriendlyShipping
       label_format: nil,
       label_data: nil,
       shipment_cost: nil,
-      data: {},
-      original_request: nil,
-      original_response: nil
+      data: {}
     )
       @id = id
       @shipment_id = shipment_id
@@ -47,8 +41,6 @@ module FriendlyShipping
       @shipment_cost = shipment_cost
       @label_data = label_data
       @data = data
-      @original_request = original_request
-      @original_response = original_response
     end
   end
 end

--- a/lib/friendly_shipping/rate.rb
+++ b/lib/friendly_shipping/rate.rb
@@ -9,9 +9,7 @@ module FriendlyShipping
                 :delivery_date,
                 :warnings,
                 :errors,
-                :data,
-                :original_request,
-                :original_response
+                :data
 
     # @param [FriendlyShipping::ShippingMethod] shipping_method The rate's shipping method
     # @param [Hash] amounts The amounts (as Money objects) that make up the rate
@@ -20,8 +18,6 @@ module FriendlyShipping
     # @param [Array] warnings Any warnings that were generated
     # @param [Array] errors Any errors that were generated
     # @param [Hash] data Additional data related to the rate
-    # @param [FriendlyShipping::Request] original_request The HTTP request used to obtain the rate
-    # @param [FriendlyShipping::Response] original_response The HTTP response for the rate
     def initialize(
       shipping_method:,
       amounts:,
@@ -29,9 +25,7 @@ module FriendlyShipping
       delivery_date: nil,
       warnings: [],
       errors: [],
-      data: {},
-      original_request: nil,
-      original_response: nil
+      data: {}
     )
       @remote_service_id = remote_service_id
       @shipping_method = shipping_method
@@ -40,8 +34,6 @@ module FriendlyShipping
       @warnings = warnings
       @errors = errors
       @data = data
-      @original_request = original_request
-      @original_response = original_response
     end
 
     def total_amount

--- a/lib/friendly_shipping/services/ship_engine/parse_rate_estimate_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_rate_estimate_response.rb
@@ -28,9 +28,7 @@ module FriendlyShipping
                 remote_service_id: rate['rate_id'],
                 delivery_date: Time.parse(rate['estimated_delivery_date']),
                 warnings: rate['warning_messages'],
-                errors: rate['error_messages'],
-                original_request: request,
-                original_response: response
+                errors: rate['error_messages']
               )
             end.compact
 

--- a/spec/friendly_shipping/label_spec.rb
+++ b/spec/friendly_shipping/label_spec.rb
@@ -12,6 +12,4 @@ RSpec.describe FriendlyShipping::Label do
   it { is_expected.to respond_to(:label_format) }
   it { is_expected.to respond_to(:shipment_cost) }
   it { is_expected.to respond_to(:label_data) }
-  it { is_expected.to respond_to(:original_request) }
-  it { is_expected.to respond_to(:original_response) }
 end

--- a/spec/friendly_shipping/rate_spec.rb
+++ b/spec/friendly_shipping/rate_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe FriendlyShipping::Rate do
   it { is_expected.to respond_to(:warnings) }
   it { is_expected.to respond_to(:errors) }
   it { is_expected.to respond_to(:data) }
-  it { is_expected.to respond_to(:original_request) }
-  it { is_expected.to respond_to(:original_response) }
 
   describe '#total_amount' do
     subject do

--- a/spec/friendly_shipping/services/ship_engine/parse_rate_estimate_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_rate_estimate_response_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::ParseRateEstimateResponse do
   let(:carrier_json) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'carriers.json')).read }
-  let(:request) { double(debug: false) }
+  let(:request) { double(debug: true) }
   let(:response) { double(body: response_body) }
   let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'rate_estimates_success.json')).read }
   let(:carriers) { FriendlyShipping::Services::ShipEngine::ParseCarrierResponse.call(request: request, response: double(body: carrier_json)).data }
@@ -29,7 +29,7 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::ParseRateEstimateResponse
     expect(rate.warnings).to eq([])
     expect(rate.errors).to eq([])
     expect(rate.data).to eq({})
-    expect(rate.original_request).to eq(request)
-    expect(rate.original_response).to eq(response)
+    expect(subject.value!.original_request).to eq(request)
+    expect(subject.value!.original_response).to eq(response)
   end
 end


### PR DESCRIPTION
We now have the ApiResult/ApiFailure classes for this data.