### PR TITLE
USPS: Use "Acceptance Date" if "Effective Acceptance Date" invalid

### DIFF
--- a/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
@@ -37,7 +37,11 @@ module FriendlyShipping
             return [] if expedited_commitment_nodes.empty?
 
             # All Expedited Commitments have the same acceptance date
-            effective_acceptance_date = Time.parse(expedited_commitment_nodes.at('EAD').text)
+            # However, sometimes that date is invalid.
+            effective_acceptance_date = [
+              Time.parse(expedited_commitment_nodes.at('EAD').text),
+              Time.parse(expedited_commitment_nodes.document.at('AcceptDate').text)
+            ].max
             expedited_commitment_nodes.xpath('Commitment').map do |commitment_node|
               shipping_method = SHIPPING_METHODS.detect do |potential_shipping_method|
                 potential_shipping_method.name == MAIL_CLASSES[commitment_node.at('MailClass').text]

--- a/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseTimeInTransitResponse do
       it "does not break" do
         first_rate = subject.first
         expect(first_rate.shipping_method.name).to eq('Priority')
-        expect(first_rate.pickup).to eq(Time.new(0o001, 0o1, 0o1))
-        expect(first_rate.delivery).to eq(Time.new(2020, 0o1, 19))
+        expect(first_rate.pickup).to eq(Time.new(2020, 1, 17))
+        expect(first_rate.delivery).to eq(Time.new(2020, 1, 19))
         expect(first_rate.properties).to eq(
           commitment: '2-Day',
           destination_type: :street


### PR DESCRIPTION
Sometimes, USPS returns an EAD of "0001-01-01". This is obviously bogus,
so let's use the "Acceptance Date" date USPS returns instead of the
bogus date.