### PR TITLE
Wrap HTTP errors in ApiFailure objects

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/bad_request_handler.rb
+++ b/lib/friendly_shipping/services/ship_engine/bad_request_handler.rb
@@ -8,11 +8,23 @@ module FriendlyShipping
       class BadRequestHandler
         extend Dry::Monads::Result::Mixin
 
-        def self.call(error)
+        def self.call(error, original_request: nil, original_response: nil)
           if error.http_code == 400
-            Failure(BadRequest.new(error))
+            Failure(
+              ApiFailure.new(
+                BadRequest.new(error),
+                original_request: original_request,
+                original_response: original_response
+              )
+            )
           else
-            Failure(error)
+            Failure(
+              ApiFailure.new(
+                error,
+                original_request: original_request,
+                original_response: original_response
+              )
+            )
           end
         end
       end

--- a/lib/friendly_shipping/services/ups_freight/restful_api_error_handler.rb
+++ b/lib/friendly_shipping/services/ups_freight/restful_api_error_handler.rb
@@ -6,7 +6,7 @@ module FriendlyShipping
       class RestfulApiErrorHandler
         extend Dry::Monads::Result::Mixin
 
-        def self.call(error)
+        def self.call(error, original_request: nil, original_response: nil)
           parsed_json = JSON.parse(error.response.body)
           errors = parsed_json.dig('response', 'errors')
 
@@ -16,7 +16,13 @@ module FriendlyShipping
             [status, desc].compact.join(": ").presence || 'UPS could not process the request.'
           end.join("\n")
 
-          Failure(failure_string)
+          Failure(
+            ApiFailure.new(
+              failure_string,
+              original_request: original_request,
+              original_response: original_response
+            )
+          )
         end
       end
     end

--- a/spec/friendly_shipping/http_client_spec.rb
+++ b/spec/friendly_shipping/http_client_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'friendly_shipping/http_client'
 
 RSpec.describe FriendlyShipping::HttpClient do
   let(:response) { double }
@@ -22,6 +23,7 @@ RSpec.describe FriendlyShipping::HttpClient do
       expect(::RestClient).to receive(:get).with('https://example.com', "X-Token" => "s3cr3t").and_raise(RestClient::ExceptionWithResponse)
       result = subject.get(request)
       expect(result).to be_failure
+      expect(result.failure).to be_a(FriendlyShipping::ApiFailure)
     end
   end
 
@@ -39,6 +41,7 @@ RSpec.describe FriendlyShipping::HttpClient do
       expect(::RestClient).to receive(:post).with('https://example.com', 'body', "X-Token" => "s3cr3t").and_raise(RestClient::ExceptionWithResponse)
       result = subject.post(request)
       expect(result).to be_failure
+      expect(result.failure).to be_a(FriendlyShipping::ApiFailure)
     end
   end
 
@@ -56,6 +59,7 @@ RSpec.describe FriendlyShipping::HttpClient do
       expect(::RestClient).to receive(:put).with('https://example.com', 'body', "X-Token" => "s3cr3t").and_raise(RestClient::ExceptionWithResponse)
       result = subject.put(request)
       expect(result).to be_failure
+      expect(result.failure).to be_a(FriendlyShipping::ApiFailure)
     end
   end
 end

--- a/spec/friendly_shipping/services/ship_engine_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe FriendlyShipping::Services::ShipEngine do
       context "when unwrapped" do
         subject { labels.failure }
 
-        it { is_expected.to be_a FriendlyShipping::Services::ShipEngine::BadRequest }
+        it { is_expected.to be_a FriendlyShipping::ApiFailure }
 
         it "converts to an understandable error message" do
           expect(subject.to_s).to eq("invalid package_code 'not_a_usps_package_code'")

--- a/spec/friendly_shipping/services/ups_freight/restful_api_error_handler_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/restful_api_error_handler_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::RestfulApiErrorHandler do
   it { is_expected.to be_failure }
 
   it 'contains the correct string' do
-    expect(subject.failure).to eq("9360721: Missing or Invalid Attention name in the request.\n9370701: Invalid processing option.")
+    expect(subject.failure.to_s).to eq("9360721: Missing or Invalid Attention name in the request.\n9370701: Invalid processing option.")
   end
 end

--- a/spec/friendly_shipping/services/ups_freight_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight do
       it { is_expected.to be_failure }
 
       it 'has the correct error message' do
-        expect(subject.failure).to eq("9360703: Missing or Invalid Postal Code(s) provided in request.")
+        expect(subject.failure.to_s).to eq("9360703: Missing or Invalid Postal Code(s) provided in request.")
       end
     end
   end


### PR DESCRIPTION
We wrap all of our errors in ApiFailure objects since version 0.5.3, but
we missed the HTTP errors, where we also want to use our ApiFailure
class.