### PR TITLE
Rename "First-Class Package Service" to "Package Services"

### DIFF
--- a/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
@@ -113,7 +113,7 @@ module FriendlyShipping
             '1' => 'Priority Mail Express',
             '2' => 'Priority',
             '3' => 'First-Class',
-            '6' => 'First-Class Package Service'
+            '6' => 'Package Services'
           }.freeze
 
           # This code carries a few details about the shipment:

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -26,7 +26,8 @@ module FriendlyShipping
         flat: 'FLAT',
         parcel: 'PARCEL',
         post_card: 'POSTCARD',
-        package_service: 'PACKAGE SERVICE'
+        package_service: 'PACKAGE SERVICE',
+        package_service_retail: 'PACKAGE SERVICE RETAIL'
       }.freeze
 
       SHIPPING_METHODS = [

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -26,7 +26,7 @@ module FriendlyShipping
         flat: 'FLAT',
         parcel: 'PARCEL',
         post_card: 'POSTCARD',
-        package_service: 'PACKAGESERVICE'
+        package_service: 'PACKAGE SERVICE'
       }.freeze
 
       SHIPPING_METHODS = [

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -31,7 +31,7 @@ module FriendlyShipping
 
       SHIPPING_METHODS = [
         'First-Class',
-        'First-Class Package Service',
+        'Package Services',
         'Priority',
         'Priority Mail Express',
         'Standard Post',

--- a/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseRateResponse do
       276, 673, 715, 3660
     ].map { |cents| Money.new(cents, 'USD') })
     expect(subject.value!.data.map(&:shipping_method).map(&:name)).to contain_exactly(
-      "First-Class Package Service",
+      "First-Class",
       "Priority",
       "Priority Mail Express",
       "Standard Post"

--- a/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseTimeInTransitResponse do
         commitment: '1-Day'
       )
       last_rate = subject.last
-      expect(last_rate.shipping_method.name).to eq('First-Class Package Service')
+      expect(last_rate.shipping_method.name).to eq('Package Services')
       expect(last_rate.pickup).to eq(Time.new(2019, 12, 0o3))
       expect(last_rate.delivery).to eq(Time.new(2019, 12, 0o5))
       expect(last_rate.properties).to eq(
@@ -42,7 +42,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseTimeInTransitResponse do
 
       it "does not break" do
         last_rate = subject.last
-        expect(last_rate.shipping_method.name).to eq('First-Class Package Service')
+        expect(last_rate.shipping_method.name).to eq('Package Services')
         expect(last_rate.pickup).to eq(Time.new(2019, 12, 0o3))
         expect(last_rate.delivery).to eq(Time.new(2019, 12, 0o5))
         expect(last_rate.properties).to eq(


### PR DESCRIPTION
The correct name for this mail class is simply "Package Services." After doing some research on the USPS web site, I realized that the "Package Services" mail class actually encapsulates USPS Retail Ground, Media Mail, and a few other oddball shipping methods. It doesn't appear to have anything to do with First Class shipping, therefore the words "First-Class" shouldn't be in the name.

This rename also fixes a bug where USPS rate responses that included both FC and Package Services quotes would assign the FC quote to the Package Services shipping method since that shipping method had the words "First-Class" in it but had a longer name than just "First-Class."