### PR TITLE
Use options objects for UPS and USPS rate estimation

### DIFF
--- a/lib/friendly_shipping/services/ups.rb
+++ b/lib/friendly_shipping/services/ups.rb
@@ -20,6 +20,7 @@ require 'friendly_shipping/services/ups/parse_time_in_transit_response'
 require 'friendly_shipping/services/ups/parse_void_shipment_response'
 require 'friendly_shipping/services/ups/shipping_methods'
 require 'friendly_shipping/services/ups/label_options'
+require 'friendly_shipping/services/ups/rate_estimate_options'
 require 'friendly_shipping/services/ups/timing_options'
 
 module FriendlyShipping
@@ -63,10 +64,12 @@ module FriendlyShipping
 
       # Get rates for a shipment
       # @param [Physical::Shipment] shipment The shipment we want to get rates for
+      # @param [FriendlyShipping::Services::Ups::RateEstimateOptions] options What options
+      #    to use for this rate estimate call
       # @return [Result<ApiResult<Array<Rate>>>] The rates returned from UPS encoded in a
       #   `FriendlyShipping::ApiResult` object.
-      def rate_estimates(shipment, debug: false)
-        rate_request_xml = SerializeRatingServiceSelectionRequest.call(shipment: shipment)
+      def rate_estimates(shipment, options:, debug: false)
+        rate_request_xml = SerializeRatingServiceSelectionRequest.call(shipment: shipment, options: options)
         url = base_url + RESOURCES[:rates]
         request = FriendlyShipping::Request.new(
           url: url,

--- a/lib/friendly_shipping/services/ups/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/ups/rate_estimate_options.rb
@@ -69,7 +69,7 @@ module FriendlyShipping
           shipper: nil,
           shipping_method: nil,
           with_time_in_transit: false,
-          package_options_class: RateEstimatePackageOptions,
+          package_options_class: FriendlyShipping::Services::Ups::RateEstimatePackageOptions,
           **kwargs
         )
           @carbon_neutral = carbon_neutral

