### PR TITLE
Include negotiated charges for UPS

### DIFF
--- a/lib/friendly_shipping/services/ups/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_rate_response.rb
@@ -36,6 +36,7 @@ module FriendlyShipping
               negotiated_rate = ParseMoneyElement.call(
                 rated_shipment.at('NegotiatedRates/NetSummaryCharges/GrandTotal')
               )&.last
+              negotiated_charges = extract_charges(rated_shipment.xpath('NegotiatedRates/ItemizedCharges'))
               itemized_charges = extract_charges(rated_shipment.xpath('ItemizedCharges'))
 
               rated_shipment_warnings = rated_shipment.css('RatedShipmentWarning').map { |e| e.text.strip }
@@ -53,6 +54,7 @@ module FriendlyShipping
                 data: {
                   insurance_price: insurance_price,
                   negotiated_rate: negotiated_rate,
+                  negotiated_charges: negotiated_charges,
                   days_to_delivery: days_to_delivery,
                   new_address_type: new_address_type,
                   itemized_charges: itemized_charges,
@@ -72,6 +74,7 @@ module FriendlyShipping
                 service_options_charges: ParseMoneyElement.call(rated_package.at('ServiceOptionsCharges'))&.last,
                 itemized_charges: extract_charges(rated_package.xpath('ItemizedCharges')),
                 total_charges: ParseMoneyElement.call(rated_package.at('TotalCharges')).last,
+                negotiated_charges: extract_charges(rated_package.xpath('NegotiatedCharges/ItemizedCharges')),
                 weight: BigDecimal(rated_package.at('Weight').text),
                 billing_weight: BigDecimal(rated_package.at('BillingWeight/Weight').text)
               }.compact

--- a/lib/friendly_shipping/services/ups/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_rate_response.rb
@@ -37,6 +37,10 @@ module FriendlyShipping
                 rated_shipment.at('NegotiatedRates/NetSummaryCharges/GrandTotal')
               )&.last
 
+              itemized_charges = rated_shipment.xpath('ItemizedCharges').map do |element|
+                ParseMoneyElement.call(element)
+              end.compact.to_h
+
               rated_shipment_warnings = rated_shipment.css('RatedShipmentWarning').map { |e| e.text.strip }
               if rated_shipment_warnings.any? { |e| e.match?(/to Residential/) }
                 new_address_type = 'residential'
@@ -54,6 +58,7 @@ module FriendlyShipping
                   negotiated_rate: negotiated_rate,
                   days_to_delivery: days_to_delivery,
                   new_address_type: new_address_type,
+                  itemized_charges: itemized_charges,
                   packages: build_packages(rated_shipment)
                 }.compact
               )

--- a/lib/friendly_shipping/services/ups/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_rate_response.rb
@@ -36,10 +36,7 @@ module FriendlyShipping
               negotiated_rate = ParseMoneyElement.call(
                 rated_shipment.at('NegotiatedRates/NetSummaryCharges/GrandTotal')
               )&.last
-
-              itemized_charges = rated_shipment.xpath('ItemizedCharges').map do |element|
-                ParseMoneyElement.call(element)
-              end.compact.to_h
+              itemized_charges = extract_charges(rated_shipment.xpath('ItemizedCharges'))
 
               rated_shipment_warnings = rated_shipment.css('RatedShipmentWarning').map { |e| e.text.strip }
               if rated_shipment_warnings.any? { |e| e.match?(/to Residential/) }
@@ -69,19 +66,22 @@ module FriendlyShipping
 
           def build_packages(rated_shipment)
             rated_shipment.css('RatedPackage').map do |rated_package|
-              itemized_charges = rated_package.xpath('ItemizedCharges').map do |element|
-                ParseMoneyElement.call(element)
-              end.compact.to_h
               {
                 transportation_charges: ParseMoneyElement.call(rated_package.at('TransportationCharges')).last,
                 base_service_charge: ParseMoneyElement.call(rated_package.at('BaseServiceCharge')).last,
                 service_options_charges: ParseMoneyElement.call(rated_package.at('ServiceOptionsCharges'))&.last,
-                itemized_charges: itemized_charges,
+                itemized_charges: extract_charges(rated_package.xpath('ItemizedCharges')),
                 total_charges: ParseMoneyElement.call(rated_package.at('TotalCharges')).last,
                 weight: BigDecimal(rated_package.at('Weight').text),
                 billing_weight: BigDecimal(rated_package.at('BillingWeight/Weight').text)
               }.compact
             end
