### PR TITLE
Fix handling invalid XML docs in UPS parser

### DIFF
--- a/lib/friendly_shipping/services/ups/parse_xml_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_xml_response.rb
@@ -13,8 +13,7 @@ module FriendlyShipping
 
             if xml.root.nil? || xml.root.name != expected_root_tag
               Failure('Invalid document')
-            end
-            if request_successful?(xml)
+            elsif request_successful?(xml)
               Success(xml)
             else
               Failure(error_message(xml))

--- a/spec/friendly_shipping/services/ups/parse_xml_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_xml_response_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe FriendlyShipping::Services::Ups::ParseXMLResponse do
   let(:response) do
     Nokogiri::XML::Builder.new do |xml|
-      xml.ResponseRoot do
+      xml.RatingServiceSelectionResponse do
         xml.Response do
           xml.ResponseStatusCode '0'
           xml.ResponseStatusDescription 'Failure'
@@ -19,12 +19,29 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseXMLResponse do
     end.to_xml
   end
 
-  subject(:parser) { described_class.call(response, 'SomeTag') }
+  subject(:parser) { described_class.call(response, 'RatingServiceSelectionResponse') }
 
   it { is_expected.to be_failure }
 
   it 'has the correct error message' do
     expect(subject.failure.to_s).to eq('Failure: Something went wrong')
+  end
+
+  context 'with a successful response' do
+    let(:response) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'ups_rates_api_response.xml')).read }
+
+    it { is_expected.to be_success }
+
+    it 'contains an XML document with the requested root' do
+      expect(subject.value!).to be_a(Nokogiri::XML::Document)
+      expect(subject.value!.root.name).to eq('RatingServiceSelectionResponse')
+    end
+
+    context 'when requesting the wrong root tag' do
+      subject(:parser) { described_class.call(response, 'Wat') }
+
+      it { is_expected.to be_failure }
+    end
   end
 
   context 'with invalid XML in response body' do


### PR DESCRIPTION
In the event that an unexpected root tag was received in an XML response, the UPS parser is supposed to return a failure. Due to a typo the parser was bypassing this branch entirely.