--- a/lib/friendly_shipping/services/ups/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/ups/rate_estimate_options.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/ups/rate_estimate_package_options'
+
+module FriendlyShipping
+  module Services
+    # Option container for rating a shipment via UPS
+    #
+    # Required:
+    #
+    # @option shipper_number [String] The shipper number of the origin of the shipment.
+    #
+    # Optional:
+    #
+    # @option carbon_neutral [Boolean] Ship with UPS' carbon neutral program
+    # @option customer_context [String ] Optional element to identify transactions between client and server
+    # @option customer_classification [Symbol] Which kind of rates to request. See UPS docs for more details. Default: `shipper_number`
+    # @option negotiated_rates [Boolean] if truthy negotiated rates will be requested from ups. Only valid if
+    #   shipper account has negotiated rates. Default: false
+    # @option saturday_delivery [Boolean] should we request Saturday delivery?. Default: false
+    # @option saturday_pickup [Boolean] should we request Saturday pickup?. Default: false
+    # @option shipping_method [FriendlyShipping::ShippingMethod] Request rates for a particular shipping method only?
+    #   Default is `nil`, which translates to 'All shipping methods' (The "Shop" option in UPS parlance)
+    # @option with_time_in_transit [Boolean] Whether to request timing information alongside the rates
+    # @option package_options_class [Class] See FriendlyShipping::ShipmentOptions
+    #
+    class Ups
+      class RateEstimateOptions < FriendlyShipping::ShipmentOptions
+        PICKUP_TYPE_CODES = {
+          daily_pickup: "01",
+          customer_counter: "03",
+          one_time_pickup: "06",
+          on_call_air: "07",
+          suggested_retail_rates: "11",
+          letter_center: "19",
+          air_service_center: "20"
+        }.freeze
+
+        CUSTOMER_CLASSIFICATION_CODES = {
+          shipper_number: "00",
+          daily_rates: "01",
+          retail_rates: "04",
+          regional_rates: "05",
+          general_rates: "06",
+          standard_rates: "53"
+        }.freeze
+
+        attr_reader :carbon_neutral,
+                    :customer_context,
+                    :destination_account,
+                    :negotiated_rates,
+                    :saturday_delivery,
+                    :saturday_pickup,
+                    :shipper,
+                    :shipper_number,
+                    :shipping_method,
+                    :with_time_in_transit
+
+        def initialize(
+          shipper_number:,
+          carbon_neutral: true,
+          customer_context: nil,
+          customer_classification: :daily_rates,
+          destination_account: nil,
+          negotiated_rates: false,
+          pickup_type: :daily_pickup,
+          saturday_delivery: false,
+          saturday_pickup: false,
+          shipper: nil,
+          shipping_method: nil,
+          with_time_in_transit: false,
+          package_options_class: RateEstimatePackageOptions,
+          **kwargs
+        )
+          @carbon_neutral = carbon_neutral
+          @customer_context = customer_context
+          @customer_classification = customer_classification
+          @destination_account = destination_account
+          @negotiated_rates = negotiated_rates
+          @shipper_number = shipper_number
+          @pickup_type = pickup_type
+          @saturday_delivery = saturday_delivery
+          @saturday_pickup = saturday_pickup
+          @shipper = shipper
+          @shipping_method = shipping_method
+          @with_time_in_transit = with_time_in_transit
+          super kwargs.merge(package_options_class: package_options_class)
+        end
+
+        def pickup_type_code
+          PICKUP_TYPE_CODES[@pickup_type]
+        end
+
+        def customer_classification_code
+          CUSTOMER_CLASSIFICATION_CODES[@customer_classification]
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/ups/rate_estimate_package_options.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/ups/label_item_options'
+
+module FriendlyShipping
+  module Services
+    class Ups
+      # Package properties relevant for quoting a UPS package
+      #
+      # @option transmit_dimensions [Boolean] Whether to transmit the dimensions of this package, or quote only based on weight.
+      class RateEstimatePackageOptions < FriendlyShipping::PackageOptions
+        attr_reader :transmit_dimensions
+
+        def initialize(
+          transmit_dimensions: true,
+          **kwargs
+        )
+          @transmit_dimensions = transmit_dimensions
+          super kwargs
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups/serialize_package_node.rb
+++ b/lib/friendly_shipping/services/ups/serialize_package_node.rb
@@ -9,7 +9,8 @@ module FriendlyShipping
           package:,
           reference_numbers: {},
           delivery_confirmation_code: nil,
-          shipper_release: false
+          shipper_release: false,
+          transmit_dimensions: true
         )
           xml.Package do
             xml.PackagingType do
@@ -20,7 +21,7 @@ module FriendlyShipping
               xml.Description(package.items.map(&:description).compact.join(', '))
             end
 
-            if package.dimensions.all? { |dim| !dim.value.zero? && !dim.value.infinite? }
+            if transmit_dimensions && package.dimensions.all? { |dim| !dim.value.zero? && !dim.value.infinite? }
               xml.Dimensions do
                 xml.UnitOfMeasurement do
                   xml.Code('IN')

--- a/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
@@ -8,47 +8,30 @@ module FriendlyShipping
   module Services
     class Ups
       class SerializeRatingServiceSelectionRequest
-        PICKUP_CODES = HashWithIndifferentAccess.new(
-          daily_pickup: "01",
-          customer_counter: "03",
-          one_time_pickup: "06",
-          on_call_air: "07",
-          suggested_retail_rates: "11",
-          letter_center: "19",
-          air_service_center: "20"
-        )
-
-        CUSTOMER_CLASSIFICATIONS = HashWithIndifferentAccess.new(
-          shipper_number: "00",
-          daily_rates: "01",
-          retail_rates: "04",
-          regional_rates: "05",
-          general_rates: "06",
-          standard_rates: "53"
-        )
-
-        def self.call(shipment:)
-          shipper = shipment.options[:shipper] || shipment.origin
-          pickup_type = PICKUP_CODES[shipment.options[:pickup_type] || :daily_pickup]
-          customer_classification = CUSTOMER_CLASSIFICATIONS[
-            shipment.options[:customer_classification] || :daily_rates
-          ]
-          origin_account = shipment.options[:origin_account]
-          destination_account = shipment.options[:destination_account]
+        def self.call(shipment:, options:)
+          shipper = options.shipper || shipment.origin
 
           xml_builder = Nokogiri::XML::Builder.new do |xml|
             xml.RatingServiceSelectionRequest do
               xml.Request do
                 xml.RequestAction('Rate')
