### PR TITLE
Bump Version to 4.8.2, log changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.8] - 2020-01-06
+
+### Changed
+- USPS Service: Only transmit weights up to 150 pounds to timing API (#64)
+- UPS Service: Transmit City and State when asking for timing information (#62)
+- USPS Service: Gracefully handle missing expedited timing nodes (#60)
+
 ## [0.4.7] - 2019-11-28
 
 ### Changed

--- a/lib/friendly_shipping/version.rb
+++ b/lib/friendly_shipping/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
-  VERSION = "0.4.7"
+  VERSION = "0.4.8"
 end


### PR DESCRIPTION
Tiny release with fixes for both UPS and USPS timing calls.