### PR TITLE
Add simplecov for code coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 # Gemfile.lock
 Gemfile.lock
 .env
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,6 @@ gem 'factory_bot'
 gem 'pry'
 gem 'rspec_junit_formatter'
 gem 'rubocop'
+gem 'simplecov', require: false
 gem 'vcr'
 gem 'webmock'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.start
+
 require "bundler/setup"
 require "friendly_shipping"
 require "vcr"


### PR DESCRIPTION
Run the specs and open coverage/index.html to see the report. This will help us identify untested areas of the gem.