### PR TITLE
Skip timing commitments with invalid sequences

### DIFF
--- a/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
@@ -44,6 +44,8 @@ module FriendlyShipping
               end
               commitment_sequence = commitment_node.at('CommitmentSeq').text
               properties = COMMITMENT_SEQUENCES[commitment_sequence]
+              next unless properties # Sometimes USPS returns an invalid CommitmentSeq
+
               scheduled_delivery_time = properties.delete(:commitment_time)
               scheduled_delivery_date = commitment_node.at('SDD').text
               parsed_delivery_time = Time.parse("#{scheduled_delivery_date} #{scheduled_delivery_time}")
@@ -56,7 +58,7 @@ module FriendlyShipping
                 guaranteed: guaranteed,
                 properties: properties
               )
-            end
+            end.compact
           end
 
           def parse_non_expedited_commitment_nodes(non_expedited_commitment_nodes)

--- a/spec/cassettes/usps/timings/success_with_invalid_commitment_seq.yml
+++ b/spec/cassettes/usps/timings/success_with_invalid_commitment_seq.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://stg-secure.shippingapis.com/ShippingAPI.dll
+    body:
+      encoding: UTF-8
+      string: API=SDCGetLocations&XML=%3C%3Fxml+version%3D%221.0%22%3F%3E%0A%3CSDCGetLocationsRequest+USERID%3D%22%USPS_LOGIN%%22%3E%0A++%3CMailClass%3E0%3C%2FMailClass%3E%0A++%3COriginZIP%3E27703%3C%2FOriginZIP%3E%0A++%3CDestinationZIP%3E20189%3C%2FDestinationZIP%3E%0A++%3CAcceptDate%3E17-Jan-2020%3C%2FAcceptDate%3E%0A++%3CNonEMDetail%3Etrue%3C%2FNonEMDetail%3E%0A%3C%2FSDCGetLocationsRequest%3E%0A
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (darwin19.0.0 x86_64) ruby/2.6.5p114
+      Content-Length:
+      - '387'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - stg-secure.shippingapis.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Backside-Transport:
+      - OK OK
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 17 Jan 2020 18:34:06 GMT
+      X-Global-Transaction-Id:
+      - ec50ae425e21fe1e175717c1
+      Access-Control-Allow-Origin:
+      - "*"
+      Connection:
+      - Keep-Alive
+      Ntcoent-Length:
+      - '4831'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '734'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <SDCGetLocationsResponse><Release>2.0</Release><CallerID>4</CallerID><SourceID>004</SourceID><MailClass>0</MailClass><OriginZIP>27703</OriginZIP><OriginCity>DURHAM</OriginCity><OriginState>NC</OriginState><DestZIP>20189</DestZIP><DestCity>DULLES</DestCity><DestState>VA</DestState><AcceptDate>2020-01-17</AcceptDate><AcceptTime>1234</AcceptTime><Expedited><EAD>0001-01-01</EAD><Commitment><MailClass>1</MailClass><CommitmentName/><CommitmentTime/><CommitmentSeq>A0</CommitmentSeq><Location><SDD>0001-01-01</SDD><COT/><FacType>POST OFFICE</FacType><Street>1100 N MIAMI BLVD</Street><City>DURHAM</City><State>NC</State><ZIP>27703</ZIP><IsGuaranteed>2</IsGuaranteed></Location><Location><SDD>0001-01-01</SDD><COT/><FacType>CONTRACT POSTAL UNIT</FacType><Street>3801 WAKE FOREST RD STE 118</Street><City>DURHAM</City><State>NC</State><ZIP>27703</ZIP><IsGuaranteed>2</IsGuaranteed></Location></Commitment><Commitment><MailClass>2</MailClass><CommitmentName>2-Day</CommitmentName><CommitmentTime/><CommitmentSeq>C0200</CommitmentSeq><Location><SDD>2020-01-19</SDD><COT>1600</COT><FacType>POST OFFICE</FacType><Street>1100 N MIAMI BLVD</Street><City>DURHAM</City><State>NC</State><ZIP>27703</ZIP><IsGuaranteed>2</IsGuaranteed></Location><Location><SDD>2020-01-19</SDD><COT>1700</COT><FacType>CONTRACT POSTAL UNIT</FacType><Street>3801 WAKE FOREST RD STE 118</Street><City>DURHAM</City><State>NC</State><ZIP>27703</ZIP><IsGuaranteed>2</IsGuaranteed></Location></Commitment><Commitment><MailClass>2</MailClass><CommitmentName>2-Day</CommitmentName><CommitmentTime/><CommitmentSeq>D0200</CommitmentSeq><Location><SDD>2020-01-22</SDD><COT>1600</COT><FacType>POST OFFICE</FacType><Street>1100 N MIAMI BLVD</Street><City>DURHAM</City><State>NC</State><ZIP>27703</ZIP><IsGuaranteed>2</IsGuaranteed></Location><Location><SDD>2020-01-22</SDD><COT>1700</COT><FacType>CONTRACT POSTAL UNIT</FacType><Street>3801 WAKE FOREST RD STE 118</Street><City>DURHAM</City><State>NC</State><ZIP>27703</ZIP><IsGuaranteed>2</IsGuaranteed></Location></Commitment></Expedited><NonExpedited><MailClass>3</MailClass><NonExpeditedDestType>1</NonExpeditedDestType><EAD>2020-01-17</EAD><COT>1820</COT><SvcStdMsg>2 Days</SvcStdMsg><SvcStdDays>2</SvcStdDays><SchedDlvryDate>2020-01-21</SchedDlvryDate></NonExpedited><NonExpedited><MailClass>3</MailClass><NonExpeditedDestType>2</NonExpeditedDestType><EAD>2020-01-17</EAD><COT>1820</COT><SvcStdMsg>2 Days</SvcStdMsg><SvcStdDays>2</SvcStdDays><SchedDlvryDate>2020-01-22</SchedDlvryDate></NonExpedited><NonExpedited><MailClass>3</MailClass><NonExpeditedDestType>3</NonExpeditedDestType><HFPU><EAD>2020-01-17</EAD><COT>1820</COT><HFPUGlobalExcept><NoHFPULocInd>1</NoHFPULocInd></HFPUGlobalExcept></HFPU></NonExpedited><NonExpedited><MailClass>4</MailClass><NonExpeditedDestType>1</NonExpeditedDestType><EAD>2020-01-17</EAD><COT>1820</COT><SvcStdMsg>7 Days</SvcStdMsg><SvcStdDays>7</SvcStdDays><SchedDlvryDate>2020-01-24</SchedDlvryDate></NonExpedited><NonExpedited><MailClass>4</MailClass><NonExpeditedDestType>2</NonExpeditedDestType><EAD>2020-01-17</EAD><COT>1820</COT><SvcStdMsg>7 Days</SvcStdMsg><SvcStdDays>7</SvcStdDays><SchedDlvryDate>2020-01-25</SchedDlvryDate></NonExpedited><NonExpedited><MailClass>4</MailClass><NonExpeditedDestType>3</NonExpeditedDestType><HFPU><EAD>2020-01-17</EAD><COT>1820</COT><HFPUGlobalExcept><NoHFPULocInd>1</NoHFPULocInd></HFPUGlobalExcept></HFPU></NonExpedited><NonExpedited><MailClass>5</MailClass><NonExpeditedDestType>1</NonExpeditedDestType><EAD>2020-01-17</EAD><COT>1820</COT><SvcStdMsg>3 Days</SvcStdMsg><SvcStdDays>3</SvcStdDays><SchedDlvryDate>2020-01-21</SchedDlvryDate></NonExpedited><NonExpedited><MailClass>5</MailClass><NonExpeditedDestType>2</NonExpeditedDestType><EAD>2020-01-17</EAD><COT>1820</COT><SvcStdMsg>3 Days</SvcStdMsg><SvcStdDays>3</SvcStdDays><SchedDlvryDate>2020-01-22</SchedDlvryDate></NonExpedited><NonExpedited><MailClass>5</MailClass><NonExpeditedDestType>3</NonExpeditedDestType><HFPU><EAD>2020-01-17</EAD><COT>1820</COT><HFPUGlobalExcept><NoHFPULocInd>1</NoHFPULocInd></HFPUGlobalExcept></HFPU></NonExpedited><NonExpedited><MailClass>6</MailClass><NonExpeditedDestType>1</NonExpeditedDestType><EAD>2020-01-17</EAD><COT>1820</COT><SvcStdMsg>5 Days</SvcStdMsg><SvcStdDays>5</SvcStdDays><SchedDlvryDate>2020-01-22</SchedDlvryDate></NonExpedited><NonExpedited><MailClass>6</MailClass><NonExpeditedDestType>2</NonExpeditedDestType><EAD>2020-01-17</EAD><COT>1820</COT><SvcStdMsg>5 Days</SvcStdMsg><SvcStdDays>5</SvcStdDays><SchedDlvryDate>2020-01-23</SchedDlvryDate></NonExpedited><NonExpedited><MailClass>6</MailClass><NonExpeditedDestType>3</NonExpeditedDestType><HFPU><EAD>2020-01-17</EAD><COT>1820</COT><HFPUGlobalExcept><NoHFPULocInd>1</NoHFPULocInd></HFPUGlobalExcept></HFPU></NonExpedited></SDCGetLocationsResponse>
+    http_version: 
+  recorded_at: Fri, 17 Jan 2020 18:34:07 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/usps/time_in_transit_response_with_invalid_commitment_seq.xml
+++ b/spec/fixtures/usps/time_in_transit_response_with_invalid_commitment_seq.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SDCGetLocationsResponse>
+  <Release>2.0</Release>
+  <CallerID>4</CallerID>
+  <SourceID>004</SourceID>
+  <MailClass>0</MailClass>
+  <OriginZIP>27703</OriginZIP>
+  <OriginCity>DURHAM</OriginCity>
+  <OriginState>NC</OriginState>
+  <DestZIP>20189</DestZIP>
+  <DestCity>DULLES</DestCity>
+  <DestState>VA</DestState>
+  <AcceptDate>2020-01-17</AcceptDate>
+  <AcceptTime>1234</AcceptTime>
+  <Expedited>
+    <EAD>0001-01-01</EAD>
+    <Commitment>
+      <MailClass>1</MailClass>
+      <CommitmentName/>
+      <CommitmentTime/>
+      <CommitmentSeq>A0</CommitmentSeq>
+      <Location>
+        <SDD>0001-01-01</SDD>
+        <COT/>
+        <FacType>POST OFFICE</FacType>
+        <Street>1100 N MIAMI BLVD</Street>
+        <City>DURHAM</City>
+        <State>NC</State>
+        <ZIP>27703</ZIP>
+        <IsGuaranteed>2</IsGuaranteed>
+      </Location>
+      <Location>
+        <SDD>0001-01-01</SDD>
+        <COT/>
+        <FacType>CONTRACT POSTAL UNIT</FacType>
+        <Street>3801 WAKE FOREST RD STE 118</Street>
+        <City>DURHAM</City>
+        <State>NC</State>
+        <ZIP>27703</ZIP>
+        <IsGuaranteed>2</IsGuaranteed>
+      </Location>
+    </Commitment>
+    <Commitment>
+      <MailClass>2</MailClass>
+      <CommitmentName>2-Day</CommitmentName>
+      <CommitmentTime/>
+      <CommitmentSeq>C0200</CommitmentSeq>
+      <Location>
+        <SDD>2020-01-19</SDD>
+        <COT>1600</COT>
+        <FacType>POST OFFICE</FacType>
+        <Street>1100 N MIAMI BLVD</Street>
+        <City>DURHAM</City>
+        <State>NC</State>
+        <ZIP>27703</ZIP>
+        <IsGuaranteed>2</IsGuaranteed>
+      </Location>
+      <Location>
+        <SDD>2020-01-19</SDD>
+        <COT>1700</COT>
+        <FacType>CONTRACT POSTAL UNIT</FacType>
+        <Street>3801 WAKE FOREST RD STE 118</Street>
+        <City>DURHAM</City>
+        <State>NC</State>
+        <ZIP>27703</ZIP>
+        <IsGuaranteed>2</IsGuaranteed>
+      </Location>
+    </Commitment>
+    <Commitment>
+      <MailClass>2</MailClass>
+      <CommitmentName>2-Day</CommitmentName>
+      <CommitmentTime/>
+      <CommitmentSeq>D0200</CommitmentSeq>
+      <Location>
+        <SDD>2020-01-22</SDD>
+        <COT>1600</COT>
+        <FacType>POST OFFICE</FacType>
+        <Street>1100 N MIAMI BLVD</Street>
+        <City>DURHAM</City>
+        <State>NC</State>
+        <ZIP>27703</ZIP>
+        <IsGuaranteed>2</IsGuaranteed>
+      </Location>
+      <Location>
+        <SDD>2020-01-22</SDD>
+        <COT>1700</COT>
+        <FacType>CONTRACT POSTAL UNIT</FacType>
+        <Street>3801 WAKE FOREST RD STE 118</Street>
+        <City>DURHAM</City>
+        <State>NC</State>
+        <ZIP>27703</ZIP>
+        <IsGuaranteed>2</IsGuaranteed>
+      </Location>
+    </Commitment>
+  </Expedited>
+  <NonExpedited>
+    <MailClass>3</MailClass>
+    <NonExpeditedDestType>1</NonExpeditedDestType>
+    <EAD>2020-01-17</EAD>
+    <COT>1820</COT>
+    <SvcStdMsg>2 Days</SvcStdMsg>
+    <SvcStdDays>2</SvcStdDays>
+    <SchedDlvryDate>2020-01-21</SchedDlvryDate>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>3</MailClass>
+    <NonExpeditedDestType>2</NonExpeditedDestType>
+    <EAD>2020-01-17</EAD>
+    <COT>1820</COT>
+    <SvcStdMsg>2 Days</SvcStdMsg>
+    <SvcStdDays>2</SvcStdDays>
+    <SchedDlvryDate>2020-01-22</SchedDlvryDate>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>3</MailClass>
+    <NonExpeditedDestType>3</NonExpeditedDestType>
+    <HFPU>
+      <EAD>2020-01-17</EAD>
+      <COT>1820</COT>
+      <HFPUGlobalExcept>
+        <NoHFPULocInd>1</NoHFPULocInd>
+      </HFPUGlobalExcept>
+    </HFPU>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>4</MailClass>
+    <NonExpeditedDestType>1</NonExpeditedDestType>
+    <EAD>2020-01-17</EAD>
+    <COT>1820</COT>
+    <SvcStdMsg>7 Days</SvcStdMsg>
+    <SvcStdDays>7</SvcStdDays>
+    <SchedDlvryDate>2020-01-24</SchedDlvryDate>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>4</MailClass>
+    <NonExpeditedDestType>2</NonExpeditedDestType>
+    <EAD>2020-01-17</EAD>
+    <COT>1820</COT>
+    <SvcStdMsg>7 Days</SvcStdMsg>
+    <SvcStdDays>7</SvcStdDays>
+    <SchedDlvryDate>2020-01-25</SchedDlvryDate>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>4</MailClass>
+    <NonExpeditedDestType>3</NonExpeditedDestType>
+    <HFPU>
+      <EAD>2020-01-17</EAD>
+      <COT>1820</COT>
+      <HFPUGlobalExcept>
+        <NoHFPULocInd>1</NoHFPULocInd>
+      </HFPUGlobalExcept>
+    </HFPU>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>5</MailClass>
+    <NonExpeditedDestType>1</NonExpeditedDestType>
+    <EAD>2020-01-17</EAD>
+    <COT>1820</COT>
+    <SvcStdMsg>3 Days</SvcStdMsg>
+    <SvcStdDays>3</SvcStdDays>
+    <SchedDlvryDate>2020-01-21</SchedDlvryDate>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>5</MailClass>
+    <NonExpeditedDestType>2</NonExpeditedDestType>
+    <EAD>2020-01-17</EAD>
+    <COT>1820</COT>
+    <SvcStdMsg>3 Days</SvcStdMsg>
+    <SvcStdDays>3</SvcStdDays>
+    <SchedDlvryDate>2020-01-22</SchedDlvryDate>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>5</MailClass>
+    <NonExpeditedDestType>3</NonExpeditedDestType>
+    <HFPU>
+      <EAD>2020-01-17</EAD>
+      <COT>1820</COT>
+      <HFPUGlobalExcept>
+        <NoHFPULocInd>1</NoHFPULocInd>
+      </HFPUGlobalExcept>
+    </HFPU>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>6</MailClass>
+    <NonExpeditedDestType>1</NonExpeditedDestType>
+    <EAD>2020-01-17</EAD>
+    <COT>1820</COT>
+    <SvcStdMsg>5 Days</SvcStdMsg>
+    <SvcStdDays>5</SvcStdDays>
+    <SchedDlvryDate>2020-01-22</SchedDlvryDate>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>6</MailClass>
+    <NonExpeditedDestType>2</NonExpeditedDestType>
+    <EAD>2020-01-17</EAD>
+    <COT>1820</COT>
+    <SvcStdMsg>5 Days</SvcStdMsg>
+    <SvcStdDays>5</SvcStdDays>
+    <SchedDlvryDate>2020-01-23</SchedDlvryDate>
+  </NonExpedited>
+  <NonExpedited>
+    <MailClass>6</MailClass>
+    <NonExpeditedDestType>3</NonExpeditedDestType>
+    <HFPU>
+      <EAD>2020-01-17</EAD>
+      <COT>1820</COT>
+      <HFPUGlobalExcept>
+        <NoHFPULocInd>1</NoHFPULocInd>
+      </HFPUGlobalExcept>
+    </HFPU>
+  </NonExpedited>
+</SDCGetLocationsResponse>

