### PR TITLE
Add UPS transit timings

### DIFF
--- a/lib/friendly_shipping/services/ups/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_time_in_transit_response.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Ups
+      class ParseTimeInTransitResponse
+        def self.call(request:, response:)
+          parsing_result = ParseXMLResponse.call(response.body, 'TimeInTransitResponse')
+          parsing_result.fmap do |xml|
+            origin_country_code = xml.at('TransitResponse/TransitFrom/AddressArtifactFormat/CountryCode').text
+            timings = xml.root.xpath('//TransitResponse/ServiceSummary').map do |service_summary|
+              # First find the shipping method
+              service_description = service_summary.at('Service/Description').text.gsub(/\s+/, ' ').strip
+              shipping_method = SHIPPING_METHODS.detect do |potential_shipping_method|
+                potential_shipping_method.name.starts_with?(service_description) &&
+                  potential_shipping_method.origin_countries.map(&:code).include?(origin_country_code)
+              end
+
+              # Figure out the dates and times
+              delivery_date = service_summary.at('EstimatedArrival/Date').text
+              delivery_time = service_summary.at('EstimatedArrival/Time').text
+              delivery = Time.parse("#{delivery_date} #{delivery_time}")
+              pickup_date = service_summary.at('EstimatedArrival/PickupDate').text
+              pickup_time = service_summary.at('EstimatedArrival/PickupTime').text
+              pickup = Time.parse("#{pickup_date} #{pickup_time}")
+
+              # Some additional data
+              guaranteed = service_summary.at('Guaranteed/Code').text == 'Y'
+              business_transit_days = service_summary.at('EstimatedArrival/BusinessTransitDays').text
+
+              FriendlyShipping::Timing.new(
+                shipping_method: shipping_method,
+                pickup: pickup,
+                delivery: delivery,
+                guaranteed: guaranteed,
+                properties: {
+                  business_transit_days: business_transit_days
+                }
+              )
+            end
+
+            FriendlyShipping::ApiResult.new(
+              timings,
+              original_request: request,
+              original_response: response
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups/serialize_time_in_transit_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_time_in_transit_request.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Ups
+      class SerializeTimeInTransitRequest
+        def self.call(shipment:, options:)
+          xml_builder = Nokogiri::XML::Builder.new do |xml|
+            xml.TimeInTransitRequest do
+              xml.Request do
+                if options.customer_context
+                  xml.TransactionReference do
+                    xml.CustomerContext(options.customer_context)
+                  end
+                end
+                xml.RequestAction('TimeInTransit')
+              end
+              xml.TransitFrom do
+                xml.AddressArtifactFormat do
+                  xml.PoliticalDivision2(shipment.origin.city)
+                  xml.PoliticalDivision1(shipment.origin.region.code)
+                  xml.CountryCode(shipment.origin.country.code)
+                  xml.PostcodePrimaryLow(shipment.origin.zip)
+                end
+              end
+              xml.TransitTo do
+                xml.AddressArtifactFormat do
+                  # We no longer include the destination city since it doesn't seem to change the timing
+                  # result and can prevent the time in transit request from succeeding when invalid.
+                  xml.CountryCode(shipment.destination.country.code)
+                  xml.PostcodePrimaryLow(shipment.destination.zip)
+                end
+              end
+              xml.ShipmentWeight do
+                xml.UnitOfMeasurement do
+                  xml.Code('LBS')
+                end
+                shipment_weight = shipment.packages.map(&:weight).inject(Measured::Weight(0, :pounds), :+)
+                xml.Weight(shipment_weight.convert_to(:pounds).value.to_f.round(3))
+              end
+              xml.InvoiceLineTotal do
+                xml.CurrencyCode(options.invoice_total.currency.iso_code)
+                xml.MonetaryValue(options.invoice_total.to_f.round(2))
+              end
+              xml.PickupDate(options.pickup.strftime('%Y%m%d'))
+            end
+          end
+          xml_builder.to_xml
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups/timing_options.rb
+++ b/lib/friendly_shipping/services/ups/timing_options.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class Ups
+      # Options for getting timing information from UPS
+      # @attribute [Time] pickup When the shipment will be picked up
+      # @attribute [Money] invoice_total How much the items in the shipment are worth
+      #   As this is not super important for getting timing information, we use a default
+      #   value of 50 USD here.
+      # @attribute [Boolean] documents_only Does the shipment only contain documents?
+      # @attribute [String] customer_context A string to connect request and response in the calling code
+      class TimingOptions
+        attr_reader :pickup,
+                    :invoice_total,
+                    :documents_only,
+                    :customer_context
+
+        def initialize(
+          pickup: Time.now,
+          invoice_total: Money.new(5000, 'USD'),
+          documents_only: false,
+          customer_context: nil
+        )
+          @pickup = pickup
+          @invoice_total = invoice_total
+          @documents_only = documents_only
+          @customer_context = customer_context
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/ups/timings/success.yml
+++ b/spec/cassettes/ups/timings/success.yml
@@ -1,0 +1,102 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/ups.app/xml/TimeInTransit
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <AccessRequest>
+          <AccessLicenseNumber>%UPS_KEY%</AccessLicenseNumber>
+          <UserId>%UPS_LOGIN%</UserId>
+          <Password>%UPS_PASSWORD%</Password>
+        </AccessRequest>
+        <?xml version="1.0"?>
+        <TimeInTransitRequest>
+          <Request>
+            <RequestAction>TimeInTransit</RequestAction>
+          </Request>
+          <TransitFrom>
+            <AddressArtifactFormat>
+              <PoliticalDivision2>Raleigh</PoliticalDivision2>
+              <PoliticalDivision1>NC</PoliticalDivision1>
+              <CountryCode>US</CountryCode>
+              <PostcodePrimaryLow>27615</PostcodePrimaryLow>
+            </AddressArtifactFormat>
+          </TransitFrom>
+          <TransitTo>
+            <AddressArtifactFormat>
+              <CountryCode>US</CountryCode>
+              <PostcodePrimaryLow>32821</PostcodePrimaryLow>
+            </AddressArtifactFormat>
+          </TransitTo>
+          <ShipmentWeight>
+            <UnitOfMeasurement>
+              <Code>LBS</Code>
+            </UnitOfMeasurement>
+            <Weight>1.221</Weight>
+          </ShipmentWeight>
+          <InvoiceLineTotal>
+            <CurrencyCode>USD</CurrencyCode>
+            <MonetaryValue>50.0</MonetaryValue>
+          </InvoiceLineTotal>
+          <PickupDate>20191204</PickupDate>
+        </TimeInTransitRequest>
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Length:
+      - '1094'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: '200'
+    headers:
+      Date:
+      - Wed, 04 Dec 2019 14:27:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, max-age=0, no-cache=Set-Cookie
+      Pragma:
+      - no-cache
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Apihttpstatus:
+      - '200'
+      Content-Length:
+      - '3944'
+      Content-Type:
+      - application/xml
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><TimeInTransitResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><TransitResponse><PickupDate>2019-12-04</PickupDate><TransitFrom><AddressArtifactFormat><PoliticalDivision2>RALEIGH</PoliticalDivision2><PoliticalDivision1>NC</PoliticalDivision1><Country>UNITED
+        STATES</Country><CountryCode>US</CountryCode><PostcodePrimaryLow>27615</PostcodePrimaryLow></AddressArtifactFormat></TransitFrom><TransitTo><AddressArtifactFormat><PoliticalDivision2>ORLANDO</PoliticalDivision2><PoliticalDivision1>FL</PoliticalDivision1><Country>UNITED
+        STATES</Country><CountryCode>US</CountryCode><PostcodePrimaryLow>32821</PostcodePrimaryLow></AddressArtifactFormat></TransitTo><ShipmentWeight><UnitOfMeasurement><Code>LBS</Code></UnitOfMeasurement><Weight>1.2</Weight></ShipmentWeight><InvoiceLineTotal><CurrencyCode>USD</CurrencyCode><MonetaryValue>50.00</MonetaryValue></InvoiceLineTotal><Disclaimer>Services
+        listed as guaranteed are backed by a money-back guarantee for transportation
+        charges only. UPS guarantees the day of delivery for every ground package
+        you ship to any address within all 50 states and Puerto Rico. See Terms and
+        Conditions in the Service Guide for details.</Disclaimer><ServiceSummary><Service><Code>1DM</Code><Description>UPS
+        Next Day Air Early</Description></Service><Guaranteed><Code>Y</Code></Guaranteed><EstimatedArrival><BusinessTransitDays>1</BusinessTransitDays><Time>08:00:00</Time><PickupDate>2019-12-04</PickupDate><PickupTime>20:00:00</PickupTime><Date>2019-12-05</Date><DayOfWeek>THU</DayOfWeek><CustomerCenterCutoff>19:00:00</CustomerCenterCutoff></EstimatedArrival></ServiceSummary><ServiceSummary><Service><Code>1DA</Code><Description>UPS
+        Next Day Air</Description></Service><Guaranteed><Code>Y</Code></Guaranteed><EstimatedArrival><BusinessTransitDays>1</BusinessTransitDays><Time>10:30:00</Time><PickupDate>2019-12-04</PickupDate><PickupTime>20:00:00</PickupTime><Date>2019-12-05</Date><DayOfWeek>THU</DayOfWeek><CustomerCenterCutoff>19:00:00</CustomerCenterCutoff></EstimatedArrival></ServiceSummary><ServiceSummary><Service><Code>1DP</Code><Description>UPS
+        Next Day Air Saver</Description></Service><Guaranteed><Code>Y</Code></Guaranteed><EstimatedArrival><BusinessTransitDays>1</BusinessTransitDays><Time>15:00:00</Time><PickupDate>2019-12-04</PickupDate><PickupTime>20:00:00</PickupTime><Date>2019-12-05</Date><DayOfWeek>THU</DayOfWeek><CustomerCenterCutoff>19:00:00</CustomerCenterCutoff></EstimatedArrival></ServiceSummary><ServiceSummary><Service><Code>2DM</Code><Description>UPS
+        2nd Day Air A.M.</Description></Service><Guaranteed><Code>Y</Code></Guaranteed><EstimatedArrival><BusinessTransitDays>2</BusinessTransitDays><Time>10:30:00</Time><PickupDate>2019-12-04</PickupDate><PickupTime>20:00:00</PickupTime><Date>2019-12-06</Date><DayOfWeek>FRI</DayOfWeek><CustomerCenterCutoff>19:00:00</CustomerCenterCutoff></EstimatedArrival></ServiceSummary><ServiceSummary><Service><Code>2DA</Code><Description>UPS
+        2nd Day Air</Description></Service><Guaranteed><Code>Y</Code></Guaranteed><EstimatedArrival><BusinessTransitDays>2</BusinessTransitDays><Time>23:00:00</Time><PickupDate>2019-12-04</PickupDate><PickupTime>20:00:00</PickupTime><Date>2019-12-06</Date><DayOfWeek>FRI</DayOfWeek><CustomerCenterCutoff>19:00:00</CustomerCenterCutoff></EstimatedArrival></ServiceSummary><ServiceSummary><Service><Code>GND</Code><Description>UPS
+        Ground</Description></Service><Guaranteed><Code>N</Code></Guaranteed><EstimatedArrival><BusinessTransitDays>2</BusinessTransitDays><Time>23:00:00</Time><PickupDate>2019-12-04</PickupDate><PickupTime>20:00:00</PickupTime><Date>2019-12-06</Date><DayOfWeek>FRI</DayOfWeek><CustomerCenterCutoff>19:00:00</CustomerCenterCutoff></EstimatedArrival></ServiceSummary><MaximumListSize>35</MaximumListSize></TransitResponse></TimeInTransitResponse>
+    http_version:
+  recorded_at: Wed, 04 Dec 2019 14:27:09 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/ups/ups_timing_api_response.xml
+++ b/spec/fixtures/ups/ups_timing_api_response.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0"?>
+<TimeInTransitResponse>
+  <Response>
+    <TransactionReference>
+      <CustomerContext>Time in Transit</CustomerContext>
+      <XpciVersion>1.0002</XpciVersion>
+    </TransactionReference>
+    <ResponseStatusCode>1</ResponseStatusCode>
+    <ResponseStatusDescription>Success</ResponseStatusDescription>
+  </Response>
+  <TransitResponse>
+    <PickupDate>2018-06-20</PickupDate>
+    <TransitFrom>
+      <AddressArtifactFormat>
+        <PoliticalDivision2>SPARKS</PoliticalDivision2>
+        <PoliticalDivision1>NV</PoliticalDivision1>
+        <Country>UNITED STATES</Country>
+        <CountryCode>US</CountryCode>
+        <PostcodePrimaryLow>89431</PostcodePrimaryLow>
+      </AddressArtifactFormat>
+    </TransitFrom>
+    <TransitTo>
+      <AddressArtifactFormat>
+        <PoliticalDivision2>ORLANDO</PoliticalDivision2>
+        <PoliticalDivision1>FL</PoliticalDivision1>
+        <Country>UNITED STATES</Country>
+        <CountryCode>US</CountryCode>
+        <PostcodePrimaryLow>32821</PostcodePrimaryLow>
+      </AddressArtifactFormat>
+    </TransitTo>
+    <ShipmentWeight>
+      <UnitOfMeasurement>
+        <Code>LBS</Code>
+      </UnitOfMeasurement>
+      <Weight>1.0</Weight>
+    </ShipmentWeight>
+    <InvoiceLineTotal>
+      <CurrencyCode>USD</CurrencyCode>
+      <MonetaryValue>50.00</MonetaryValue>
+    </InvoiceLineTotal>
+    <Disclaimer>Services
+  listed as guaranteed are backed by a money-back guarantee for transportation
+  charges only. UPS guarantees the day of delivery for every ground package
+  you ship to any address within all 50 states and Puerto Rico. See Terms and
+  Conditions in the Service Guide for details.</Disclaimer>
+    <ServiceSummary>
+      <Service>
+        <Code>1DM</Code>
+        <Description>UPS Next Day Air Early</Description>
+      </Service>
+      <Guaranteed>
+        <Code>Y</Code>
+      </Guaranteed>
+      <EstimatedArrival>
+        <BusinessTransitDays>1</BusinessTransitDays>
+        <Time>08:00:00</Time>
+        <PickupDate>2018-06-20</PickupDate>
+        <PickupTime>17:00:00</PickupTime>
+        <Date>2018-06-21</Date>
+        <DayOfWeek>THU</DayOfWeek>
+        <CustomerCenterCutoff>16:00:00</CustomerCenterCutoff>
+      </EstimatedArrival>
+    </ServiceSummary>
+    <ServiceSummary>
+      <Service>
+        <Code>1DA</Code>
+        <Description>UPS Next Day Air</Description>
+      </Service>
+      <Guaranteed>
+        <Code>Y</Code>
+      </Guaranteed>
+      <EstimatedArrival>
+        <BusinessTransitDays>1</BusinessTransitDays>
+        <Time>10:30:00</Time>
+        <PickupDate>2018-06-20</PickupDate>
+        <PickupTime>17:00:00</PickupTime>
+        <Date>2018-06-21</Date>
+        <DayOfWeek>THU</DayOfWeek>
+        <CustomerCenterCutoff>16:00:00</CustomerCenterCutoff>
+      </EstimatedArrival>
+    </ServiceSummary>
+    <ServiceSummary>
+      <Service>
+        <Code>1DP</Code>
+        <Description>UPS Next Day Air Saver</Description>
+      </Service>
+      <Guaranteed>
+        <Code>Y</Code>
+      </Guaranteed>
+      <EstimatedArrival>
+        <BusinessTransitDays>1</BusinessTransitDays>
+        <Time>15:00:00</Time>
+        <PickupDate>2018-06-20</PickupDate>
+        <PickupTime>17:00:00</PickupTime>
+        <Date>2018-06-21</Date>
+        <DayOfWeek>THU</DayOfWeek>
+        <CustomerCenterCutoff>16:00:00</CustomerCenterCutoff>
+      </EstimatedArrival>
+    </ServiceSummary>
+    <ServiceSummary>
+      <Service>
+        <Code>2DM</Code>
+        <Description>UPS 2nd Day Air A.M.</Description>
+      </Service>
+      <Guaranteed>
+        <Code>Y</Code>
+      </Guaranteed>
+      <EstimatedArrival>
+        <BusinessTransitDays>2</BusinessTransitDays>
+        <Time>10:30:00</Time>
+        <PickupDate>2018-06-20</PickupDate>
+        <PickupTime>17:00:00</PickupTime>
+        <Date>2018-06-22</Date>
+        <DayOfWeek>FRI</DayOfWeek>
+        <CustomerCenterCutoff>16:00:00</CustomerCenterCutoff>
+      </EstimatedArrival>
+    </ServiceSummary>
+    <ServiceSummary>
+      <Service>
+        <Code>2DA</Code>
+        <Description>UPS 2nd Day Air</Description>
+      </Service>
+      <Guaranteed>
+        <Code>Y</Code>
+      </Guaranteed>
+      <EstimatedArrival>
+        <BusinessTransitDays>2</BusinessTransitDays>
+        <Time>23:00:00</Time>
+        <PickupDate>2018-06-20</PickupDate>
+        <PickupTime>17:00:00</PickupTime>
+        <Date>2018-06-22</Date>
+        <DayOfWeek>FRI</DayOfWeek>
+        <CustomerCenterCutoff>16:00:00</CustomerCenterCutoff>
+      </EstimatedArrival>
+    </ServiceSummary>
+    <ServiceSummary>
+      <Service>
+        <Code>3DS</Code>
+        <Description>UPS
+  3 Day Select</Description>
+      </Service>
+      <Guaranteed>
+        <Code>Y</Code>
+      </Guaranteed>
+      <EstimatedArrival>
+        <BusinessTransitDays>3</BusinessTransitDays>
+        <Time>23:00:00</Time>
+        <PickupDate>2018-06-20</PickupDate>
+        <PickupTime>17:00:00</PickupTime>
+        <Date>2018-06-25</Date>
+        <DayOfWeek>MON</DayOfWeek>
+        <CustomerCenterCutoff>16:00:00</CustomerCenterCutoff>
+      </EstimatedArrival>
+    </ServiceSummary>
+    <ServiceSummary>
+      <Service>
+        <Code>GND</Code>
+        <Description>UPS Ground</Description>
+      </Service>
+      <Guaranteed>
+        <Code>Y</Code>
+      </Guaranteed>
+      <EstimatedArrival>
+        <BusinessTransitDays>5</BusinessTransitDays>
+        <Time>23:00:00</Time>
+        <PickupDate>2018-06-20</PickupDate>
+        <PickupTime>17:00:00</PickupTime>
+        <Date>2018-06-27</Date>
+        <DayOfWeek>WED</DayOfWeek>
+        <CustomerCenterCutoff>16:00:00</CustomerCenterCutoff>
+      </EstimatedArrival>
+    </ServiceSummary>
+    <MaximumListSize>35</MaximumListSize>
+  </TransitResponse>
+</TimeInTransitResponse>

--- a/spec/friendly_shipping/services/ups/parse_time_in_transit_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_time_in_transit_response_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ups/parse_time_in_transit_response'
+
+RSpec.describe FriendlyShipping::Services::Ups::ParseTimeInTransitResponse do
+  include Dry::Monads::Result::Mixin
+  let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'ups_timing_api_response.xml')).read }
+  let(:response) { double(body: response_body) }
+  let(:request) { FriendlyShipping::Request.new(url: 'http://www.example.com') }
+
+  subject(:result) do
+    described_class.call(
+      request: request,
+      response: response,
+    )
+  end
+
+  it { is_expected.to be_success }
+
+  describe 'Success result value' do
+    subject { result.value!.data }
+
+    it 'returns rates along with the response' do
+      expect(subject).to be_a(Enumerable)
+      expect(subject.length).to eq(7)
+      expect(subject.map(&:shipping_method).map(&:name)).to contain_exactly(
+        "UPS Next Day Air Early",
+        "UPS Next Day Air",
+        "UPS Next Day Air Saver",
+        "UPS 2nd Day Air A.M.",
+        "UPS 2nd Day Air",
+        "UPS Ground",
+        "UPS 3 Day Select"
+      )
+      last_timing = subject.last
+      expect(last_timing.shipping_method.name).to eq('UPS Ground')
+      expect(last_timing.pickup.strftime('%Y-%m-%dT%H:%M')).to eq('2018-06-20T17:00')
+      expect(last_timing.delivery.strftime('%Y-%m-%dT%H:%M')).to eq('2018-06-27T23:00')
+      expect(subject.map { |h| h.properties[:business_transit_days] }).to eq(["1", "1", "1", "2", "2", "3", "5"])
+    end
+  end
+end