+          end
+
+          def extract_charges(node)
+            node.map do |element|
+              ParseMoneyElement.call(element)
+            end.compact.to_h
           end
         end
       end

--- a/spec/fixtures/ups/ups_rates_api_response.xml
+++ b/spec/fixtures/ups/ups_rates_api_response.xml
@@ -66,6 +66,19 @@
         <CurrencyCode>USD</CurrencyCode>
         <MonetaryValue>15.51</MonetaryValue>
       </TotalCharges>
+      <NegotiatedCharges>
+        <ItemizedCharges>
+          <Code>376</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>0.00</MonetaryValue>
+          <SubType>Suburban</SubType>
+        </ItemizedCharges>
+        <ItemizedCharges>
+          <Code>375</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>0.53</MonetaryValue>
+        </ItemizedCharges>
+      </NegotiatedCharges>
       <Weight>4.0</Weight>
       <BillingWeight>
         <UnitOfMeasurement>
@@ -75,6 +88,11 @@
       </BillingWeight>
     </RatedPackage>
     <NegotiatedRates>
+      <ItemizedCharges>
+        <Code>270</Code>
+        <CurrencyCode>USD</CurrencyCode>
+        <MonetaryValue>3.60</MonetaryValue>
+      </ItemizedCharges>
       <NetSummaryCharges>
         <GrandTotal>
           <CurrencyCode>USD</CurrencyCode>
@@ -145,6 +163,19 @@
         <CurrencyCode>USD</CurrencyCode>
         <MonetaryValue>22.04</MonetaryValue>
       </TotalCharges>
+      <NegotiatedCharges>
+        <ItemizedCharges>
+          <Code>376</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>0.00</MonetaryValue>
+          <SubType>Suburban</SubType>
+        </ItemizedCharges>
+        <ItemizedCharges>
+          <Code>375</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>0.82</MonetaryValue>
+        </ItemizedCharges>
+      </NegotiatedCharges>
       <Weight>4.0</Weight>
       <BillingWeight>
         <UnitOfMeasurement>
@@ -154,6 +185,11 @@
       </BillingWeight>
     </RatedPackage>
     <NegotiatedRates>
+      <ItemizedCharges>
+        <Code>270</Code>
+        <CurrencyCode>USD</CurrencyCode>
+        <MonetaryValue>4.15</MonetaryValue>
+      </ItemizedCharges>
       <NetSummaryCharges>
         <GrandTotal>
           <CurrencyCode>USD</CurrencyCode>
@@ -224,6 +260,19 @@
         <CurrencyCode>USD</CurrencyCode>
         <MonetaryValue>28.73</MonetaryValue>
       </TotalCharges>
+      <NegotiatedCharges>
+        <ItemizedCharges>
+          <Code>376</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>0.00</MonetaryValue>
+          <SubType>Suburban</SubType>
+        </ItemizedCharges>
+        <ItemizedCharges>
+          <Code>375</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>1.07</MonetaryValue>
+        </ItemizedCharges>
+      </NegotiatedCharges>
       <Weight>4.0</Weight>
       <BillingWeight>
         <UnitOfMeasurement>
@@ -233,6 +282,11 @@
       </BillingWeight>
     </RatedPackage>
     <NegotiatedRates>
+      <ItemizedCharges>
+        <Code>270</Code>
+        <CurrencyCode>USD</CurrencyCode>
+        <MonetaryValue>4.15</MonetaryValue>
+      </ItemizedCharges>
       <NetSummaryCharges>
         <GrandTotal>
           <CurrencyCode>USD</CurrencyCode>
@@ -303,6 +357,19 @@
         <CurrencyCode>USD</CurrencyCode>
         <MonetaryValue>76.41</MonetaryValue>
       </TotalCharges>
+      <NegotiatedCharges>
+        <ItemizedCharges>
+          <Code>376</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>0.00</MonetaryValue>
+          <SubType>Suburban</SubType>
+        </ItemizedCharges>
+        <ItemizedCharges>
+          <Code>375</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>2.83</MonetaryValue>
+        </ItemizedCharges>
+      </NegotiatedCharges>
       <Weight>4.0</Weight>
       <BillingWeight>
         <UnitOfMeasurement>
@@ -312,6 +379,11 @@
       </BillingWeight>
     </RatedPackage>
     <NegotiatedRates>
+      <ItemizedCharges>
+        <Code>270</Code>
+        <CurrencyCode>USD</CurrencyCode>
+        <MonetaryValue>4.15</MonetaryValue>
+      </ItemizedCharges>
       <NetSummaryCharges>
         <GrandTotal>
           <CurrencyCode>USD</CurrencyCode>
