### PR TITLE
USPS: Only specify package dimensions for variable and regular packages

### DIFF
--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -33,10 +33,12 @@ module FriendlyShipping
                     container = CONTAINERS[package.properties[:box_name] || :rectangular]
                     xml.Container(container)
                     xml.Size(size_code)
-                    xml.Width("%<width>0.2f" % { width: package.width.convert_to(:inches).value.to_f })
-                    xml.Length("%<length>0.2f" % { length: package.length.convert_to(:inches).value.to_f })
-                    xml.Height("%<height>0.2f" % { height: package.height.convert_to(:inches).value.to_f })
-                    xml.Girth("%<girth>0.2f" % { girth: girth(package) })
+                    if ['RECTANGULAR', 'VARIABLE'].include?(container)
+                      xml.Width("%<width>0.2f" % { width: package.width.convert_to(:inches).value.to_f })
+                      xml.Length("%<length>0.2f" % { length: package.length.convert_to(:inches).value.to_f })
+                      xml.Height("%<height>0.2f" % { height: package.height.convert_to(:inches).value.to_f })
+                      xml.Girth("%<girth>0.2f" % { girth: girth(package) })
+                    end
                     xml.Machinable(machinable(package))
                   end
                 end

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
 
     it 'uses correct container' do
       expect(node.at_xpath('Container').text).to eq('REGIONALRATEBOXA')
+      expect(node.at_xpath('Width')).to be nil
+      expect(node.at_xpath('Length')).to be nil
+      expect(node.at_xpath('Height')).to be nil
+      expect(node.at_xpath('Girth')).to be nil
     end
   end
 


### PR DESCRIPTION
When we specify a particular USPS-branded box type, they know the
dimensions.