-                xml.RequestOption('Shop')
+                # If no shipping method is given, request all of them
+                # I one is given, omit the request option. It then becomes "Rate", the default.
+                xml.RequestOption('Shop') unless options.shipping_method
                 xml.SubVersion('1707')
+                # Optional element to identify transactions between client and server.
+                if options.customer_context
+                  xml.TransactionReference do
+                    xml.CustomerContext(options.customer_context)
+                  end
+                end
               end
 
               xml.PickupType do
-                xml.Code(pickup_type)
+                xml.Code(options.pickup_type_code)
               end
               xml.CustomerClassification do
-                xml.Code(customer_classification)
+                xml.Code(options.customer_classification_code)
               end
 
               xml.Shipment do
@@ -56,14 +39,14 @@ module FriendlyShipping
                 xml.Shipper do
                   SerializeAddressSnippet.call(xml: xml, location: shipper)
 
-                  xml.ShipperNumber(origin_account)
+                  xml.ShipperNumber(options.shipper_number)
                 end
 
                 xml.ShipTo do
                   SerializeAddressSnippet.call(xml: xml, location: shipment.destination)
 
-                  if destination_account
-                    xml.ShipperAssignedIdentificationNumber(destination_account)
+                  if options.destination_account
+                    xml.ShipperAssignedIdentificationNumber(options.destination_account)
                   end
                 end
 
@@ -75,6 +58,22 @@ module FriendlyShipping
 
                 shipment.packages.each do |package|
                   SerializePackageNode.call(xml: xml, package: package)
+                end
+
+                if options.shipping_method
+                  xml.Service do
+                    xml.Code options.shipping_method.service_code
+                  end
+                end
+
+                xml.ShipmentServiceOptions do
+                  xml.UPScarbonneutralIndicator if options.carbon_neutral
+                  xml.SaturdayDelivery if options.saturday_delivery
+                  xml.SaturdayPickup if options.saturday_pickup
+                end
+
+                xml.RateInformation do
+                  xml.NegotiatedRatesIndicator if options.negotiated_rates
                 end
               end
             end

--- a/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
@@ -57,7 +57,12 @@ module FriendlyShipping
                 end
 
                 shipment.packages.each do |package|
-                  SerializePackageNode.call(xml: xml, package: package)
+                  package_options = options.options_for_package(package)
+                  SerializePackageNode.call(
+                    xml: xml,
+                    package: package,
+                    transmit_dimensions: package_options.transmit_dimensions
+                  )
                 end
 
                 if options.shipping_method

--- a/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
@@ -77,8 +77,10 @@ module FriendlyShipping
                   xml.SaturdayPickup if options.saturday_pickup
                 end
 
-                xml.RateInformation do
-                  xml.NegotiatedRatesIndicator if options.negotiated_rates
+                if options.negotiated_rates
+                  xml.RateInformation do
+                    xml.NegotiatedRatesIndicator if options.negotiated_rates
+                  end
                 end
               end
             end

--- a/lib/friendly_shipping/services/usps/choose_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/choose_package_rate.rb
@@ -16,19 +16,18 @@ module FriendlyShipping
         # @param [Array<FriendlyShipping::Rate>] The rates we select from
         #
         # @return [FriendlyShipping::Rate] The rate that most closely matches our package
-        def self.call(shipping_method, package, rates)
+        def self.call(shipping_method, rates, package_options)
           # Keep all rates with the requested shipping method
           rates_with_this_shipping_method = rates.select { |r| r.shipping_method == shipping_method }
 
           # Keep only rates with the package type of this package
           rates_with_this_package_type = rates_with_this_shipping_method.select do |r|
-            r.data[:box_name] == package.properties[:box_name] ||
-              r.data[:box_name] == :flat_rate_boxes && package.properties[:box_name]&.match?(FLAT_RATE_BOX)
+            r.data[:box_name] == package_options.box_name
           end
 
           # Filter by our package's `hold_for_pickup` option
           rates_with_this_hold_for_pickup_option = rates_with_this_package_type.select do |r|
