### PR TITLE
Bump Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.4
+       - image: circleci/ruby:2.5
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 inherit_from:
 - .rubocop-relaxed.yml

--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "nokogiri", ">= 1.6"
   spec.add_runtime_dependency "physical", ">= 0.4.4"
   spec.add_runtime_dependency "rest-client", "~> 2.0"
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "dotenv"


### PR DESCRIPTION
Recent versions of ActiveSupport will not run with Ruby 2.4, thus making
our test suite fail.
See https://circleci.com/gh/friendlycart/friendly_shipping/306