### PR TITLE
Add USPS Priority Mail Cubic shipping method

### DIFF
--- a/lib/friendly_shipping/services/usps/parse_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/parse_package_rate.rb
@@ -83,13 +83,19 @@ module FriendlyShipping
 
             # Some USPS services only offer commercial pricing. Unfortunately, USPS then returns a retail rate of 0.
             # In these cases, return the commercial rate instead of the normal rate.
+            #
             # Some rates are available in both commercial and retail pricing - if we want the commercial pricing here,
             # we need to specify the commercial_pricing property on the `Physical::Package`.
-            rate_value = if (package_options.commercial_pricing || rate_node.at(RATE_TAG).text.to_d.zero?) && (rate_node.at(COMMERCIAL_RATE_TAG) || rate_node.at(COMMERCIAL_PLUS_RATE_TAG))
-                           rate_node.at(COMMERCIAL_RATE_TAG)&.text&.to_d || rate_node.at(COMMERCIAL_PLUS_RATE_TAG).text.to_d
-                         else
-                           rate_node.at(RATE_TAG).text.to_d
-                         end
+            #
+            commercial_rate_requested_or_rate_is_zero = package_options.commercial_pricing || rate_node.at(RATE_TAG).text.to_d.zero?
+            commercial_rate_available = rate_node.at(COMMERCIAL_RATE_TAG) || rate_node.at(COMMERCIAL_PLUS_RATE_TAG)
+
+            rate_value =
+              if commercial_rate_requested_or_rate_is_zero && commercial_rate_available
+                rate_node.at(COMMERCIAL_RATE_TAG)&.text&.to_d || rate_node.at(COMMERCIAL_PLUS_RATE_TAG).text.to_d
+              else
+                rate_node.at(RATE_TAG).text.to_d
+              end
 
             # The rate expressed as a RubyMoney objext
             rate = Money.new(rate_value * CURRENCY.subunit_to_unit, CURRENCY)

--- a/lib/friendly_shipping/services/usps/parse_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/parse_package_rate.rb
@@ -54,6 +54,7 @@ module FriendlyShipping
         SERVICE_NAME_TAG = 'MailService'
         RATE_TAG = 'Rate'
         COMMERCIAL_RATE_TAG = 'CommercialRate'
+        COMMERCIAL_PLUS_RATE_TAG = 'CommercialPlusRate'
         CURRENCY = Money::Currency.new('USD').freeze
 
         class << self
@@ -84,8 +85,8 @@ module FriendlyShipping
             # In these cases, return the commercial rate instead of the normal rate.
             # Some rates are available in both commercial and retail pricing - if we want the commercial pricing here,
             # we need to specify the commercial_pricing property on the `Physical::Package`.
-            rate_value = if (package_options.commercial_pricing || rate_node.at(RATE_TAG).text.to_d.zero?) && rate_node.at(COMMERCIAL_RATE_TAG)
-                           rate_node.at(COMMERCIAL_RATE_TAG).text.to_d
+            rate_value = if (package_options.commercial_pricing || rate_node.at(RATE_TAG).text.to_d.zero?) && (rate_node.at(COMMERCIAL_RATE_TAG) || rate_node.at(COMMERCIAL_PLUS_RATE_TAG))
+                           rate_node.at(COMMERCIAL_RATE_TAG)&.text&.to_d || rate_node.at(COMMERCIAL_PLUS_RATE_TAG).text.to_d
                          else
                            rate_node.at(RATE_TAG).text.to_d
                          end

--- a/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
@@ -49,6 +49,9 @@ module FriendlyShipping
         def service_code
           return 'ALL' unless shipping_method
 
+          # Cubic shipping methods don't have HFP or COMMERCIAL modifiers
+          return shipping_method.service_code if shipping_method.service_code =~ /CUBIC/
+
           service_code = [shipping_method.service_code]
           service_code << 'HFP' if hold_for_pickup
           service_code << 'COMMERCIAL' if commercial_pricing

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -34,7 +34,8 @@ module FriendlyShipping
           standard: '3',
           hold_for_pickup: '2',
           sunday_holiday_delivery: '23'