-            r.data[:hold_for_pickup] == !!package.properties[:hold_for_pickup]
+            r.data[:hold_for_pickup] == package_options.hold_for_pickup
           end
 
           # At this point, we have one or two rates left, and they're similar enough.

--- a/lib/friendly_shipping/services/usps/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_rate_response.rb
@@ -16,20 +16,24 @@ module FriendlyShipping
           # @param [FriendlyShipping::Request] request The request that was used to obtain this Response
           # @param [FriendlyShipping::Response] response The response that USPS returned
           # @param [Physical::Shipment] shipment The shipment object we're trying to get results for
+          # @param [FriendlyShipping::Services::Usps::RateEstimateOptions] options The options we sent with this request
           # @return [Result<ApiResult<Array<FriendlyShipping::Rate>>>] When successfully parsing, an array of rates in a Success Monad.
-          def call(request:, response:, shipment:)
+          def call(request:, response:, shipment:, options:)
             # Filter out error responses and directly return a failure
             parsing_result = ParseXMLResponse.call(response.body, 'RateV4Response')
             rates = []
             parsing_result.fmap do |xml|
               # Get all the possible rates for each package
-              rates_by_package = rates_from_response_node(xml, shipment)
+              rates_by_package = rates_from_response_node(xml, shipment, options)
 
               rates = SHIPPING_METHODS.map do |shipping_method|
                 # For every package ...
                 matching_rates = rates_by_package.map do |package, package_rates|
                   # ... choose the rate that fits this package best.
-                  ChoosePackageRate.call(shipping_method, package, package_rates)
+
+                  package_options = options.options_for_package(package)
+
+                  ChoosePackageRate.call(shipping_method, package_rates, package_options)
                 end.compact # Some shipping rates are not available for every shipping method.
 
                 # in this case, go to the next shipping method.
@@ -62,17 +66,17 @@ module FriendlyShipping
           # @param [Physical::Shipment] shipment The shipment we're trying to get rates for
           #
           # @return [Hash<Physical::Package => Array<FriendlyShipping::Rate>>]
-          def rates_from_response_node(xml, shipment)
+          def rates_from_response_node(xml, shipment, options)
             xml.xpath(PACKAGE_NODE_XPATH).each_with_object({}) do |package_node, result|
               package_id = package_node['ID']
               corresponding_package = shipment.packages[package_id.to_i]
-
+              package_options = options.options_for_package(corresponding_package)
               # There should always be a package in the original shipment that corresponds to the package ID
               # in the USPS response.
               raise BoxNotFoundError if corresponding_package.nil?
 
               result[corresponding_package] = package_node.xpath(SERVICE_NODE_NAME).map do |service_node|
-                ParsePackageRate.call(service_node, corresponding_package)
+                ParsePackageRate.call(service_node, corresponding_package, package_options)
               end
             end
           end

--- a/lib/friendly_shipping/services/usps/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_options.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/usps/rate_estimate_package_options'
+
+module FriendlyShipping
+  module Services
+    # Option container for rating a shipment via USPS
+    #
+    # Context: The shipment object we're trying to get results for
+    # USPS returns rates on a package-by-package basis, so the options for obtaining rates are
+    # set on the [FriendlyShipping/RateEstimateobect] hash. The possible options are:
+
+    # @param [Physical::ShippingMethod] shipping_method The shipping method ("service" in USPS parlance) we want
+    #   to get rates for.
+    # @param [Boolean] commercial_pricing Whether we prefer commercial pricing results or retail results
+    # @param [Boolean] hold_for_pickup Whether we want a rate with Hold For Pickup Service
+    class Usps
+      class RateEstimateOptions < FriendlyShipping::ShipmentOptions
+        def initialize(
+          package_options_class: FriendlyShipping::Services::Usps::RateEstimatePackageOptions,
+          **kwargs
+        )
+          super kwargs.merge(package_options_class: package_options_class)
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
@@ -14,7 +14,8 @@ module FriendlyShipping
                     :commercial_pricing,
                     :first_class_mail_type,
                     :hold_for_pickup,
