### PR TITLE
Use Country CODE instead of Country to compare with Country isos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2019-11-27
+
+### Changed
+- UPS Labels: Allow passing ShipperReleaseIndicator
+- UPS Labels: Fix bug that did not allow reference numbers
+
 ## [0.4.3] - 2019-11-27
 
 ### Changed

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -192,7 +192,7 @@ module FriendlyShipping
           # if the package is US -> US or PR -> PR the only type of reference numbers that are allowed are package-level
           # Otherwise the only type of reference numbers that are allowed are shipment-level
           def allow_package_level_reference_numbers(shipment)
-            origin, destination = shipment.origin.country, shipment.destination.country
+            origin, destination = shipment.origin.country.code, shipment.destination.country.code
             [['US', 'US'], ['PR', 'PR']].include?([origin, destination])
           end
 
@@ -201,7 +201,7 @@ module FriendlyShipping
           # otherwise the delivery_confirmation option must be specified on the entire shipment.
           # See Appendix P of UPS Shipping Package XML Developers Guide for the rules on which the logic below is based.
           def package_level_delivery_confirmation?(shipment)
-            origin, destination = shipment.origin.country, shipment.destination.country
+            origin, destination = shipment.origin.country.code, shipment.destination.country.code
             origin == destination || [['US', 'PR'], ['PR', 'US']].include?([origin, destination])
           end
 

--- a/lib/friendly_shipping/version.rb
+++ b/lib/friendly_shipping/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end


### PR DESCRIPTION
In these two private methods, we compared instances of `Carmen::Country`
objects to strings, which would always yield false. This meant that no
shipment would ever allow package level reference numbers or delivery
confirmations.