-        }
+        },
+        priority_mail_cubic: '999'
       }.freeze
 
       SHIPPING_METHODS = [
@@ -42,6 +43,7 @@ module FriendlyShipping
         ['PACKAGE SERVICES', 'Package Services'],
         ['PRIORITY', 'Priority Mail'],
         ['PRIORITY MAIL EXPRESS', 'Priority Mail Express', CLASS_IDS[:priority_mail_express].values],
+        ['PRIORITY MAIL CUBIC', 'Priority Mail Cubic', CLASS_IDS[:priority_mail_cubic]],
         ['STANDARD POST', 'Standard Post'],
         ['RETAIL GROUND', 'Retail Ground'],
         ['MEDIA MAIL', 'Media Mail'],

--- a/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe FriendlyShipping::Services::Usps::ParsePackageRate do
     end
   end
 
+  context "Priority Mail Cubic" do
+    let(:class_id) { "999" }
+    let(:mail_service) { "Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Cubic" }
+
+    it "has the correct shipping method" do
+      expect(subject.shipping_method.name).to eq("Priority Mail Cubic")
+      expect(subject.data[:service_code]).to eq("999")
+    end
+  end
+
   context 'Priority Mail in a Flat Rate Box' do
     let(:class_id) { "22" }
     let(:mail_service) { "Priority Mail 2-Day&lt;sup&gt;&#8482;&lt;/sup&gt; Large Flat Rate Box" }

--- a/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
@@ -106,4 +106,13 @@ RSpec.describe FriendlyShipping::Services::Usps::ParsePackageRate do
       expect(subject.total_amount.to_f).to eq(4.5)
     end
   end
+
+  context "if rate is 0 and commercial rate is missing" do
+    let(:rate) { "0.0" }
+    let(:commercial_plus_rate) { "5.70" }
+
+    it "uses commercial plus rate" do
+      expect(subject.total_amount.to_f).to eq(5.7)
+    end
+  end
 end

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -55,6 +55,42 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
       end
     end
 
+    context "with cubic shipping method" do
+      let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: "PRIORITY MAIL CUBIC") }
+
+      it "returns unmodified service code" do
+        expect(options.service_code).to eq("PRIORITY MAIL CUBIC")
+      end
+
+      context "with commercial pricing" do
+        let(:options) do
+          described_class.new(
+            package_id: package_id,
+            shipping_method: shipping_method,
+            commercial_pricing: true
+          )
+        end
+
+        it "returns unmodified service code" do
+          expect(options.service_code).to eq("PRIORITY MAIL CUBIC")
+        end
+      end
+
+      context "with hold for pickup" do
+        let(:options) do
+          described_class.new(
+            package_id: package_id,
+            shipping_method: shipping_method,
+            hold_for_pickup: true
+          )
+        end
+
+        it "returns unmodified service code" do
+          expect(options.service_code).to eq("PRIORITY MAIL CUBIC")
+        end
+      end
+    end
+
     context 'with commercial pricing' do
       let(:options) do
         described_class.new(

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
 
   describe 'box_name' do
     context 'when setting it to something that is no USPS box' do
-      let(:options) do
+      subject do
         described_class.new(
           package_id: package_id,
           box_name: :package
@@ -28,109 +28,84 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
       end
 
       it 'become "variable"' do
-        expect(options.box_name).to eq(:variable)
+        expect(subject.box_name).to eq(:variable)
       end
     end
   end
 
   describe '#service_code' do
-    let(:options) do
+    subject do
       described_class.new(
         package_id: package_id,
-        shipping_method: shipping_method
+        shipping_method: shipping_method,
+        commercial_pricing: commercial_pricing,
+        hold_for_pickup: hold_for_pickup
       )
     end
 
-    let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: 'PRIORITY') }
+    let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: service_code) }
+    let(:service_code) { "PRIORITY" }
+    let(:commercial_pricing) { false }
+    let(:hold_for_pickup) { false }
 
     it 'returns service code from shipping method' do
