### PR TITLE
Fix shipment address indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2019-11-27
+
+### Changed
+- UPS Labels: Use correct Residential Address indication tag
+
 ## [0.4.4] - 2019-11-27
 
 ### Changed

--- a/lib/friendly_shipping/services/ups/serialize_shipment_address_snippet.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_address_snippet.rb
@@ -12,7 +12,7 @@ module FriendlyShipping
             # Rates use ResidentialAddressIndicator whereas shipments use ResidentialAddress.
             # Presence indicates residential address. Absence indicates commercial address.
             #
-            xml.ResidentialAddressIndicator unless location.commercial?
+            xml.ResidentialAddress unless location.commercial?
           end
         end
       end

--- a/lib/friendly_shipping/version.rb
+++ b/lib/friendly_shipping/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end

--- a/spec/friendly_shipping/services/ups/serialize_shipment_address_snippet_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_address_snippet_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentAddressSnippet do
+  let(:context_root) { "ShipTo" }
+
+  subject do
+    Nokogiri::XML::Builder.new do |xml|
+      xml.send(context_root) do
+        described_class.call(xml: xml, location: location)
+      end
+    end.doc
+  end
+
+  let(:location) do
+    FactoryBot.build(:physical_location, company_name: 'A very nice company', phone: "0998877665", zip: '00001')
+  end
+
+  it 'adds a address to the context' do
+    expect(subject.at_xpath('//ShipTo/Address/ResidentialAddress')).to be_present
+  end
+
+  context 'with commercial address' do
+    let(:location) { FactoryBot.build(:physical_location, address_type: 'commercial') }
+
+    it 'includes residential address indicator' do
+      expect(subject.at_xpath('//ShipTo/Address/ResidentialAddress')).not_to be_present
+    end
+  end
+
+  context 'with unknown address' do
+    let(:location) { FactoryBot.build(:physical_location, address_type: 'unknown') }
+
+    it 'includes residential address indicator' do
+      expect(subject.at_xpath('//ShipTo/Address/ResidentialAddress')).to be_present
+    end
+  end
+end


### PR DESCRIPTION
The label creation API from UPS needs a different XML tag to account for residential addresses than the rating API. This had been thought of previously in the source, but the indicator was not, actually changed.