### PR TITLE
Include shipment-level itemized charges for UPS

### DIFF
--- a/lib/friendly_shipping/services/ups/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_rate_response.rb
@@ -37,6 +37,10 @@ module FriendlyShipping
                 rated_shipment.at('NegotiatedRates/NetSummaryCharges/GrandTotal')
               )&.last
 
+              itemized_charges = rated_shipment.xpath('ItemizedCharges').map do |element|
+                ParseMoneyElement.call(element)
+              end.compact.to_h
+
               rated_shipment_warnings = rated_shipment.css('RatedShipmentWarning').map { |e| e.text.strip }
               if rated_shipment_warnings.any? { |e| e.match?(/to Residential/) }
                 new_address_type = 'residential'
@@ -54,6 +58,7 @@ module FriendlyShipping
                   negotiated_rate: negotiated_rate,
                   days_to_delivery: days_to_delivery,
                   new_address_type: new_address_type,
+                  itemized_charges: itemized_charges,
                   packages: build_packages(rated_shipment)
                 }.compact
               )

--- a/lib/friendly_shipping/services/ups/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_rate_response.rb
@@ -36,10 +36,7 @@ module FriendlyShipping
               negotiated_rate = ParseMoneyElement.call(
                 rated_shipment.at('NegotiatedRates/NetSummaryCharges/GrandTotal')
               )&.last
-
-              itemized_charges = rated_shipment.xpath('ItemizedCharges').map do |element|
-                ParseMoneyElement.call(element)
-              end.compact.to_h
+              itemized_charges = extract_charges(rated_shipment.xpath('ItemizedCharges'))
 
               rated_shipment_warnings = rated_shipment.css('RatedShipmentWarning').map { |e| e.text.strip }
               if rated_shipment_warnings.any? { |e| e.match?(/to Residential/) }
@@ -69,19 +66,22 @@ module FriendlyShipping
 
           def build_packages(rated_shipment)
             rated_shipment.css('RatedPackage').map do |rated_package|
-              itemized_charges = rated_package.xpath('ItemizedCharges').map do |element|
-                ParseMoneyElement.call(element)
-              end.compact.to_h
               {
                 transportation_charges: ParseMoneyElement.call(rated_package.at('TransportationCharges')).last,
                 base_service_charge: ParseMoneyElement.call(rated_package.at('BaseServiceCharge')).last,
                 service_options_charges: ParseMoneyElement.call(rated_package.at('ServiceOptionsCharges'))&.last,
-                itemized_charges: itemized_charges,
+                itemized_charges: extract_charges(rated_package.xpath('ItemizedCharges')),
                 total_charges: ParseMoneyElement.call(rated_package.at('TotalCharges')).last,
                 weight: BigDecimal(rated_package.at('Weight').text),
                 billing_weight: BigDecimal(rated_package.at('BillingWeight/Weight').text)
               }.compact
             end
+          end
+
+          def extract_charges(node)
+            node.map do |element|
+              ParseMoneyElement.call(element)
+            end.compact.to_h
           end
         end
       end

--- a/spec/friendly_shipping/services/ups/parse_rate_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_rate_response_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseRateResponse do
     )
   end
 
+  it 'returns itemized charges for the shipment' do
+    rates = subject.value!.data
+    expect(rates.map { |r| r.data[:itemized_charges] }).to contain_exactly(
+      { 'RESIDENTIAL ADDRESS' => Money.new(360, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') }
+    )
+  end
+
   describe 'address type changed' do
     context 'when changed to residential' do
       let(:fixture) { 'ups_rates_address_type_residential_api_response.xml' }


### PR DESCRIPTION
We were already returning package-level itemized charges in UPS rates. This adds shipment-level itemized charges to the same rates. Shipment-level itemized charges typically consist of the residential surcharge (if any).