-      expect(options.service_code).to eq('PRIORITY')
+      expect(subject.service_code).to eq('PRIORITY')
     end
 
     context 'with no shipping method' do
       let(:shipping_method) { nil }
 
       it 'returns ALL' do
-        expect(options.service_code).to eq('ALL')
+        expect(subject.service_code).to eq('ALL')
       end
     end
 
     context "with cubic shipping method" do
-      let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: "PRIORITY MAIL CUBIC") }
+      let(:service_code) { "PRIORITY MAIL CUBIC" }
 
       it "returns unmodified service code" do
-        expect(options.service_code).to eq("PRIORITY MAIL CUBIC")
+        expect(subject.service_code).to eq("PRIORITY MAIL CUBIC")
       end
 
       context "with commercial pricing" do
-        let(:options) do
-          described_class.new(
-            package_id: package_id,
-            shipping_method: shipping_method,
-            commercial_pricing: true
-          )
-        end
+        let(:commercial_pricing) { true }
 
         it "returns unmodified service code" do
-          expect(options.service_code).to eq("PRIORITY MAIL CUBIC")
+          expect(subject.service_code).to eq("PRIORITY MAIL CUBIC")
         end
       end
 
       context "with hold for pickup" do
-        let(:options) do
-          described_class.new(
-            package_id: package_id,
-            shipping_method: shipping_method,
-            hold_for_pickup: true
-          )
-        end
+        let(:hold_for_pickup) { true }
 
         it "returns unmodified service code" do
-          expect(options.service_code).to eq("PRIORITY MAIL CUBIC")
+          expect(subject.service_code).to eq("PRIORITY MAIL CUBIC")
         end
       end
     end
 
     context 'with commercial pricing' do
-      let(:options) do
-        described_class.new(
-          package_id: package_id,
-          shipping_method: shipping_method,
-          commercial_pricing: true
-        )
-      end
+      let(:commercial_pricing) { true }
 
       it 'appends COMMERCIAL to service code' do
-        expect(options.service_code).to eq('PRIORITY COMMERCIAL')
+        expect(subject.service_code).to eq('PRIORITY COMMERCIAL')
       end
     end
 
     context 'with hold for pickup' do
-      let(:options) do
-        described_class.new(
-          package_id: package_id,
-          shipping_method: shipping_method,
-          hold_for_pickup: true
-        )
-      end
+      let(:hold_for_pickup) { true }
 
       it 'appends HFP to service code' do
-        expect(options.service_code).to eq('PRIORITY HFP')
+        expect(subject.service_code).to eq('PRIORITY HFP')
       end
     end
 
     context 'with commercial pricing and hold for pickup' do
-      let(:options) do
-        described_class.new(
-          package_id: package_id,
-          shipping_method: shipping_method,
-          commercial_pricing: true,
-          hold_for_pickup: true
-        )
-      end
+      let(:commercial_pricing) { true }
+      let(:hold_for_pickup) { true }
 
       it 'appends HFP and COMMERCIAL to service code' do
-        expect(options.service_code).to eq('PRIORITY HFP COMMERCIAL')
+        expect(subject.service_code).to eq('PRIORITY HFP COMMERCIAL')
       end
     end
   end


### PR DESCRIPTION
This adds a shipping method and supporting code for the USPS Priority Mail Cubic shipping method.

This shipping method is an outlier in that it always returns a Commercial Plus rate in the API response, even though the service name passed to the API is simply `PRIORITY MAIL CUBIC` without a `COMMERCIAL` modifier.

Something else to note is that, while the API accepts container names of `CUBIC PARCELS` or `CUBIC SOFT PACK`, there is no difference in rates versus using the `VARIABLE` container name.