--- a/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
@@ -51,5 +51,20 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseTimeInTransitResponse do
         )
       end
     end
+
+    context 'if there is an invalid commitment sequence' do
+      let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'time_in_transit_response_with_invalid_commitment_seq.xml')).read }
+
+      it "does not break" do
+        first_rate = subject.first
+        expect(first_rate.shipping_method.name).to eq('Priority')
+        expect(first_rate.pickup).to eq(Time.new(0o001, 0o1, 0o1))
+        expect(first_rate.delivery).to eq(Time.new(2020, 0o1, 19))
+        expect(first_rate.properties).to eq(
+          commitment: '2-Day',
+          destination_type: :street
+        )
+      end
+    end
   end
 end

--- a/spec/friendly_shipping/services/usps_spec.rb
+++ b/spec/friendly_shipping/services/usps_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe FriendlyShipping::Services::Usps do
       aggregate_failures do
         is_expected.to be_success
         expect(subject.value!.data).to be_a(Array)
-        expect(subject.value!.data.first).to be_a(FriendlyShipping::Rate)
+        expect(subject.value!.data).to all(be_a(FriendlyShipping::Rate))
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe FriendlyShipping::Services::Usps do
       aggregate_failures do
         is_expected.to be_success
         expect(subject.value!.data).to be_a(Array)
