### PR TITLE
Add UPS Freight Pickup Date Element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2019-11-27
+
+### Changed
+- UPS Freight: Allow passing PickupRequest element with Pickup date
+
 ## [0.4.2] - 2019-11-19
 
 ### Changed

--- a/lib/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash.rb
+++ b/lib/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash.rb
@@ -19,12 +19,22 @@ module FriendlyShipping
                   Code: options.shipping_method.service_code
                 },
                 Commodity: options.commodity_information_generator.call(shipment: shipment, options: options),
-                TimeInTransitIndicator: 'true'
+                TimeInTransitIndicator: 'true',
+                PickupRequest: pickup_request(options)
               }.compact.merge(handling_units(shipment, options).reduce(&:merge).to_h)
             }
           end
 
           private
+
+          def pickup_request(options)
+            return unless options.pickup_date
+
+            {
+              PickupDate: options.pickup_date.strftime('%Y%m%d'),
+              AdditionalComments: options.pickup_comments
+            }
+          end
 
           def handling_units(shipment, options)
             all_package_options = shipment.packages.map { |package| options.options_for_package(package) }

--- a/lib/friendly_shipping/services/ups_freight/rates_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_options.rb
@@ -16,6 +16,8 @@ module FriendlyShipping
       #     and an options object to create an Array of commodity fields as per the UPS docs.
       # @attribute [Symbol] billing One of the keys in the `BILLING_CODES` constant. How the shipment
       #     would be billed.
+      # @attribute [Date] pickup_date Date of the Pickup
+      # @attribute [String] pickup_comments Additional pickup instructions
       # @attribute [RatesPackageOptions] package_options Options for each of the packages/pallets in this shipment
       class RatesOptions < FriendlyShipping::ShipmentOptions
         BILLING_CODES = {
@@ -29,6 +31,8 @@ module FriendlyShipping
                     :billing_code,
                     :customer_context,
                     :shipping_method,
+                    :pickup_date,
+                    :pickup_comments,
                     :commodity_information_generator
 
         def initialize(
@@ -37,6 +41,8 @@ module FriendlyShipping
           shipping_method:,
           billing: :prepaid,
           customer_context: nil,
+          pickup_date: nil,
+          pickup_comments: nil,
           commodity_information_generator: GenerateCommodityInformation,
           **kwargs
         )
@@ -45,6 +51,8 @@ module FriendlyShipping
           @shipping_method = shipping_method
           @billing_code = BILLING_CODES.fetch(billing)
           @customer_context = customer_context
+          @pickup_date = pickup_date
+          @pickup_comments = pickup_comments
           @commodity_information_generator = commodity_information_generator
           super kwargs.merge(package_options_class: RatesPackageOptions)
         end

--- a/lib/friendly_shipping/version.rb
+++ b/lib/friendly_shipping/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end

--- a/spec/cassettes/ups_freight/rates/success.yml
+++ b/spec/cassettes/ups_freight/rates/success.yml
@@ -9,14 +9,15 @@ http_interactions:
         Test 1","Address":{"AddressLine":"01 Developer Way","City":"Richmond","StateProvinceCode":"VA","PostalCode":"23224","CountryCode":"US"},"AttentionName":null},"ShipTo":{"Name":"Consignee
         Test 1","Address":{"AddressLine":"000 Consignee Street","City":"Allanton","StateProvinceCode":"MO","PostalCode":"63025","CountryCode":"US"},"AttentionName":null},"PaymentInformation":{"Payer":{"Name":"Acme
         Co.","Address":{"AddressLine":"Far away on the outer rim","City":"Durham","StateProvinceCode":"NC","PostalCode":"27703","CountryCode":"US"},"AttentionName":"Test
-        Testman","ShipperNumber":"%UPS_SHIPPER_NUMBER%"},"ShipmentBillingOption":{"Code":"10"}},"Service":{"Code":"308"},"Commodity":[{"Description":"Commodities","Weight":{"UnitOfMeasurement":{"Code":"LBS"},"Value":"500.0"},"NumberOfPieces":"1","PackagingType":{"Code":"CTN"},"FreightClass":"92.5"},{"Description":"Commodities","Weight":{"UnitOfMeasurement":{"Code":"LBS"},"Value":"500.0"},"NumberOfPieces":"1","PackagingType":{"Code":"PLT"},"FreightClass":"92.5"}],"TimeInTransitIndicator":"true","HandlingUnitOne":{"Quantity":"2","Type":{"Code":"PLT","Description":"Pallet"}}}}'
+        Testman","ShipperNumber":"%UPS_SHIPPER_NUMBER%"},"ShipmentBillingOption":{"Code":"10"}},"Service":{"Code":"308"},"Commodity":[{"Description":"Commodities","Weight":{"UnitOfMeasurement":{"Code":"LBS"},"Value":"500.0"},"NumberOfPieces":"1","PackagingType":{"Code":"CTN"},"FreightClass":"92.5"},{"Description":"Commodities","Weight":{"UnitOfMeasurement":{"Code":"LBS"},"Value":"500.0"},"NumberOfPieces":"1","PackagingType":{"Code":"PLT"},"FreightClass":"92.5"}],"TimeInTransitIndicator":"true","PickupRequest":{"PickupDate":"20191224","AdditionalComments":"Fork
+        lift needed"},"HandlingUnitOne":{"Quantity":"2","Type":{"Code":"PLT","Description":"Pallet"}}}}'
     headers:
       Accept:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
       Content-Length:
-      - '1422'
+      - '1504'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -27,7 +28,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Nov 2019 15:25:11 GMT
+      - Wed, 27 Nov 2019 11:42:25 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -37,14 +38,14 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Cache-Control:
-      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie, Set-Cookie2
+      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie
       Pragma:
       - no-cache
       - no-cache
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Oracle-Dms-Ecid:
-      - 46af41a1-279b-419f-b19b-a02c802dc1fb-000254b8
+      - a93312db-c8dc-4042-a390-acba807d7267-0000a610
       X-Oracle-Dms-Rid:
       - '0'
       Apihttpstatus:
@@ -73,5 +74,5 @@ http_interactions:
         "Service":{"Code":"308"}, "GuaranteedIndicator":"", "RatingSchedule":{"Code":"02",
         "Description":"Published Rates"}, "TimeInTransit":{"DaysInTransit":"2"}}}'
     http_version: 