-                    :shipping_method
+                    :shipping_method,
+                    :transmit_dimensions
 
         def initialize(
           box_name: :variable,
@@ -22,6 +23,7 @@ module FriendlyShipping
           first_class_mail_type: nil,
           hold_for_pickup: false,
           shipping_method: nil,
+          transmit_dimensions: true,
           **kwargs
         )
           @box_name = CONTAINERS.key?(box_name) ? box_name : :variable
@@ -29,6 +31,7 @@ module FriendlyShipping
           @first_class_mail_type = first_class_mail_type
           @hold_for_pickup = hold_for_pickup
           @shipping_method = shipping_method
+          @transmit_dimensions = transmit_dimensions
           super kwargs
         end
 

--- a/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/ups/rate_estimate_package_options'
+
+module FriendlyShipping
+  module Services
+    # Options for one package when rating
+    #
+    # @param [Symbol] box_name The type of box we want to get rates for. Has to be one of the keys
+    #  of FriendlyShipping::Services::Usps::CONTAINERS.
+    class Usps
+      class RateEstimatePackageOptions < FriendlyShipping::PackageOptions
+        attr_reader :box_name,
+                    :commercial_pricing,
+                    :first_class_mail_type,
+                    :hold_for_pickup,
+                    :shipping_method
+
+        def initialize(
+          box_name: :variable,
+          commercial_pricing: false,
+          first_class_mail_type: nil,
+          hold_for_pickup: false,
+          shipping_method: nil,
+          **kwargs
+        )
+          @box_name = CONTAINERS.key?(box_name) ? box_name : :variable
+          @commercial_pricing = commercial_pricing
+          @first_class_mail_type = first_class_mail_type
+          @hold_for_pickup = hold_for_pickup
+          @shipping_method = shipping_method
+          super kwargs
+        end
+
+        def container_code
+          CONTAINERS.fetch(box_name)
+        end
+
+        def first_class_mail_type_code
+          FIRST_CLASS_MAIL_TYPES[first_class_mail_type]
+        end
+
+        def service_code
+          return 'ALL' unless shipping_method
+
+          if commercial_pricing
+            "#{shipping_method.service_code} COMMERCIAL"
+          else
+            shipping_method.service_code
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -33,7 +33,7 @@ module FriendlyShipping
                     size_code = size_code_for(package)
                     xml.Container(package_options.container_code)
                     xml.Size(size_code)
-                    if package_options.container_code == 'VARIABLE'
+                    if package_options.transmit_dimensions && package_options.container_code == 'VARIABLE'
                       xml.Width("%<width>0.2f" % { width: package.width.convert_to(:inches).value.to_f })
                       xml.Length("%<length>0.2f" % { length: package.length.convert_to(:inches).value.to_f })
                       xml.Height("%<height>0.2f" % { height: package.height.convert_to(:inches).value.to_f })

--- a/spec/friendly_shipping/services/ups/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/rate_estimate_package_options_spec.rb
@@ -11,4 +11,10 @@ RSpec.describe FriendlyShipping::Services::Ups::RateEstimatePackageOptions do
   ].each do |message|
     it { is_expected.to respond_to(message) }
   end
+
+  describe 'package_id' do
+    subject { options.package_id }
+
+    it { is_expected.to eq('my_package_id') }
+  end
 end

--- a/spec/friendly_shipping/services/ups/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/rate_estimate_package_options_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ups/rate_estimate_package_options'
+
+RSpec.describe FriendlyShipping::Services::Ups::RateEstimatePackageOptions do
+  subject(:options) { described_class.new(package_id: 'my_package_id') }
+
+  [
+    :transmit_dimensions
+  ].each do |message|
+    it { is_expected.to respond_to(message) }
+  end
+end