@@ -382,6 +454,19 @@
         <CurrencyCode>USD</CurrencyCode>
         <MonetaryValue>115.13</MonetaryValue>
       </TotalCharges>
+      <NegotiatedCharges>
+        <ItemizedCharges>
+          <Code>376</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>0.00</MonetaryValue>
+          <SubType>Suburban</SubType>
+        </ItemizedCharges>
+        <ItemizedCharges>
+          <Code>375</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>4.27</MonetaryValue>
+        </ItemizedCharges>
+      </NegotiatedCharges>
       <Weight>4.0</Weight>
       <BillingWeight>
         <UnitOfMeasurement>
@@ -391,6 +476,11 @@
       </BillingWeight>
     </RatedPackage>
     <NegotiatedRates>
+      <ItemizedCharges>
+        <Code>270</Code>
+        <CurrencyCode>USD</CurrencyCode>
+        <MonetaryValue>4.15</MonetaryValue>
+      </ItemizedCharges>
       <NetSummaryCharges>
         <GrandTotal>
           <CurrencyCode>USD</CurrencyCode>
@@ -461,6 +551,19 @@
         <CurrencyCode>USD</CurrencyCode>
         <MonetaryValue>82.73</MonetaryValue>
       </TotalCharges>
+      <NegotiatedCharges>
+        <ItemizedCharges>
+          <Code>376</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>0.00</MonetaryValue>
+          <SubType>Suburban</SubType>
+        </ItemizedCharges>
+        <ItemizedCharges>
+          <Code>375</Code>
+          <CurrencyCode>USD</CurrencyCode>
+          <MonetaryValue>3.07</MonetaryValue>
+        </ItemizedCharges>
+      </NegotiatedCharges>
       <Weight>4.0</Weight>
       <BillingWeight>
         <UnitOfMeasurement>
@@ -470,6 +573,11 @@
       </BillingWeight>
     </RatedPackage>
     <NegotiatedRates>
+      <ItemizedCharges>
+        <Code>270</Code>
+        <CurrencyCode>USD</CurrencyCode>
+        <MonetaryValue>4.15</MonetaryValue>
+      </ItemizedCharges>
       <NetSummaryCharges>
         <GrandTotal>
           <CurrencyCode>USD</CurrencyCode>

--- a/spec/friendly_shipping/services/ups/parse_rate_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_rate_response_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseRateResponse do
     )
   end
 
+  it 'returns itemized charges for the shipment' do
+    rates = subject.value!.data
+    expect(rates.map { |r| r.data[:itemized_charges] }).to contain_exactly(
+      { 'RESIDENTIAL ADDRESS' => Money.new(360, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') }
+    )
+  end
+
   describe 'address type changed' do
     context 'when changed to residential' do
       let(:fixture) { 'ups_rates_address_type_residential_api_response.xml' }

--- a/spec/friendly_shipping/services/ups/parse_rate_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_rate_response_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseRateResponse do
     )
   end
 
+  it 'returns negotiated shipment rate and charges along with the response' do
+    rates = subject.value!.data
+    expect(rates.map { |r| r.data[:negotiated_rate] }).to contain_exactly(
+      Money.new(1102, 'USD'),
+      Money.new(1596, 'USD'),
+      Money.new(1539, 'USD'),
+      Money.new(3038, 'USD'),
+      Money.new(11_513, 'USD'),
+      Money.new(3265, 'USD')
+    )
+    expect(rates.map { |r| r.data[:negotiated_charges] }).to contain_exactly(
+      { 'RESIDENTIAL ADDRESS' => Money.new(360, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(415, 'USD') }
+    )
+  end
+
   describe 'address type changed' do
     context 'when changed to residential' do
       let(:fixture) { 'ups_rates_address_type_residential_api_response.xml' }
@@ -87,6 +107,9 @@ RSpec.describe FriendlyShipping::Services::Ups::ParseRateResponse do
           total_charges: Money.new(1551, 'USD'),
           itemized_charges: {
             'FUEL SURCHARGE' => Money.new(105, 'USD')
+          },
+          negotiated_charges: {
+            'FUEL SURCHARGE' => Money.new(53, 'USD')
           },
           weight: 4.0,
           billing_weight: 4.0


### PR DESCRIPTION
**Depends on #117**

This adds package and shipment-level negotiated charges to the returned UPS rates. These will only be present when negotiated rates have been requested from the API.