### PR TITLE
Add missing commitment sequence

### DIFF
--- a/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
@@ -168,6 +168,11 @@ module FriendlyShipping
               commitment_time: '10:30 AM',
               destination_type: :hold_for_pickup
             },
+            'B0215' => {
+              commitment: '2-Day',
+              commitment_time: '3:00 PM',
+              destination_type: :hold_for_pickup
+            },
             'C0100' => {
               commitment: '1-Day',
               destination_type: :street

--- a/spec/fixtures/usps/time_in_transit_response.xml
+++ b/spec/fixtures/usps/time_in_transit_response.xml
@@ -44,7 +44,7 @@
       <MailClass>1</MailClass>
       <CommitmentName>1-Day</CommitmentName>
       <CommitmentTime>1500</CommitmentTime>
-      <CommitmentSeq>B0115</CommitmentSeq>
+      <CommitmentSeq>B0215</CommitmentSeq>
       <Location>
         <SDD>2019-12-04</SDD>
         <COT>1600</COT>


### PR DESCRIPTION
Commitment sequences map information about when a USPS shipment arrives
to a short 5-digit code. We have a constant that lists all of them, but that was missing
one code. This missing code led to errors when parsing USPS time in transit responses
that contained it.