### PR TITLE
Configure dependency updates for this repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This activates dependency updates for this repo by adding a Dependabot config file.

Documentation for Dependabot can be found here: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically

Closes #108.