### PR TITLE
Move cop to the right namespace

### DIFF
--- a/.rubocop-relaxed.yml
+++ b/.rubocop-relaxed.yml
@@ -156,7 +156,7 @@ Metrics/ModuleLength:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Layout/LineLength:
+Metrics/LineLength:
   Enabled: false
 
 Metrics/MethodLength:


### PR DESCRIPTION
This fixes:

`.rubocop-relaxed.yml: Layout/LineLength has the wrong namespace - should be Metrics`