### PR TITLE
Fix USPS rate response parsing 

### DIFF
--- a/lib/friendly_shipping/services/usps/choose_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/choose_package_rate.rb
@@ -31,13 +31,8 @@ module FriendlyShipping
             r.data[:hold_for_pickup] == !!package.properties[:hold_for_pickup]
           end
 
-          # At this point we should be left with a single rate. If we are not, raise an error,
-          # as that means we're missing some code.
-          if rates_with_this_hold_for_pickup_option.length > 1
-            raise CannotDetermineRate
-          end
-
-          # As we only have one rate left, return that without the array.
+          # At this point, we have one or two rates left, and they're similar enough.
+          # Once this poses an actual problem, we'll fix it.
           rates_with_this_hold_for_pickup_option.first
         end
       end

--- a/lib/friendly_shipping/services/usps/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_rate_response.rb
@@ -65,7 +65,7 @@ module FriendlyShipping
           def rates_from_response_node(xml, shipment)
             xml.xpath(PACKAGE_NODE_XPATH).each_with_object({}) do |package_node, result|
               package_id = package_node['ID']
-              corresponding_package = shipment.packages.detect { |p| p.id == package_id }
+              corresponding_package = shipment.packages[package_id.to_i]
 
               # There should always be a package in the original shipment that corresponds to the package ID
               # in the USPS response.

--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -19,8 +19,8 @@ module FriendlyShipping
           def call(shipment:, login:, shipping_method: nil)
             xml_builder = Nokogiri::XML::Builder.new do |xml|
               xml.RateV4Request('USERID' => login) do
-                shipment.packages.each do |package|
-                  xml.Package('ID' => package.id) do
+                shipment.packages.each_with_index do |package, index|
+                  xml.Package('ID' => index) do
                     xml.Service(service_code_by(shipping_method, package))
                     if package.properties[:first_class_mail_type]
                       xml.FirstClassMailType(FIRST_CLASS_MAIL_TYPES[package.properties[:first_class_mail_type]])

--- a/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
@@ -50,22 +50,4 @@ RSpec.describe FriendlyShipping::Services::Usps::ChoosePackageRate do
       expect(subject.data[:hold_for_pickup]).to be false
     end
   end
-
-  context 'if not left with single rate at end' do
-    let(:rates) do
-      [
-        FriendlyShipping::Rate.new(
-          shipping_method: shipping_method,
-          amounts: { package.id => 1 },
-          data: { hold_for_pickup: false }
-        )
-      ] * 2
-    end
-
-    it 'raises an exception' do
-      expect { subject }.to raise_exception(
-        FriendlyShipping::Services::Usps::ChoosePackageRate::CannotDetermineRate
-      )
-    end
-  end
 end


### PR DESCRIPTION
When requesting First Class rates, I ran into some errors. These two commits fix them: 

- In some cases, the API will return differing rates for "Metered" and "Stamped" mail, and I don't think anyone will really use the rating API for that kind of Mail. We just return the first, more standard type of mail and do not raise an error if we're not down to exactly one shipping quote in the ChoosePackageRate class.

- Identify packages by index rather than by randomly generated ID to facilitate using tools like VCR for recording.