### PR TITLE
Enable strict XML parsing

### DIFF
--- a/lib/friendly_shipping/services/ups/parse_xml_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_xml_response.rb
@@ -9,7 +9,8 @@ module FriendlyShipping
 
         class << self
           def call(response_body, expected_root_tag)
-            xml = Nokogiri.XML(response_body)
+            xml = Nokogiri.XML(response_body, &:strict)
+
             if xml.root.nil? || xml.root.name != expected_root_tag
               Failure('Invalid document')
             end

--- a/lib/friendly_shipping/services/usps/parse_xml_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_xml_response.rb
@@ -9,7 +9,7 @@ module FriendlyShipping
 
         class << self
           def call(response_body, expected_root_tag)
-            xml = Nokogiri.XML(response_body)
+            xml = Nokogiri.XML(response_body, &:strict)
 
             if xml.root.nil? || ![expected_root_tag, 'Error'].include?(xml.root.name)
               Failure('Invalid document')

--- a/spec/friendly_shipping/services/ups/parse_xml_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_xml_response_spec.rb
@@ -26,4 +26,15 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseXMLResponse do
   it 'has the correct error message' do
     expect(subject.failure.to_s).to eq('Failure: Something went wrong')
   end
+
+  context 'with invalid XML in response body' do
+    let(:response) { 'invalid XML' }
+
+    it { is_expected.to be_failure }
+
+    it 'has the correct error' do
+      expect(subject.failure).to be_a(Nokogiri::XML::SyntaxError)
+      expect(subject.failure.message).to match(/Start tag expected/)
+    end
+  end
 end

--- a/spec/friendly_shipping/services/usps/parse_xml_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_xml_response_spec.rb
@@ -37,4 +37,15 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseXMLResponse do
       it { is_expected.to be_failure }
     end
   end
+
+  context 'with invalid XML in response body' do
+    let(:response) { 'invalid XML' }
+
+    it { is_expected.to be_failure }
+
+    it 'has the correct error' do
+      expect(subject.failure).to be_a(Nokogiri::XML::SyntaxError)
+      expect(subject.failure.message).to match(/Start tag expected/)
+    end
+  end
 end


### PR DESCRIPTION
Previously, invalid XML would still result in a valid Nokogiri document, but the root would be nil and no elements could be traversed. Instead, let's be noisy and raise an exception if the XML is invalid.