### PR TITLE
UPS: Transmit a maximum of 150 pounds to time in transit API

### DIFF
--- a/lib/friendly_shipping/services/ups/serialize_time_in_transit_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_time_in_transit_request.rb
@@ -4,6 +4,8 @@ module FriendlyShipping
   module Services
     class Ups
       class SerializeTimeInTransitRequest
+        MAX_SHIPMENT_WEIGHT = Measured::Weight.new(150, :pounds)
+
         def self.call(shipment:, options:)
           xml_builder = Nokogiri::XML::Builder.new do |xml|
             xml.TimeInTransitRequest do
@@ -36,7 +38,8 @@ module FriendlyShipping
                   xml.Code('LBS')
                 end
                 shipment_weight = shipment.packages.map(&:weight).inject(Measured::Weight(0, :pounds), :+)
-                xml.Weight(shipment_weight.convert_to(:pounds).value.to_f.round(3))
+                weight_for_ups = [shipment_weight, MAX_SHIPMENT_WEIGHT].min
+                xml.Weight(weight_for_ups.convert_to(:pounds).value.to_f.round(3))
               end
               xml.InvoiceLineTotal do
                 xml.CurrencyCode(options.invoice_total.currency.iso_code)

--- a/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
@@ -72,4 +72,17 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeTimeInTransitRequest do
       expect(node.at_xpath('ShipmentWeight/Weight').text).to eq('5.0')
     end
   end
+
+  context 'if shipment weighs more than 150 pounds' do
+    let(:package) do
+      Physical::Package.new(
+        weight: Measured::Weight.new(151, :pounds),
+      )
+    end
+
+    it 'lowers the weight to just 150 pounds' do
+      node = subject.at_xpath('//TimeInTransitRequest')
+      expect(node.at_xpath('ShipmentWeight/Weight').text).to eq('150.0')
+    end
+  end
 end


### PR DESCRIPTION
The time in transit API only allows shipments up to 150 pounds. However,
sometimes UPS will ship packages larger than this - to allow for that,
limit the weight we transmit to them to what their API thinks their maximum is.