### PR TITLE
Wrap UPS/USPS failure responses in ApiFailure class

### DIFF
--- a/lib/friendly_shipping/services/ups/parse_address_classification_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_address_classification_response.rb
@@ -7,8 +7,11 @@ module FriendlyShipping
         extend Dry::Monads::Result::Mixin
 
         def self.call(request:, response:)
-          parsing_result = ParseXMLResponse.call(response.body, 'AddressValidationResponse')
-
+          parsing_result = ParseXMLResponse.call(
+            request: request,
+            response: response,
+            expected_root_tag: 'AddressValidationResponse'
+          )
           parsing_result.bind do |xml|
             address_type = xml.at('AddressClassification/Description')&.text&.downcase
             Success(

--- a/lib/friendly_shipping/services/ups/parse_address_validation_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_address_validation_response.rb
@@ -7,8 +7,11 @@ module FriendlyShipping
         extend Dry::Monads::Result::Mixin
 
         def self.call(request:, response:)
-          parsing_result = ParseXMLResponse.call(response.body, 'AddressValidationResponse')
-
+          parsing_result = ParseXMLResponse.call(
+            request: request,
+            response: response,
+            expected_root_tag: 'AddressValidationResponse'
+          )
           parsing_result.bind do |xml|
             if xml.at('NoCandidatesIndicator')
               Failure(

--- a/lib/friendly_shipping/services/ups/parse_city_state_lookup_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_city_state_lookup_response.rb
@@ -7,8 +7,11 @@ module FriendlyShipping
         extend Dry::Monads::Result::Mixin
 
         def self.call(request:, response:, location:)
-          parsing_result = ParseXMLResponse.call(response.body, 'AddressValidationResponse')
-
+          parsing_result = ParseXMLResponse.call(
+            request: request,
+            response: response,
+            expected_root_tag: 'AddressValidationResponse'
+          )
           parsing_result.fmap do |xml|
             FriendlyShipping::ApiResult.new(
               [

--- a/lib/friendly_shipping/services/ups/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_rate_response.rb
@@ -9,7 +9,11 @@ module FriendlyShipping
       class ParseRateResponse
         class << self
           def call(request:, response:, shipment:)
-            parsing_result = ParseXMLResponse.call(response.body, 'RatingServiceSelectionResponse')
+            parsing_result = ParseXMLResponse.call(
+              request: request,
+              response: response,
+              expected_root_tag: 'RatingServiceSelectionResponse'
+            )
             parsing_result.fmap do |xml|
               FriendlyShipping::ApiResult.new(
                 build_rates(xml, shipment),

--- a/lib/friendly_shipping/services/ups/parse_shipment_accept_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_shipment_accept_response.rb
@@ -11,7 +11,11 @@ module FriendlyShipping
 
         class << self
           def call(request:, response:)
-            parsing_result = ParseXMLResponse.call(response.body, 'ShipmentAcceptResponse')
+            parsing_result = ParseXMLResponse.call(
+              request: request,
+              response: response,
+              expected_root_tag: 'ShipmentAcceptResponse'
+            )
             parsing_result.fmap do |xml|
               FriendlyShipping::ApiResult.new(
                 build_labels(xml),

--- a/lib/friendly_shipping/services/ups/parse_shipment_confirm_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_shipment_confirm_response.rb
@@ -7,7 +7,11 @@ module FriendlyShipping
     class Ups
       class ParseShipmentConfirmResponse
         def self.call(request:, response:)
-          parsing_result = ParseXMLResponse.call(response.body, 'ShipmentConfirmResponse')
+          parsing_result = ParseXMLResponse.call(
+            request: request,
+            response: response,
+            expected_root_tag: 'ShipmentConfirmResponse'
+          )
           parsing_result.fmap do |xml|
             FriendlyShipping::ApiResult.new(
               xml.root.at('ShipmentDigest').text,

--- a/lib/friendly_shipping/services/ups/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_time_in_transit_response.rb
@@ -5,7 +5,11 @@ module FriendlyShipping
     class Ups
       class ParseTimeInTransitResponse
         def self.call(request:, response:)
-          parsing_result = ParseXMLResponse.call(response.body, 'TimeInTransitResponse')
+          parsing_result = ParseXMLResponse.call(
+            request: request,
+            response: response,
+            expected_root_tag: 'TimeInTransitResponse'
+          )
           parsing_result.fmap do |xml|
             origin_country_code = xml.at('TransitResponse/TransitFrom/AddressArtifactFormat/CountryCode').text
             timings = xml.root.xpath('//TransitResponse/ServiceSummary').map do |service_summary|

--- a/lib/friendly_shipping/services/ups/parse_void_shipment_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_void_shipment_response.rb
@@ -7,7 +7,11 @@ module FriendlyShipping
     class Ups
       class ParseVoidShipmentResponse
         def self.call(request:, response:)
-          parsing_result = ParseXMLResponse.call(response.body, 'VoidShipmentResponse')
+          parsing_result = ParseXMLResponse.call(
+            request: request,
+            response: response,
+            expected_root_tag: 'VoidShipmentResponse'
+          )
           parsing_result.fmap do |xml|
             FriendlyShipping::ApiResult.new(
               xml.root.at('ResponseStatusDescription').text,

--- a/lib/friendly_shipping/services/usps/parse_address_validation_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_address_validation_response.rb
@@ -12,7 +12,11 @@ module FriendlyShipping
           # @return [Result<FriendlyShipping::AddressValidationResult>]
           def call(request:, response:)
             # Filter out error responses and directly return a failure
-            parsing_result = ParseXMLResponse.call(response.body, 'AddressValidateResponse')
+            parsing_result = ParseXMLResponse.call(
+              request: request,
+              response: response,
+              expected_root_tag: 'AddressValidateResponse'
+            )
             parsing_result.fmap do |xml|
               address = xml.root.at('Address')
               suggestions = [

--- a/lib/friendly_shipping/services/usps/parse_city_state_lookup_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_city_state_lookup_response.rb
@@ -12,7 +12,11 @@ module FriendlyShipping
           # @return [Result<FriendlyShipping::AddressValidationResult>]
           def call(request:, response:)
             # Filter out error responses and directly return a failure
-            parsing_result = ParseXMLResponse.call(response.body, 'CityStateLookupResponse')
+            parsing_result = ParseXMLResponse.call(
+              request: request,
+              response: response,
+              expected_root_tag: 'CityStateLookupResponse'
+            )
             parsing_result.fmap do |xml|
               address = xml.root.at('ZipCode')
               suggestions = [

--- a/lib/friendly_shipping/services/usps/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_rate_response.rb
@@ -20,8 +20,11 @@ module FriendlyShipping
           # @return [Result<ApiResult<Array<FriendlyShipping::Rate>>>] When successfully parsing, an array of rates in a Success Monad.
           def call(request:, response:, shipment:, options:)
             # Filter out error responses and directly return a failure
-            parsing_result = ParseXMLResponse.call(response.body, 'RateV4Response')
-            rates = []
+            parsing_result = ParseXMLResponse.call(
+              request: request,
+              response: response,
+              expected_root_tag: 'RateV4Response'
+            )
             parsing_result.fmap do |xml|
               # Get all the possible rates for each package
               rates_by_package = rates_from_response_node(xml, shipment, options)

--- a/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
@@ -15,7 +15,11 @@ module FriendlyShipping
           # @return [Result<ApiResult<Array<FriendlyShipping::Timing>>>] When successfully parsing, an array of timings in a Success Monad.
           def call(request:, response:)
             # Filter out error responses and directly return a failure
-            parsing_result = ParseXMLResponse.call(response.body, 'SDCGetLocationsResponse')
+            parsing_result = ParseXMLResponse.call(
+              request: request,
+              response: response,
+              expected_root_tag: 'SDCGetLocationsResponse'
+            )
             parsing_result.fmap do |xml|
               expedited_commitments = xml.xpath('//Expedited')
               expedited_timings = parse_expedited_commitment_nodes(expedited_commitments)

--- a/lib/friendly_shipping/services/usps/parse_xml_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_xml_response.rb
@@ -8,18 +8,18 @@ module FriendlyShipping
         ERROR_TAG = 'Error'
 
         class << self
-          def call(response_body, expected_root_tag)
-            xml = Nokogiri.XML(response_body, &:strict)
+          def call(request:, response:, expected_root_tag:)
+            xml = Nokogiri.XML(response.body, &:strict)
 
             if xml.root.nil? || ![expected_root_tag, 'Error'].include?(xml.root.name)
-              Failure('Invalid document')
+              wrap_failure('Invalid document', request, response)
             elsif request_successful?(xml)
               Success(xml)
             else
-              Failure(error_message(xml))
+              wrap_failure(error_message(xml), request, response)
             end
           rescue Nokogiri::XML::SyntaxError => e
-            Failure(e)
+            wrap_failure(e, request, response)
           end
 
           private
@@ -32,6 +32,16 @@ module FriendlyShipping
             number = xml.xpath('//Error/Number')&.text
             desc = xml.xpath('//Error/Description')&.text
             [number, desc].select(&:present?).join(': ').presence&.strip || 'USPS could not process the request.'
+          end
+
+          def wrap_failure(failure, request, response)
+            Failure(
+              FriendlyShipping::ApiFailure.new(
+                failure,
+                original_request: request,
+                original_response: response
+              )
+            )
           end
         end
       end

--- a/spec/friendly_shipping/services/ups/parse_xml_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_xml_response_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe FriendlyShipping::Services::Ups::ParseXMLResponse do
-  let(:response) do
+  let(:body) do
     Nokogiri::XML::Builder.new do |xml|
       xml.RatingServiceSelectionResponse do
         xml.Response do
@@ -19,16 +19,28 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseXMLResponse do
     end.to_xml
   end
 
-  subject(:parser) { described_class.call(response, 'RatingServiceSelectionResponse') }
+  let(:request) { FriendlyShipping::Request.new(url: nil, debug: true) }
+  let(:response) { FriendlyShipping::Response.new(status: nil, body: body, headers: nil) }
+
+  subject(:parser) do
+    described_class.call(
+      request: request,
+      response: response,
+      expected_root_tag: 'RatingServiceSelectionResponse'
+    )
+  end
 
   it { is_expected.to be_failure }
 
   it 'has the correct error message' do
-    expect(subject.failure.to_s).to eq('Failure: Something went wrong')
+    expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
+    expect(subject.failure.failure).to eq('Failure: Something went wrong')
+    expect(subject.failure.original_request).to eq(request)
+    expect(subject.failure.original_response).to eq(response)
   end
 
   context 'with a successful response' do
-    let(:response) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'ups_rates_api_response.xml')).read }
+    let(:body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups', 'ups_rates_api_response.xml')).read }
 
     it { is_expected.to be_success }
 
@@ -38,20 +50,34 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseXMLResponse do
     end
 
     context 'when requesting the wrong root tag' do
-      subject(:parser) { described_class.call(response, 'Wat') }
+      subject(:parser) do
+        described_class.call(
+          request: request,
+          response: response,
+          expected_root_tag: 'Wat'
+        )
+      end
 
       it { is_expected.to be_failure }
+
+      it 'has the correct error message' do
+        expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
+        expect(subject.failure.failure).to eq('Invalid document')
+        expect(subject.failure.original_request).to eq(request)
+        expect(subject.failure.original_response).to eq(response)
+      end
     end
   end
 
   context 'with invalid XML in response body' do
-    let(:response) { 'invalid XML' }
+    let(:body) { 'invalid XML' }
 
     it { is_expected.to be_failure }
 
     it 'has the correct error' do
-      expect(subject.failure).to be_a(Nokogiri::XML::SyntaxError)
-      expect(subject.failure.message).to match(/Start tag expected/)
+      expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
+      expect(subject.failure.failure).to be_a(Nokogiri::XML::SyntaxError)
+      expect(subject.failure.failure.message).to match(/Start tag expected/)
     end
   end
 end

--- a/spec/friendly_shipping/services/ups_spec.rb
+++ b/spec/friendly_shipping/services/ups_spec.rb
@@ -531,7 +531,8 @@ RSpec.describe FriendlyShipping::Services::Ups do
       it { is_expected.to be_failure }
 
       it 'raises a ResponseError' do
-        expect(subject.failure).to eq('Failure: The Pickup Request associated with this shipment has already been completed')
+        expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
+        expect(subject.failure.failure).to eq('Failure: The Pickup Request associated with this shipment has already been completed')
       end
     end
   end


### PR DESCRIPTION
Previously we were returning simple strings on failure. It's nice to have the original request/response available in debug mode. The `ApiFailure` class seems appropriate.