### PR TITLE
Refactor ApiFailure to subclass ApiResult

### DIFF
--- a/lib/friendly_shipping/api_failure.rb
+++ b/lib/friendly_shipping/api_failure.rb
@@ -1,21 +1,8 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
-  class ApiFailure
-    attr_reader :failure, :original_request, :original_response
-
-    # @param [Object] failure The API failure
-    # @param [FriendlyShipping::Request] original_request The HTTP request (when debugging is enabled)
-    # @param [FriendlyShipping::Response] original_response The HTTP response (when debugging is enabled)
-    def initialize(failure, original_request:, original_response:)
-      @failure = failure
-
-      # We do not want to attach debugging information in every single response to save memory in production
-      return unless original_request&.debug
-
-      @original_request = original_request
-      @original_response = original_response
-    end
+  class ApiFailure < ApiResult
+    alias_method :failure, :data
 
     def to_s
       failure.to_s

--- a/spec/friendly_shipping/api_failure_spec.rb
+++ b/spec/friendly_shipping/api_failure_spec.rb
@@ -1,28 +1,32 @@
 # frozen_string_literal: true
 
 RSpec.describe FriendlyShipping::ApiFailure do
-  let(:failure) { :failure }
+  let(:data) { :failure }
   let(:original_request) { double(debug: debug) }
   let(:original_response) { :original_response }
   let(:debug) { false }
 
-  subject { described_class.new(failure, original_request: original_request, original_response: original_response) }
+  subject { described_class.new(data, original_request: original_request, original_response: original_response) }
 
-  it 'stores the failure but no debugging info' do
+  it 'aliases #failure to #data' do
     expect(subject.failure).to eq(:failure)
+  end
+
+  it 'stores the data but no debugging info' do
+    expect(subject.data).to eq(:failure)
     expect(subject.original_request).to be nil
     expect(subject.original_response).to be nil
   end
 
-  it 'serializes the failure when to_s is called' do
+  it 'serializes the data when to_s is called' do
     expect(subject.to_s).to eq("failure")
   end
 
   context 'with debug set to true' do
     let(:debug) { true }
 
-    it 'stores the failure with debugging info' do
-      expect(subject.failure).to eq(:failure)
+    it 'stores the data with debugging info' do
+      expect(subject.data).to eq(:failure)
       expect(subject.original_request).to eq(original_request)
       expect(subject.original_response).to eq(original_response)
     end

--- a/spec/friendly_shipping/services/ups/parse_xml_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_xml_response_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseXMLResponse do
 
   it 'has the correct error message' do
     expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
-    expect(subject.failure.failure).to eq('Failure: Something went wrong')
+    expect(subject.failure.data).to eq('Failure: Something went wrong')
     expect(subject.failure.original_request).to eq(request)
     expect(subject.failure.original_response).to eq(response)
   end
@@ -62,7 +62,7 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseXMLResponse do
 
       it 'has the correct error message' do
         expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
-        expect(subject.failure.failure).to eq('Invalid document')
+        expect(subject.failure.data).to eq('Invalid document')
         expect(subject.failure.original_request).to eq(request)
         expect(subject.failure.original_response).to eq(response)
       end
@@ -76,8 +76,8 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseXMLResponse do
 
     it 'has the correct error' do
       expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
-      expect(subject.failure.failure).to be_a(Nokogiri::XML::SyntaxError)
-      expect(subject.failure.failure.message).to match(/Start tag expected/)
+      expect(subject.failure.data).to be_a(Nokogiri::XML::SyntaxError)
+      expect(subject.failure.data.message).to match(/Start tag expected/)
     end
   end
 end

--- a/spec/friendly_shipping/services/ups_spec.rb
+++ b/spec/friendly_shipping/services/ups_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe FriendlyShipping::Services::Ups do
 
       it 'raises a ResponseError' do
         expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
-        expect(subject.failure.failure).to eq('Failure: The Pickup Request associated with this shipment has already been completed')
+        expect(subject.failure.data).to eq('Failure: The Pickup Request associated with this shipment has already been completed')
       end
     end
   end

--- a/spec/friendly_shipping/services/usps/parse_xml_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_xml_response_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseXMLResponse do
 
   it 'has the correct error message' do
     expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
-    expect(subject.failure.failure).to eq('0: Something went wrong')
+    expect(subject.failure.data).to eq('0: Something went wrong')
     expect(subject.failure.original_request).to eq(request)
     expect(subject.failure.original_response).to eq(response)
   end
@@ -56,7 +56,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseXMLResponse do
 
       it 'has the correct error message' do
         expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
-        expect(subject.failure.failure).to eq('Invalid document')
+        expect(subject.failure.data).to eq('Invalid document')
         expect(subject.failure.original_request).to eq(request)
         expect(subject.failure.original_response).to eq(response)
       end
@@ -70,8 +70,8 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseXMLResponse do
 
     it 'has the correct error' do
       expect(subject.failure).to be_a(FriendlyShipping::ApiFailure)
-      expect(subject.failure.failure).to be_a(Nokogiri::XML::SyntaxError)
-      expect(subject.failure.failure.message).to match(/Start tag expected/)
+      expect(subject.failure.data).to be_a(Nokogiri::XML::SyntaxError)
+      expect(subject.failure.data.message).to match(/Start tag expected/)
     end
   end
 end


### PR DESCRIPTION
These are similar enough that they should probably be related this way.