--- a/spec/friendly_shipping/services/ups/rate_estimates_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/rate_estimates_options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ups/rate_estimate_options'
+
+RSpec.describe FriendlyShipping::Services::Ups::RateEstimateOptions do
+  subject(:options) { described_class.new(shipper_number: 'SECRET') }
+  [
+    :carbon_neutral,
+    :customer_context,
+    :destination_account,
+    :negotiated_rates,
+    :saturday_delivery,
+    :saturday_pickup,
+    :shipper,
+    :shipper_number,
+    :shipping_method,
+    :with_time_in_transit
+  ].each do |message|
+    it { is_expected.to respond_to(message) }
+  end
+
+  describe '#options_for_package' do
+    subject { options.options_for_package(double(package_id: 'my_package_id')) }
+
+    it { is_expected.to be_a(FriendlyShipping::Services::Ups::RateEstimatePackageOptions) }
+  end
+
+  describe '#pickup_type_code' do
+    subject { options.pickup_type_code }
+
+    it { is_expected.to eq('01') }
+  end
+
+  describe '#customer_classification_code' do
+    subject { options.pickup_type_code }
+
+    it { is_expected.to eq('01') }
+  end
+end

--- a/spec/friendly_shipping/services/ups/serialize_package_node_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_package_node_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializePackageNode do
         expect(subject.at_xpath('//Package/Dimensions')).not_to be_present
       end
     end
+
+    context 'if serializer is told to not transmit dimensions' do
+      subject(:context) do
+        Nokogiri::XML::Builder.new do |xml|
+          described_class.call(xml: xml, package: package, transmit_dimensions: false)
+        end.doc
+      end
+
+      it 'does not add dimensions' do
+        expect(subject.at_xpath('//Package/Dimensions')).not_to be_present
+      end
+    end
   end
 
   context 'if package has reference numbers' do

--- a/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'friendly_shipping/services/ups/rate_estimate_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionRequest do
   let(:origin) { FactoryBot.build(:physical_location) }
@@ -27,16 +28,17 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
     Physical::Shipment.new(
       origin: origin,
       destination: destination,
-      packages: [package],
-      options: options
+      packages: [package]
     )
   end
 
-  let(:options) { { origin_account: "12345" } }
+  let(:options) do
+    FriendlyShipping::Services::Ups::RateEstimateOptions.new(shipper_number: "12345")
+  end
 
   subject do
     Nokogiri::XML(
-      described_class.call(shipment: shipment)
+      described_class.call(shipment: shipment, options: options)
     )
   end
 
@@ -67,7 +69,12 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
   end
 
   context 'with a different shipper' do
-    let(:options) { { shipper: FactoryBot.build(:physical_location, address1: "Another Street") } }
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        shipper: FactoryBot.build(:physical_location, address1: "Another Street")
+      )
+    end
 
     it 'contains an extra ShipFrom element' do
       aggregate_failures do
@@ -83,12 +90,123 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
   end
 
   context 'with a destination account' do
-    let(:options) { { destination_account: '98765' } }
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        destination_account: '98765'
+      )
+    end
 
     it 'contains a ShipperAssignedIdentificationNumber element' do
       expect(
         subject.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipTo/ShipperAssignedIdentificationNumber').text
       ).to eq('98765')
+    end
+  end
+
+  context 'with carbon_neutral set to true' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        carbon_neutral: true
+      )
+    end
+
+    it 'contains a UPScarbonneutralIndicator element' do
+      expect(
+        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/ShipmentServiceOptions/UPScarbonneutralIndicator')
+      ).to be_present
+    end
+  end
+
+  context 'with a customer context given' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        customer_context: 'MYORDER!!'
+      )
+    end
+
+    it 'contains a CustomerContext element' do
+      expect(
+        subject.at_xpath('/RatingServiceSelectionRequest/Request/TransactionReference/CustomerContext').text
+      ).to eq('MYORDER!!')
+    end
+  end
+
+  context 'with a special customer classification given' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        customer_classification: :regional_rates
+      )
+    end
+
+    it 'contains the right option' do
+      expect(
+        subject.at_xpath('/RatingServiceSelectionRequest/CustomerClassification/Code').text
+      ).to eq('05')
+    end
+  end
+
+  context 'with negotiated rates set to true' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        negotiated_rates: true
+      )
+    end
+
+    it 'contains the right option' do
+      expect(
+        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/RateInformation/NegotiatedRatesIndicator')
+      ).to be_present
+    end
+  end
+
+  context 'with saturday delivery requested' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        saturday_delivery: true
+      )
+    end
+
+    it 'contains the right option' do
+      expect(
+        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/ShipmentServiceOptions/SaturdayDelivery')
+      ).to be_present
+    end
+  end
+
+  context 'with saturday pickup requested' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        saturday_pickup: true
+      )
+    end
+
+    it 'contains the right option' do
+      expect(
+        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/ShipmentServiceOptions/SaturdayPickup')
+      ).to be_present
+    end
+  end
+
+  context 'with a shipping method requested' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        shipping_method: FriendlyShipping::ShippingMethod.new(service_code: 44)
+      )
+    end
+
+    it 'contains the right option' do
+      expect(subject.at_xpath('/RatingServiceSelectionRequest/Request/RequestOption')).not_to be_present
+      expect(
+        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/Service/Code').text
+      ).to eq('44')
     end
   end
 end

