### PR TITLE
Move development dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,3 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in friendly_shipping.gemspec
 gemspec
-
-gem 'dotenv'
-gem 'factory_bot'
-gem 'pry'
-gem 'rspec_junit_formatter'
-gem 'rubocop'
-gem 'simplecov', require: false
-gem 'vcr'
-gem 'webmock'

--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -31,6 +31,14 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "dotenv"
+  spec.add_development_dependency "factory_bot", "~> 5.0"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "vcr"
+  spec.add_development_dependency "webmock"
 end


### PR DESCRIPTION
This seems like a more appropriate place for development dependencies in a gem vs an app. However, I don't feel particularly strongly about this. Any thoughts? See: https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/