--- a/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ups/serialize_time_in_transit_request'
+require 'friendly_shipping/services/ups/timing_options'
+
+RSpec.describe FriendlyShipping::Services::Ups::SerializeTimeInTransitRequest do
+  let(:origin) do
+    Physical::Location.new(
+      country: 'US',
+      region: 'NC',
+      zip: '27703'
+    )
+  end
+  let(:destination) do
+    Physical::Location.new(
+      country: 'US',
+      region: 'FL',
+      zip: '32821'
+    )
+  end
+
+  let(:package) do
+    Physical::Package.new(
+      weight: Measured::Weight.new(5, :pounds),
+    )
+  end
+
+  let(:shipment) do
+    Physical::Shipment.new(
+      origin: origin,
+      destination: destination,
+      packages: [package]
+    )
+  end
+
+  let(:options) do
+    FriendlyShipping::Services::Ups::TimingOptions.new(
+      pickup: Time.new(2018, 9, 15, 10, 0, 0),
+      customer_context: 'Time in Transit'
+    )
+  end
+
+  subject do
+    Nokogiri::XML(
+      described_class.call(
+        shipment: shipment,
+        options: options
+      )
+    )
+  end
+
+  it 'contains the right data' do
+    aggregate_failures do
+      expect(subject.at_xpath('//TimeInTransitRequest')).to be_present
+      expect(subject.at_xpath('//TimeInTransitRequest/Request')).to be_present
+      expect(subject.at_xpath('//TimeInTransitRequest/Request/TransactionReference')).to be_present
+      expect(subject.at_xpath('//TimeInTransitRequest/Request/TransactionReference/CustomerContext').text).
+        to eq('Time in Transit')
+      expect(subject.at_xpath('//TimeInTransitRequest/Request/RequestAction').text).to eq('TimeInTransit')
+      expect(
+        subject.at_xpath('//TimeInTransitRequest/TransitFrom/AddressArtifactFormat/PostcodePrimaryLow').text
+      ).to eq('27703')
+      expect(
+        subject.at_xpath('//TimeInTransitRequest/TransitTo/AddressArtifactFormat/PostcodePrimaryLow').text
+      ).to eq('32821')
+      expect(
+        subject.at_xpath('//TimeInTransitRequest/ShipmentWeight/UnitOfMeasurement/Code').text
+      ).to eq('LBS')
+      expect(subject.at_xpath('//TimeInTransitRequest/ShipmentWeight/Weight').text).to eq('5.0')
+    end
+  end
+end

--- a/spec/friendly_shipping/services/ups/timing_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/timing_options_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ups/timing_options'
+
+RSpec.describe FriendlyShipping::Services::Ups::TimingOptions do
+  subject { described_class.new }
+
+  it 'has all the required attributes' do
+    expect(subject.pickup).to be_a(Time)
+    expect(subject.invoice_total).to eq(Money.new(5000, 'USD'))
+    expect(subject.documents_only).to be false
+    expect(subject.customer_context).to be nil
+  end
+end


### PR DESCRIPTION
This adds UPS time-in-transit API calls to FriendlyShipping. Currently depends on #37 .