### PR TITLE
Append HFP to service code in rate options

### DIFF
--- a/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
@@ -49,11 +49,10 @@ module FriendlyShipping
         def service_code
           return 'ALL' unless shipping_method
 
-          if commercial_pricing
-            "#{shipping_method.service_code} COMMERCIAL"
-          else
-            shipping_method.service_code
-          end
+          service_code = [shipping_method.service_code]
+          service_code << 'HFP' if hold_for_pickup
+          service_code << 'COMMERCIAL' if commercial_pricing
+          service_code.join(' ')
         end
       end
     end

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -4,7 +4,8 @@ require 'spec_helper'
 require 'friendly_shipping/services/usps/rate_estimate_package_options'
 
 RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
-  subject(:options) { described_class.new(package_id: 'my_package_id') }
+  subject { described_class.new(package_id: package_id) }
+  let(:package_id) { 'my_package_id' }
 
   [
     :box_name,
@@ -19,15 +20,81 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
 
   describe 'box_name' do
     context 'when setting it to something that is no USPS box' do
-      subject(:options) do
+      let(:options) do
         described_class.new(
-          package_id: 'my_package_id',
+          package_id: package_id,
           box_name: :package
         )
       end
 
       it 'become "variable"' do
-        expect(subject.box_name).to eq(:variable)
+        expect(options.box_name).to eq(:variable)
+      end
+    end
+  end
+
+  describe '#service_code' do
+    let(:options) do
+      described_class.new(
+        package_id: package_id,
+        shipping_method: shipping_method
+      )
+    end
+
+    let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: 'PRIORITY') }
+
+    it 'returns service code from shipping method' do
+      expect(options.service_code).to eq('PRIORITY')
+    end
+
+    context 'with no shipping method' do
+      let(:shipping_method) { nil }
+
+      it 'returns ALL' do
+        expect(options.service_code).to eq('ALL')
+      end
+    end
+
+    context 'with commercial pricing' do
+      let(:options) do
+        described_class.new(
+          package_id: package_id,
+          shipping_method: shipping_method,
+          commercial_pricing: true
+        )
+      end
+
+      it 'appends COMMERCIAL to service code' do
+        expect(options.service_code).to eq('PRIORITY COMMERCIAL')
+      end
+    end
+
+    context 'with hold for pickup' do
+      let(:options) do
+        described_class.new(
+          package_id: package_id,
+          shipping_method: shipping_method,
+          hold_for_pickup: true
+        )
+      end
+
+      it 'appends HFP to service code' do
+        expect(options.service_code).to eq('PRIORITY HFP')
+      end
+    end
+
+    context 'with commercial pricing and hold for pickup' do
+      let(:options) do
+        described_class.new(
+          package_id: package_id,
+          shipping_method: shipping_method,
+          commercial_pricing: true,
+          hold_for_pickup: true
+        )
+      end
+
+      it 'appends HFP and COMMERCIAL to service code' do
+        expect(options.service_code).to eq('PRIORITY HFP COMMERCIAL')
       end
     end
   end


### PR DESCRIPTION
When hold for pickup is enabled, we need to append HFP to the service code that gets included in the USPS rate request. Otherwise, the rate we get back won't be the hold for pickup rate.