-  recorded_at: Tue, 19 Nov 2019 15:25:11 GMT
+  recorded_at: Wed, 27 Nov 2019 11:42:26 GMT
 recorded_with: VCR 5.0.0

--- a/spec/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash_spec.rb
@@ -389,4 +389,29 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateFreightRateReques
       end
     end
   end
+
+  context 'with a Pickup Date given' do
+    let(:options) do
+      FriendlyShipping::Services::UpsFreight::RatesOptions.new(
+        shipping_method: FriendlyShipping::ShippingMethod.new(service_code: '308'),
+        shipper_number: 'xxx1234',
+        billing_address: billing_location,
+        customer_context: customer_context,
+        package_options: package_options,
+        pickup_date: Date.new(2019, 11, 10),
+        pickup_comments: 'Bring pitch forks, there will be hay'
+      )
+    end
+
+    it do
+      is_expected.to include(
+        'FreightRateRequest' => hash_including(
+          'PickupRequest' => {
+            'PickupDate' => '20191110',
+            'AdditionalComments' => 'Bring pitch forks, there will be hay'
+          }
+        )
+      )
+    end
+  end
 end

--- a/spec/friendly_shipping/services/ups_freight/rates_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/rates_options_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::RatesOptions do
     :billing_address,
     :billing_code,
     :customer_context,
+    :pickup_date,
+    :pickup_comments,
     :shipping_method
   ].each do |option|
     it { is_expected.to respond_to(option) }

--- a/spec/friendly_shipping/services/ups_freight_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight_spec.rb
@@ -84,7 +84,9 @@ RSpec.describe FriendlyShipping::Services::UpsFreight do
         shipper_number: ENV['UPS_SHIPPER_NUMBER'],
         billing_address: billing_location,
         customer_context: customer_context,
-        package_options: package_options
+        package_options: package_options,
+        pickup_date: Time.new(2019, 12, 24),
+        pickup_comments: 'Fork lift needed'
       )
     end
 


### PR DESCRIPTION
This adds the UPS Freight PickupDate element to the rates API call. It doesn't seem to do much to the response, I've even tried with pickup on Christmas eve; nothing in the response seems to make a difference. But: we can now pass the element and see what it does.