-        expect(subject.value!.data.first).to be_a(FriendlyShipping::Timing)
+        expect(subject.value!.data).to all(be_a(FriendlyShipping::Timing))
       end
     end
 
@@ -86,11 +86,22 @@ RSpec.describe FriendlyShipping::Services::Usps do
         aggregate_failures do
           is_expected.to be_success
           expect(subject.value!.data).to be_a(Array)
-          expect(subject.value!.data.first).to be_a(FriendlyShipping::Timing)
-          expect(subject.value!.data.last).to be_a(FriendlyShipping::Timing)
+          expect(subject.value!.data).to all(be_a(FriendlyShipping::Timing))
           expect(subject.value!.data.last.properties[:warning]).to eq(
             "The timeliness of service to destinations outside the contiguous US may be affected by the limited availability of transportation."
           )
+        end
+      end
+    end
+
+    context 'if one mail class has an invalid commitment sequence' do
+      let(:destination) { FactoryBot.build(:physical_location, zip: '20189') }
+
+      it 'skips the invalid commitment', vcr: { cassette_name: 'usps/timings/success_with_invalid_commitment_seq' } do
+        aggregate_failures do
+          is_expected.to be_success
+          expect(subject.value!.data).to be_a(Array)
+          expect(subject.value!.data).to all(be_a(FriendlyShipping::Timing))
         end
       end
     end


### PR DESCRIPTION
Sometimes USPS returns `CommitmentSeq` elements with invalid codes. This change ensures that we just skip those commitments instead of raising an exception.