### PR TITLE
Add readable request bodies

### DIFF
--- a/lib/friendly_shipping/request.rb
+++ b/lib/friendly_shipping/request.rb
@@ -6,13 +6,19 @@ module FriendlyShipping
 
     # @param [String] url The HTTP request URL
     # @param [String] body The HTTP request body
+    # # @param [String] readable_body Human-readable HTTP request body
     # @param [Hash] headers The HTTP request headers
     # @param [Boolean] debug Whether to debug the request
-    def initialize(url:, body: nil, headers: {}, debug: false)
+    def initialize(url:, body: nil, readable_body: nil, headers: {}, debug: false)
       @url = url
       @body = body
+      @readable_body = readable_body
       @headers = headers
       @debug = debug
+    end
+
+    def readable_body
+      @readable_body.presence || @body
     end
   end
 end

--- a/lib/friendly_shipping/services/ups.rb
+++ b/lib/friendly_shipping/services/ups.rb
@@ -74,6 +74,7 @@ module FriendlyShipping
         request = FriendlyShipping::Request.new(
           url: url,
           body: access_request_xml + rate_request_xml,
+          readable_body: rate_request_xml,
           debug: debug
         )
 
@@ -95,6 +96,7 @@ module FriendlyShipping
         request = FriendlyShipping::Request.new(
           url: time_in_transit_url,
           body: access_request_xml + time_in_transit_request_xml,
+          readable_body: time_in_transit_request_xml,
           debug: debug
         )
 
@@ -114,6 +116,7 @@ module FriendlyShipping
         ship_confirm_request = FriendlyShipping::Request.new(
           url: ship_confirm_url,
           body: access_request_xml + ship_confirm_request_xml,
+          readable_body: ship_confirm_request_xml,
           debug: debug
         )
 
@@ -132,6 +135,7 @@ module FriendlyShipping
           ship_accept_request = FriendlyShipping::Request.new(
             url: ship_accept_url,
             body: access_request_xml + ship_accept_request_xml,
+            readable_body: ship_accept_request_xml,
             debug: debug
           )
 
@@ -153,6 +157,7 @@ module FriendlyShipping
         request = FriendlyShipping::Request.new(
           url: url,
           body: access_request_xml + address_validation_request_xml,
+          readable_body: address_validation_request_xml,
           debug: debug
         )
 
@@ -170,6 +175,7 @@ module FriendlyShipping
         request = FriendlyShipping::Request.new(
           url: url,
           body: access_request_xml + address_validation_request_xml,
+          readable_body: address_validation_request_xml,
           debug: debug
         )
 
@@ -188,6 +194,7 @@ module FriendlyShipping
         request = FriendlyShipping::Request.new(
           url: url,
           body: access_request_xml + city_state_lookup_request_xml,
+          readable_body: city_state_lookup_request_xml,
           debug: debug
         )
 
@@ -202,6 +209,7 @@ module FriendlyShipping
         request = FriendlyShipping::Request.new(
           url: url,
           body: access_request_xml + void_request_xml,
+          readable_body: void_request_xml,
           debug: debug
         )
         client.post(request).bind do |response|

--- a/lib/friendly_shipping/services/usps.rb
+++ b/lib/friendly_shipping/services/usps.rb
@@ -112,6 +112,7 @@ module FriendlyShipping
         FriendlyShipping::Request.new(
           url: base_url,
           body: "API=#{RESOURCES[api]}&XML=#{CGI.escape xml}",
+          readable_body: xml,
           debug: debug
         )
       end

--- a/spec/friendly_shipping/request_spec.rb
+++ b/spec/friendly_shipping/request_spec.rb
@@ -5,12 +5,34 @@ require 'spec_helper'
 RSpec.describe FriendlyShipping::Request do
   let(:url) { 'https://www.example.com/labels' }
   let(:body) { "Hello!" }
+  let(:readable_body) { "World" }
   let(:headers) { { "X-Header" => "Nice" } }
 
-  subject { described_class.new(url: url, body: body, headers: headers) }
+  subject do
+    described_class.new(
+      url: url,
+      body: body,
+      readable_body: readable_body,
+      headers: headers
+    )
+  end
 
   it { is_expected.to respond_to(:url) }
   it { is_expected.to respond_to(:body) }
   it { is_expected.to respond_to(:headers) }
   it { is_expected.to respond_to(:debug) }
+
+  describe '#readable_body' do
+    it 'returns readable body' do
+      expect(subject.readable_body).to eq('World')
+    end
+
+    context 'with blank readable body' do
+      let(:readable_body) { '' }
+
+      it 'returns body' do
+        expect(subject.readable_body).to eq('Hello!')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since we're saving the original request bodies in our app for later troubleshooting/debugging, it's helpful to have human-readable forms of each payload. For USPS this means the unencoded XML outside of the query string. For UPS this means just the core XML without the access request.

I'm open to suggestions for a better name than "readable body."