--- a/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
   end
   let(:package) do
     Physical::Package.new(
+      id: "my_id_one",
       container: Physical::Box.new(
         weight: Measured::Weight.new(5, :pounds),
         dimensions: dimensions
@@ -60,6 +61,8 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
       ).not_to be_present
       expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipFrom')).not_to be_present
       expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package')).to be_present
+      expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/Dimensions')).to be_present
+
       expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/PackagingType/Code').text).to eq('02')
       expect(
         subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/PackageWeight/UnitOfMeasurement/Code').text
@@ -207,6 +210,24 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
       expect(
         subject.at_xpath('/RatingServiceSelectionRequest/Shipment/Service/Code').text
       ).to eq('44')
+    end
+  end
+
+  context 'when `transmit_dimensions` is set to false' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        shipper_number: "12345",
+        package_options: [
+          FriendlyShipping::Services::Ups::RateEstimatePackageOptions.new(
+            package_id: package.id,
+            transmit_dimensions: false
+          )
+        ]
+      )
+    end
+
+    it 'does not transmit dimensions' do
+      expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/Dimensions')).not_to be_present
     end
   end
 end

--- a/spec/friendly_shipping/services/ups_spec.rb
+++ b/spec/friendly_shipping/services/ups_spec.rb
@@ -32,7 +32,11 @@ RSpec.describe FriendlyShipping::Services::Ups do
     let(:origin) { FactoryBot.build(:physical_location, region: "NC", zip: '27703') }
     let(:shipment) { FactoryBot.build(:physical_shipment, origin: origin, destination: destination) }
 
-    subject { service.rate_estimates(shipment) }
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(shipper_number: "12345")
+    end
+
+    subject { service.rate_estimates(shipment, options: options) }
 
     it 'returns Physical::Rate objects wrapped in a Success Monad', vcr: { cassette_name: 'ups/rate_estimates/success' } do
       aggregate_failures do

--- a/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
@@ -9,8 +9,12 @@ RSpec.describe FriendlyShipping::Services::Usps::ParsePackageRate do
   let(:commercial_rate) { nil }
   let(:commercial_plus_rate) { nil }
   let(:class_id) { '0' }
-
-  subject { described_class.call(node, package) }
+  let(:package_options) do
+    FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+      package_id: package.id
+    )
+  end
+  subject { described_class.call(node, package, package_options) }
 
   let(:node) do
     serialized = Nokogiri::XML::Builder.new do |xml|

--- a/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
@@ -12,8 +12,16 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseRateResponse do
     ]
   end
   let(:shipment) { FactoryBot.build(:physical_shipment, packages: packages) }
-
-  subject { described_class.call(request: request, response: response, shipment: shipment) }
+  let(:options) do
+    FriendlyShipping::Services::Usps::RateEstimateOptions.new(
+      package_options: shipment.packages.map do |package|
+        FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+          package_id: package.id
+        )
+      end
+    )
+  end
+  subject { described_class.call(request: request, response: response, shipment: shipment, options: options) }
 
   it { is_expected.to be_success }
 
@@ -34,10 +42,19 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseRateResponse do
     let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'rates_api_response_regional_single.xml')).read }
     let(:packages) do
       [
-        FactoryBot.build(:physical_package, id: '0', container: container),
+        FactoryBot.build(:physical_package, id: '0'),
       ]
     end
