### PR TITLE
Add destination city/state to UPS timing serializer

### DIFF
--- a/lib/friendly_shipping/services/ups/serialize_time_in_transit_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_time_in_transit_request.rb
@@ -25,8 +25,8 @@ module FriendlyShipping
               end
               xml.TransitTo do
                 xml.AddressArtifactFormat do
-                  # We no longer include the destination city since it doesn't seem to change the timing
-                  # result and can prevent the time in transit request from succeeding when invalid.
+                  xml.PoliticalDivision2(shipment.destination.city)
+                  xml.PoliticalDivision1(shipment.destination.region.code)
                   xml.CountryCode(shipment.destination.country.code)
                   xml.PostcodePrimaryLow(shipment.destination.zip)
                 end

--- a/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeTimeInTransitRequest do
     Physical::Location.new(
       country: 'US',
       region: 'FL',
+      city: 'Orlando',
       zip: '32821'
     )
   end
@@ -62,6 +63,9 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeTimeInTransitRequest do
       expect(node.at_xpath('TransitFrom/AddressArtifactFormat/CountryCode').text).to eq('US')
       expect(node.at_xpath('TransitFrom/AddressArtifactFormat/PostcodePrimaryLow').text).to eq('27703')
 
+      expect(node.at_xpath('TransitTo/AddressArtifactFormat/PoliticalDivision2').text).to eq('Orlando')
+      expect(node.at_xpath('TransitTo/AddressArtifactFormat/PoliticalDivision1').text).to eq('FL')
+      expect(node.at_xpath('TransitTo/AddressArtifactFormat/CountryCode').text).to eq('US')
       expect(node.at_xpath('TransitTo/AddressArtifactFormat/PostcodePrimaryLow').text).to eq('32821')
 
       expect(node.at_xpath('ShipmentWeight/UnitOfMeasurement/Code').text).to eq('LBS')

--- a/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeTimeInTransitRequest do
     Physical::Location.new(
       country: 'US',
       region: 'NC',
+      city: 'Durham',
       zip: '27703'
     )
   end
@@ -52,22 +53,19 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeTimeInTransitRequest do
 
   it 'contains the right data' do
     aggregate_failures do
-      expect(subject.at_xpath('//TimeInTransitRequest')).to be_present
-      expect(subject.at_xpath('//TimeInTransitRequest/Request')).to be_present
-      expect(subject.at_xpath('//TimeInTransitRequest/Request/TransactionReference')).to be_present
-      expect(subject.at_xpath('//TimeInTransitRequest/Request/TransactionReference/CustomerContext').text).
-        to eq('Time in Transit')
-      expect(subject.at_xpath('//TimeInTransitRequest/Request/RequestAction').text).to eq('TimeInTransit')
-      expect(
-        subject.at_xpath('//TimeInTransitRequest/TransitFrom/AddressArtifactFormat/PostcodePrimaryLow').text
-      ).to eq('27703')
-      expect(
-        subject.at_xpath('//TimeInTransitRequest/TransitTo/AddressArtifactFormat/PostcodePrimaryLow').text
-      ).to eq('32821')
-      expect(
-        subject.at_xpath('//TimeInTransitRequest/ShipmentWeight/UnitOfMeasurement/Code').text
-      ).to eq('LBS')
-      expect(subject.at_xpath('//TimeInTransitRequest/ShipmentWeight/Weight').text).to eq('5.0')
+      node = subject.at_xpath('//TimeInTransitRequest')
+      expect(node.at_xpath('Request/TransactionReference/CustomerContext').text).to eq('Time in Transit')
+      expect(node.at_xpath('Request/RequestAction').text).to eq('TimeInTransit')
+
+      expect(node.at_xpath('TransitFrom/AddressArtifactFormat/PoliticalDivision2').text).to eq('Durham')
+      expect(node.at_xpath('TransitFrom/AddressArtifactFormat/PoliticalDivision1').text).to eq('NC')
+      expect(node.at_xpath('TransitFrom/AddressArtifactFormat/CountryCode').text).to eq('US')
+      expect(node.at_xpath('TransitFrom/AddressArtifactFormat/PostcodePrimaryLow').text).to eq('27703')
+
+      expect(node.at_xpath('TransitTo/AddressArtifactFormat/PostcodePrimaryLow').text).to eq('32821')
+
+      expect(node.at_xpath('ShipmentWeight/UnitOfMeasurement/Code').text).to eq('LBS')
+      expect(node.at_xpath('ShipmentWeight/Weight').text).to eq('5.0')
     end
   end
 end


### PR DESCRIPTION
We should be including the destination city/state in our UPS timing requests.