### PR TITLE
Add double splats for Ruby 2.7 compatibility

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/label_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_options.rb
@@ -26,7 +26,7 @@ module FriendlyShipping
           @shipping_method = shipping_method
           @label_format = label_format
           @label_download_type = label_download_type
-          super kwargs.merge(package_options_class: LabelPackageOptions)
+          super(**kwargs.merge(package_options_class: LabelPackageOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/ship_engine/label_package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_package_options.rb
@@ -20,7 +20,7 @@ module FriendlyShipping
         def initialize(package_code: nil, messages: [], **kwargs)
           @package_code = package_code
           @messages = messages
-          super kwargs
+          super(**kwargs)
         end
       end
     end

--- a/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
@@ -13,7 +13,7 @@ module FriendlyShipping
 
         def initialize(carriers:, **kwargs)
           @carriers = carriers
-          super kwargs
+          super(**kwargs)
         end
 
         def carrier_ids

--- a/lib/friendly_shipping/services/ups/label_item_options.rb
+++ b/lib/friendly_shipping/services/ups/label_item_options.rb
@@ -58,7 +58,7 @@ module FriendlyShipping
         )
           @commodity_code = commodity_code
           @product_unit_of_measure = product_unit_of_measure
-          super kwargs
+          super(**kwargs)
         end
 
         def product_unit_of_measure_code

--- a/lib/friendly_shipping/services/ups/label_options.rb
+++ b/lib/friendly_shipping/services/ups/label_options.rb
@@ -139,7 +139,7 @@ module FriendlyShipping
           @terms_of_shipment = terms_of_shipment
           @reason_for_export = reason_for_export
           @invoice_date = invoice_date
-          super kwargs.merge(package_options_class: package_options_class)
+          super(**kwargs.merge(package_options_class: package_options_class))
         end
 
         def delivery_confirmation_code

--- a/lib/friendly_shipping/services/ups/label_package_options.rb
+++ b/lib/friendly_shipping/services/ups/label_package_options.rb
@@ -31,7 +31,7 @@ module FriendlyShipping
           @reference_numbers = reference_numbers
           @delivery_confirmation = delivery_confirmation
           @shipper_release = shipper_release
-          super kwargs.merge(item_options_class: LabelItemOptions)
+          super(**kwargs.merge(item_options_class: LabelItemOptions))
         end
 
         def delivery_confirmation_code

--- a/lib/friendly_shipping/services/ups_freight/rates_item_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_item_options.rb
@@ -64,7 +64,7 @@ module FriendlyShipping
           @packaging_description = PACKAGING_TYPES.fetch(packaging).fetch(:description)
           @freight_class = freight_class
           @nmfc_code = nmfc_code
-          super kwargs
+          super(**kwargs)
         end
       end
     end

--- a/lib/friendly_shipping/services/ups_freight/rates_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_options.rb
@@ -54,7 +54,7 @@ module FriendlyShipping
           @pickup_date = pickup_date
           @pickup_comments = pickup_comments
           @commodity_information_generator = commodity_information_generator
-          super kwargs.merge(package_options_class: RatesPackageOptions)
+          super(**kwargs.merge(package_options_class: RatesPackageOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/ups_freight/rates_package_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_package_options.rb
@@ -30,7 +30,7 @@ module FriendlyShipping
           @handling_unit_code = HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:code)
           @handling_unit_description = HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:description)
           @handling_unit_tag = "HandlingUnit#{HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:handling_unit_tag)}"
-          super kwargs.merge(item_options_class: RatesItemOptions)
+          super(**kwargs.merge(item_options_class: RatesItemOptions))
         end
       end
     end


### PR DESCRIPTION
☝️ 

Specs run without warnings under Ruby 2.7 (with the exception of incompatible 3rd party libraries).

https://blog.saeloun.com/2019/10/07/ruby-2-7-keyword-arguments-redesign.html