### PR TITLE
Add missing cops to fix warnings

### DIFF
--- a/.rubocop-relaxed.yml
+++ b/.rubocop-relaxed.yml
@@ -133,6 +133,9 @@ Style/WordArray:
   Enabled: false
   StyleGuide: https://relaxed.ruby.style/#stylewordarray
 
+Layout/LineLength:
+  Enabled: false
+
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
   StyleGuide: https://relaxed.ruby.style/#lintambiguousregexpliteral
@@ -156,9 +159,6 @@ Metrics/ModuleLength:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Metrics/LineLength:
-  Enabled: false
-
 Metrics/MethodLength:
   Enabled: false
 
@@ -167,4 +167,3 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Enabled: false
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,12 @@ inherit_from:
 
 Metrics/BlockLength:
   Enabled: false
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
-  spec.add_development_dependency "rubocop", "~> 0.75"
+  spec.add_development_dependency "rubocop", ">= 0.80", "< 1"
   spec.add_development_dependency "simplecov", "~> 0.17"
   spec.add_development_dependency "vcr", "~> 5.0"
   spec.add_development_dependency "webmock", "~> 3.6"


### PR DESCRIPTION
When running the latest version of Rubocop in CI:

```bash
.rubocop-relaxed.yml: Metrics/LineLength has the wrong namespace - should be Layout
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/HashEachMethods (0.80)
 - Style/HashTransformKeys (0.80)
 - Style/HashTransformValues (0.80)
For more information: https://docs.rubocop.org/en/latest/versioning/
```

This PR adds the missing cops and fixes the namespace problem, along with updating our gemspec to the latest version of Rubocop.