### PR TITLE
Make ShipperReleaseIndicator accessible

### DIFF
--- a/lib/friendly_shipping/services/ups/label_package_options.rb
+++ b/lib/friendly_shipping/services/ups/label_package_options.rb
@@ -11,6 +11,8 @@ module FriendlyShipping
       #   values are _reference number values_. Example: `{ reference_numbers: { xn: 'my_reference_1 }`
       # @option delivery_confirmation [Symbol] Can be set to any key from PACKAGE_DELIVERY_CONFIRMATION_CODES.
       #   Only possible for domestic shipments or shipments between the US and Puerto Rico.
+      # @option shipper_release [Boolean] Indicates that the package may be released by driver without a signature from the
+      #   consignee. Default: false
       class LabelPackageOptions < FriendlyShipping::PackageOptions
         PACKAGE_DELIVERY_CONFIRMATION_CODES = {
           delivery_confirmation: 1,
@@ -18,15 +20,17 @@ module FriendlyShipping
           delivery_confirmation_adult_signature_required: 3
         }.freeze
 
-        attr_reader :reference_numbers
+        attr_reader :reference_numbers, :shipper_release
 
         def initialize(
           reference_numbers: {},
           delivery_confirmation: nil,
+          shipper_release: false,
           **kwargs
         )
           @reference_numbers = reference_numbers
           @delivery_confirmation = delivery_confirmation
+          @shipper_release = shipper_release
           super kwargs.merge(item_options_class: LabelItemOptions)
         end
 

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -158,7 +158,8 @@ module FriendlyShipping
                       xml: xml,
                       package: package,
                       reference_numbers: reference_numbers,
-                      delivery_confirmation_code: delivery_confirmation_code
+                      delivery_confirmation_code: delivery_confirmation_code,
+                      shipper_release: package_options.shipper_release
                     )
                   end
                 end

--- a/spec/friendly_shipping/services/ups/label_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_package_options_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe FriendlyShipping::Services::Ups::LabelPackageOptions do
 
   [
     :delivery_confirmation_code,
-    :reference_numbers
+    :reference_numbers,
+    :shipper_release
   ].each do |message|
     it { is_expected.to respond_to(message) }
   end

--- a/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
 
   let(:package) do
     Physical::Package.new(
+      id: 'package_1',
       items: [
         Physical::Item.new(
           weight: Measured::Weight.new(5, :pounds)
@@ -182,6 +183,27 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
       expect(subject.at('BillThirdPartyShipper/AccountNumber').text).to eq('12345')
       expect(subject.at('BillThirdPartyShipper/ThirdParty/Address/PostalCode').text).to eq('22222')
       expect(subject.at('BillThirdPartyShipper/ThirdParty/Address/CountryCode').text).to eq('US')
+    end
+  end
+
+  context 'with a package that has shipper release set' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::LabelOptions.new(
+        shipping_method: shipping_method,
+        shipper_number: '12345',
+        package_options: [package_options]
+      )
+    end
+
+    let(:package_options) do
+      FriendlyShipping::Services::Ups::LabelPackageOptions.new(
+        package_id: 'package_1',
+        shipper_release: true
+      )
+    end
+
+    it 'contains the relevant XML element' do
+      expect(subject.at('//ShipmentConfirmRequest/Shipment/Package/PackageServiceOptions/ShipperReleaseIndicator')).to be_present
     end
   end
 end


### PR DESCRIPTION
I missed adding this option to the package options previously.