### PR TITLE
Make FriendlyShipping::Rate attrs accessible

### DIFF
--- a/lib/friendly_shipping/rate.rb
+++ b/lib/friendly_shipping/rate.rb
@@ -3,13 +3,13 @@
 module FriendlyShipping
   class Rate
     class NoAmountsGiven < StandardError; end
-    attr_reader :shipping_method,
-                :amounts,
-                :remote_service_id,
-                :delivery_date,
-                :warnings,
-                :errors,
-                :data
+    attr_accessor :shipping_method,
+                  :amounts,
+                  :remote_service_id,
+                  :delivery_date,
+                  :warnings,
+                  :errors,
+                  :data
 
     # @param [FriendlyShipping::ShippingMethod] shipping_method The rate's shipping method
     # @param [Hash] amounts The amounts (as Money objects) that make up the rate


### PR DESCRIPTION
This will allow data on a rate to be updated after the rate has been instantiated. This is easier than having to create an entirely new rate using modified data from an existing rate.

Example use case: creating a rate in one class and passing it to a caller which then appends discounts to the amounts in the rate and passes it back to its own caller.