### PR TITLE
Bump version and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2020-08-12
+
+- UPS Service: Be more resilient when UPS does not send a PickupTime element
+
 ## [0.6.1] - 2020-03-11
 
 - Add Content-Type header to UPS Freight API requests, fixing "Name too long" 500 error responses

--- a/lib/friendly_shipping/version.rb
+++ b/lib/friendly_shipping/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end


### PR DESCRIPTION
Release 0.6.2 with a fix for non-existing PickupTime elements