### PR TITLE
Use explicit USPS service codes

### DIFF
--- a/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
@@ -115,7 +115,7 @@ module FriendlyShipping
           # This will likely be somewhat more work in the future.
           MAIL_CLASSES = {
             '1' => 'Priority Mail Express',
-            '2' => 'Priority',
+            '2' => 'Priority Mail',
             '3' => 'First-Class',
             '6' => 'Package Services'
           }.freeze

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -32,7 +32,7 @@ module FriendlyShipping
       SHIPPING_METHODS = [
         ['FIRST CLASS', 'First-Class'],
         ['PACKAGE SERVICES', 'Package Services'],
-        ['PRIORITY', 'Priority'],
+        ['PRIORITY', 'Priority Mail'],
         ['PRIORITY MAIL EXPRESS', 'Priority Mail Express'],
         ['STANDARD POST', 'Standard Post'],
         ['RETAIL GROUND', 'Retail Ground'],

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -30,19 +30,19 @@ module FriendlyShipping
       }.freeze
 
       SHIPPING_METHODS = [
-        'First-Class',
-        'Package Services',
-        'Priority',
-        'Priority Mail Express',
-        'Standard Post',
-        'Retail Ground',
-        'Media Mail',
-        'Library Mail',
-      ].map do |shipping_method_name|
+        ['FIRST CLASS', 'First-Class'],
+        ['PACKAGE SERVICES', 'Package Services'],
+        ['PRIORITY', 'Priority'],
+        ['PRIORITY MAIL EXPRESS', 'Priority Mail Express'],
+        ['STANDARD POST', 'Standard Post'],
+        ['RETAIL GROUND', 'Retail Ground'],
+        ['MEDIA MAIL', 'Media Mail'],
+        ['LIBRARY MAIL', 'Library Mail'],
+      ].map do |code, name|
         FriendlyShipping::ShippingMethod.new(
           origin_countries: [Carmen::Country.coded('US')],
-          name: shipping_method_name,
-          service_code: shipping_method_name.tr('-', ' ').upcase,
+          name: name,
+          service_code: code,
           domestic: true,
           international: false
         )

--- a/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ChoosePackageRate do
 
   context 'if requesting a rate for a special box type' do
     # There are no rates for Priority Mail Express and Large Flat Rate Box
-    let(:shipping_method_name) { 'Priority' }
+    let(:shipping_method_name) { 'Priority Mail' }
     let(:properties) { { box_name: :large_flat_rate_box } }
 
     it 'has the right attributes' do

--- a/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParsePackageRate do
     let(:mail_service) { "Priority Mail 2-Day&lt;sup&gt;&#8482;&lt;/sup&gt;" }
 
     it 'has the correct shipping method' do
-      expect(subject.shipping_method.name).to eq('Priority')
+      expect(subject.shipping_method.name).to eq('Priority Mail')
     end
   end
 

--- a/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseRateResponse do
     ].map { |cents| Money.new(cents, 'USD') })
     expect(subject.value!.data.map(&:shipping_method).map(&:name)).to contain_exactly(
       "First-Class",
-      "Priority",
+      "Priority Mail",
       "Priority Mail Express",
       "Standard Post"
     )
@@ -91,7 +91,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseRateResponse do
 
       expect(subject.value!.data.map(&:total_amount).map(&:cents)).to contain_exactly(812 + 940)
       expect(subject.value!.data.map(&:shipping_method).map(&:name)).to contain_exactly(
-        "Priority"
+        "Priority Mail"
       )
     end
   end

--- a/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseTimeInTransitResponse do
 
       it "does not break" do
         first_rate = subject.first
-        expect(first_rate.shipping_method.name).to eq('Priority')
+        expect(first_rate.shipping_method.name).to eq('Priority Mail')
         expect(first_rate.pickup).to eq(Time.new(2020, 1, 17))
         expect(first_rate.delivery).to eq(Time.new(2020, 1, 19))
         expect(first_rate.properties).to eq(

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
   context 'with priority shipping method' do
     let(:shipping_method) do
       FriendlyShipping::Services::Usps::SHIPPING_METHODS.detect do |shipping_method|
-        shipping_method.name == 'Priority'
+        shipping_method.name == 'Priority Mail'
       end
     end
     let(:package_options) do


### PR DESCRIPTION
Instead of programmatically generating USPS service codes to match against rates returned by the API, let's specify the codes inline the way we already do for UPS and Freight shipping methods.