### PR TITLE
Match USPS API rates by class ID before falling back to name

### DIFF
--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -35,7 +35,7 @@ module FriendlyShipping
           hold_for_pickup: '2',
           sunday_holiday_delivery: '23'
         }
-      }
+      }.freeze
 
       SHIPPING_METHODS = [
         ['FIRST CLASS', 'First-Class'],

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -29,22 +29,31 @@ module FriendlyShipping
         package_service_retail: 'PACKAGE SERVICE RETAIL'
       }.freeze
 
+      CLASS_IDS = {
+        priority_mail_express: {
+          standard: '3',
+          hold_for_pickup: '2',
+          sunday_holiday_delivery: '23'
+        }
+      }
+
       SHIPPING_METHODS = [
         ['FIRST CLASS', 'First-Class'],
         ['PACKAGE SERVICES', 'Package Services'],
         ['PRIORITY', 'Priority Mail'],
-        ['PRIORITY MAIL EXPRESS', 'Priority Mail Express'],
+        ['PRIORITY MAIL EXPRESS', 'Priority Mail Express', CLASS_IDS[:priority_mail_express].values],
         ['STANDARD POST', 'Standard Post'],
         ['RETAIL GROUND', 'Retail Ground'],
         ['MEDIA MAIL', 'Media Mail'],
         ['LIBRARY MAIL', 'Library Mail'],
-      ].map do |code, name|
+      ].map do |code, name, class_ids|
         FriendlyShipping::ShippingMethod.new(
           origin_countries: [Carmen::Country.coded('US')],
           name: name,
           service_code: code,
           domestic: true,
-          international: false
+          international: false,
+          data: { class_ids: class_ids }
         )
       end.freeze
     end

--- a/lib/friendly_shipping/shipping_method.rb
+++ b/lib/friendly_shipping/shipping_method.rb
@@ -2,7 +2,7 @@
 
 module FriendlyShipping
   class ShippingMethod
-    attr_reader :name, :service_code, :carrier, :origin_countries
+    attr_reader :name, :service_code, :carrier, :origin_countries, :data
 
     # @param [String] name The shipping method's name
     # @param [String] service_code The shipping method's service code
@@ -11,6 +11,7 @@ module FriendlyShipping
     # @param [Boolean] multi_package Whether this is a multi-package shipping method
     # @param [FriendlyShipping::Carrier] carrier This shipping method's carrier
     # @param [Array] origin_countries Countries this shipping method ships from
+    # @param [Hash] data Additional carrier-specific data for this shipping method
     def initialize(
       name: nil,
       service_code: nil,
@@ -18,7 +19,8 @@ module FriendlyShipping
       international: nil,
       multi_package: nil,
       carrier: nil,
-      origin_countries: []
+      origin_countries: [],
+      data: {}
     )
       @name = name
       @service_code = service_code
@@ -27,6 +29,7 @@ module FriendlyShipping
       @multi_package = multi_package
       @carrier = carrier
       @origin_countries = origin_countries
+      @data = data
     end
 
     def domestic?

--- a/spec/friendly_shipping/shipping_method_spec.rb
+++ b/spec/friendly_shipping/shipping_method_spec.rb
@@ -3,11 +3,16 @@
 require 'spec_helper'
 
 RSpec.describe FriendlyShipping::ShippingMethod do
-  it { is_expected.to respond_to(:name) }
-  it { is_expected.to respond_to(:service_code) }
-  it { is_expected.to respond_to(:carrier) }
-  it { is_expected.to respond_to(:origin_countries) }
-  it { is_expected.to respond_to(:domestic?) }
-  it { is_expected.to respond_to(:international?) }
-  it { is_expected.to respond_to(:multi_package?) }
+  [
+    :name,
+    :service_code,
+    :carrier,
+    :origin_countries,
+    :data,
+    :domestic?,
+    :international?,
+    :multi_package?,
+  ].each do |message|
+    it { is_expected.to respond_to(message) }
+  end
 end


### PR DESCRIPTION
This updates the code that matches USPS API rates with Friendly shipping methods to first attempt to match by the `CLASSID` attribute, then fall back to name (`MailService` element) if that fails. This should be a more reliable way to match shipping methods with potentially ambiguous names like Priority Mail vs. Priority Mail Express.

This also eliminates the need for special handling of Priority Mail vs. Priority Mail Express matching since we can simply provide class IDs for Express which will be matched against. This is better than matching names starting with "Priority" and sorting by length which is what was being done prior.