-    let(:container) { FactoryBot.build(:physical_box, properties: { box_name: :regional_rate_box_b } ) }
+    let(:options) do
+      FriendlyShipping::Services::Usps::RateEstimateOptions.new(
+        package_options: shipment.packages.map do |package|
+          FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+            package_id: package.id,
+            box_name: :regional_rate_box_b
+          )
+        end
+      )
+    end
 
     it 'returns regional rate' do
       expect(subject).to be_success
@@ -57,6 +74,16 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseRateResponse do
     end
     let(:regional_rate_box_a) { FactoryBot.build(:physical_box, properties: { box_name: :regional_rate_box_a } ) }
     let(:regional_rate_box_b) { FactoryBot.build(:physical_box, properties: { box_name: :regional_rate_box_b } ) }
+    let(:options) do
+      FriendlyShipping::Services::Usps::RateEstimateOptions.new(
+        package_options: shipment.packages.map do |package|
+          FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+            package_id: package.id,
+            box_name: package.properties[:box_name]
+          )
+        end
+      )
+    end
 
     it 'returns regional rates' do
       expect(subject).to be_success
@@ -73,10 +100,20 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseRateResponse do
     let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'rates_api_response_large_box.xml')).read }
     let(:packages) do
       [
-        FactoryBot.build(:physical_package, id: '0', container: container),
+        FactoryBot.build(:physical_package, id: '0'),
       ]
     end
-    let(:container) { FactoryBot.build(:physical_box, properties: { box_name: :large_flat_rate_box, commercial_pricing: true } ) }
+    let(:options) do
+      FriendlyShipping::Services::Usps::RateEstimateOptions.new(
+        package_options: shipment.packages.map do |package|
+          FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+            package_id: package.id,
+            box_name: :large_flat_rate_box,
+            commercial_pricing: true
+          )
+        end
+      )
+    end
 
     it 'returns flat rate' do
       expect(subject).to be_success

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
     :box_name,
     :commercial_pricing,
     :hold_for_pickup,
-    :shipping_method
+    :shipping_method,
+    :transmit_dimensions
   ].each do |message|
     it { is_expected.to respond_to(message) }
   end

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/usps/rate_estimate_package_options'
+
+RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
+  subject(:options) { described_class.new(package_id: 'my_package_id') }
+
+  [
+    :box_name,
+    :commercial_pricing,
+    :hold_for_pickup,
+    :shipping_method
+  ].each do |message|
+    it { is_expected.to respond_to(message) }
+  end
+
+  describe 'box_name' do
+    context 'when setting it to something that is no USPS box' do
+      subject(:options) do
+        described_class.new(
+          package_id: 'my_package_id',
+          box_name: :package
+        )
+      end
+
+      it 'become "variable"' do
+        expect(subject.box_name).to eq(:variable)
+      end
+    end
+  end
+end

--- a/spec/friendly_shipping/services/usps/rate_estimates_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimates_options_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/usps/rate_estimate_options'
+
+RSpec.describe FriendlyShipping::Services::Usps::RateEstimateOptions do
+  let(:options) { described_class.new }
+  describe '#options_for_package' do
+    subject { options.options_for_package(double(package_id: 'my_package_id')) }
+
+    it { is_expected.to be_a(FriendlyShipping::Services::Usps::RateEstimatePackageOptions) }
+  end
+end

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -120,4 +120,20 @@ RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
       expect(node.at_xpath('Size').text).to eq('LARGE')
     end
   end
+
+  context 'with transmit_dimensions set to false' do
+    let(:package_options) do
+      FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+        package_id: package.id,
+        transmit_dimensions: false
+      )
+    end
+
+    it 'does not transmit dimensions' do
+      expect(node.at_xpath('Width')).to be nil
+      expect(node.at_xpath('Length')).to be nil
+      expect(node.at_xpath('Height')).to be nil
+      expect(node.at_xpath('Girth')).to be nil
+    end
+  end
 end


### PR DESCRIPTION
This changes the method signatures of the `rate_estimates` methods on the UPS and USPS services to allow more complex option objects. Now, we can use the same `Physical::Shipment` object for calls to both services, and only have to generate an objects object for them. This is a pattern already implement for ShipEngine and UPS Freight, as well as on e.g. the `timing` methods on all services. 

Adding to this refactoring, we can now specify on a package level whether we want to transmit dimensions or not.