### PR TITLE
Explicitly set the Money rounding mode

### DIFF
--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require "physical"
+require "money"
+
+# Explicitly configure the default rounding mode to avoid deprecation warnings
+Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
 
 require "friendly_shipping/version"
 require "friendly_shipping/request"

--- a/lib/friendly_shipping/services/ship_engine/parse_rate_estimate_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_rate_estimate_response.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'money'
 
 module FriendlyShipping
   module Services


### PR DESCRIPTION
This eliminates dozens of deprecation warnings about the rounding mode for `Money` being changed in the next major release. This also relocates the require statement to a central location since the `Money` class is being used in a lot of different places now.