### PR TITLE
Add support for USPS fees

### DIFF
--- a/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
@@ -8,6 +8,7 @@ module FriendlyShipping
     #
     # @param [Symbol] box_name The type of box we want to get rates for. Has to be one of the keys
     #  of FriendlyShipping::Services::Usps::CONTAINERS.
+    # @param [Symbol] return_fees Boolean indicating whether the response should include fees.
     class Usps
       class RateEstimatePackageOptions < FriendlyShipping::PackageOptions
         attr_reader :box_name,
@@ -16,7 +17,8 @@ module FriendlyShipping
                     :hold_for_pickup,
                     :shipping_method,
                     :transmit_dimensions,
-                    :rectangular
+                    :rectangular,
+                    :return_fees
 
         def initialize(
           box_name: :variable,
@@ -26,6 +28,7 @@ module FriendlyShipping
           shipping_method: nil,
           transmit_dimensions: true,
           rectangular: true,
+          return_fees: false,
           **kwargs
         )
           @box_name = CONTAINERS.key?(box_name) ? box_name : :variable
@@ -35,6 +38,7 @@ module FriendlyShipping
           @shipping_method = shipping_method
           @transmit_dimensions = transmit_dimensions
           @rectangular = rectangular
+          @return_fees = return_fees
           super kwargs
         end
 

--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -46,6 +46,7 @@ module FriendlyShipping
                       end
                     end
                     xml.Machinable(machinable(package))
+                    xml.ReturnFees(true) if package_options.return_fees
                   end
                 end
               end

--- a/spec/fixtures/usps/usps_rates_api_response_with_fees.xml
+++ b/spec/fixtures/usps/usps_rates_api_response_with_fees.xml
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RateV4Response>
+  <Package ID="0">
+    <ZipOrigination>90210</ZipOrigination>
+    <ZipDestination>10017</ZipDestination>
+    <Pounds>0</Pounds>
+    <Ounces>8.8</Ounces>
+    <Size>REGULAR</Size>
+    <Machinable>TRUE</Machinable>
+    <Zone>8</Zone>
+    <Postage CLASSID="3">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt;</MailService>
+      <Rate>36.60</Rate>
+      <CommercialRate>30.00</CommercialRate>
+      <CommercialPlusRate>22.37</CommercialPlusRate>
+      <Fees>
+        <Fee>
+          <FeeType>Nonstandard Length fee &gt; 30 in.</FeeType>
+          <FeePrice>15.00</FeePrice>
+          <FeeInformation>
+            <FeeInfo FeeInfoType="PriceType">Rate</FeeInfo>
+          </FeeInformation>
+        </Fee>
+      </Fees>
+    </Postage>
+    <Postage CLASSID="2">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Hold For Pickup</MailService>
+      <Rate>36.60</Rate>
+      <CommercialRate>30.00</CommercialRate>
+      <CommercialPlusRate>22.37</CommercialPlusRate>
+      <Fees>
+        <Fee>
+          <FeeType>Nonstandard Length fee &gt; 30 in.</FeeType>
+          <FeePrice>15.00</FeePrice>
+          <FeeInformation>
+            <FeeInfo FeeInfoType="PriceType">Rate</FeeInfo>
+          </FeeInformation>
+        </Fee>
+      </Fees>
+    </Postage>
+    <Postage CLASSID="55">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Boxes</MailService>
+      <Rate>44.95</Rate>
+      <CommercialRate>44.95</CommercialRate>
+      <CommercialPlusRate>44.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="56">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Boxes Hold For Pickup</MailService>
+      <Rate>44.95</Rate>
+      <CommercialRate>44.95</CommercialRate>
+      <CommercialPlusRate>44.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="13">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Envelope</MailService>
+      <Rate>19.99</Rate>
+      <CommercialRate>18.11</CommercialRate>
+      <CommercialPlusRate>14.85</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="27">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Envelope Hold For Pickup</MailService>
+      <Rate>19.99</Rate>
+      <CommercialRate>18.11</CommercialRate>
+      <CommercialPlusRate>14.85</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="30">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Legal Flat Rate Envelope</MailService>
+      <Rate>19.99</Rate>
+      <CommercialRate>18.11</CommercialRate>
+      <CommercialPlusRate>14.85</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="31">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Legal Flat Rate Envelope Hold For Pickup</MailService>
+      <Rate>19.99</Rate>
+      <CommercialRate>18.11</CommercialRate>
+      <CommercialPlusRate>14.85</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="62">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Padded Flat Rate Envelope</MailService>
+      <Rate>19.99</Rate>
+      <CommercialRate>18.11</CommercialRate>
+      <CommercialPlusRate>14.85</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="63">
+      <MailService>Priority Mail Express 1-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Padded Flat Rate Envelope Hold For Pickup</MailService>
+      <Rate>19.99</Rate>
+      <CommercialRate>18.11</CommercialRate>
+      <CommercialPlusRate>14.85</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="1">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt;</MailService>
+      <Rate>7.15</Rate>
+      <CommercialRate>6.51</CommercialRate>
+      <CommercialPlusRate>6.25</CommercialPlusRate>
+      <Fees>
+        <Fee>
+          <FeeType>Nonstandard Length fee &gt; 30 in.</FeeType>
+          <FeePrice>15.00</FeePrice>
+          <FeeInformation>
+            <FeeInfo FeeInfoType="PriceType">Rate</FeeInfo>
+          </FeeInformation>
+        </Fee>
+      </Fees>
+    </Postage>
+    <Postage CLASSID="33">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>6.51</CommercialRate>
+      <CommercialPlusRate>6.25</CommercialPlusRate>
+      <Fees>
+        <Fee>
+          <FeeType>Nonstandard Length fee &gt; 30 in.</FeeType>
+          <FeePrice>15.00</FeePrice>
+          <FeeInformation>
+            <FeeInfo FeeInfoType="PriceType">Rate</FeeInfo>
+          </FeeInformation>
+        </Fee>
+      </Fees>
+    </Postage>
+    <Postage CLASSID="22">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Large Flat Rate Box</MailService>
+      <Rate>17.90</Rate>
+      <CommercialRate>15.80</CommercialRate>
+      <CommercialPlusRate>14.80</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="34">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Large Flat Rate Box Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>15.80</CommercialRate>
+      <CommercialPlusRate>14.80</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="17">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Medium Flat Rate Box</MailService>
+      <Rate>12.65</Rate>
+      <CommercialRate>11.30</CommercialRate>
+      <CommercialPlusRate>10.65</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="35">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Medium Flat Rate Box Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>11.30</CommercialRate>
+      <CommercialPlusRate>10.65</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="28">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Small Flat Rate Box</MailService>
+      <Rate>5.95</Rate>
+      <CommercialRate>5.25</CommercialRate>
+      <CommercialPlusRate>5.20</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="36">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Small Flat Rate Box Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>5.25</CommercialRate>
+      <CommercialPlusRate>5.20</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="47">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box A</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>9.97</CommercialRate>
+    </Postage>
+    <Postage CLASSID="48">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box A Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>9.97</CommercialRate>
+    </Postage>
+    <Postage CLASSID="49">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box B</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>16.28</CommercialRate>
+    </Postage>
+    <Postage CLASSID="50">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box B Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>16.28</CommercialRate>
+    </Postage>
+    <Postage CLASSID="58">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box C</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>47.43</CommercialRate>
+    </Postage>
+    <Postage CLASSID="59">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Regional Rate Box C Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>47.43</CommercialRate>
+    </Postage>
+    <Postage CLASSID="16">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Envelope</MailService>
+      <Rate>5.75</Rate>
+      <CommercialRate>5.05</CommercialRate>
+      <CommercialPlusRate>4.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="37">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Flat Rate Envelope Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>5.05</CommercialRate>
+      <CommercialPlusRate>4.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="44">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Legal Flat Rate Envelope</MailService>
+      <Rate>5.90</Rate>
+      <CommercialRate>5.25</CommercialRate>
+      <CommercialPlusRate>4.99</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="45">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Legal Flat Rate Envelope Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>5.25</CommercialRate>
+      <CommercialPlusRate>4.99</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="29">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Padded Flat Rate Envelope</MailService>
+      <Rate>6.10</Rate>
+      <CommercialRate>5.70</CommercialRate>
+      <CommercialPlusRate>5.35</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="46">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Padded Flat Rate Envelope Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>5.70</CommercialRate>
+      <CommercialPlusRate>5.35</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="38">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Gift Card Flat Rate Envelope</MailService>
+      <Rate>5.75</Rate>
+      <CommercialRate>5.05</CommercialRate>
+      <CommercialPlusRate>4.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="39">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Gift Card Flat Rate Envelope Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>5.05</CommercialRate>
+      <CommercialPlusRate>4.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="42">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Small Flat Rate Envelope</MailService>
+      <Rate>5.75</Rate>
+      <CommercialRate>5.05</CommercialRate>
+      <CommercialPlusRate>4.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="43">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Small Flat Rate Envelope Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>5.05</CommercialRate>
+      <CommercialPlusRate>4.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="40">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Window Flat Rate Envelope</MailService>
+      <Rate>5.75</Rate>
+      <CommercialRate>5.05</CommercialRate>
+      <CommercialPlusRate>4.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="41">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Window Flat Rate Envelope Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>5.05</CommercialRate>
+      <CommercialPlusRate>4.95</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="0">
+      <MailService>First-Class Mail&amp;lt;sup&amp;gt;&amp;#174;&amp;lt;/sup&amp;gt; Parcel</MailService>
+      <Rate>3.40</Rate>
+    </Postage>
+    <Postage CLASSID="0">
+      <MailService>First-Class Mail&amp;lt;sup&amp;gt;&amp;#174;&amp;lt;/sup&amp;gt; Large Envelope</MailService>
+      <Rate>2.66</Rate>
+    </Postage>
+    <Postage CLASSID="0">
+      <MailService>First-Class Mail&amp;lt;sup&amp;gt;&amp;#174;&amp;lt;/sup&amp;gt; Postcards</MailService>
+      <Rate>0.34</Rate>
+    </Postage>
+    <Postage CLASSID="61">
+      <MailService>First-Class&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Package Service</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>2.76</CommercialRate>
+      <CommercialPlusRate>4.05</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="53">
+      <MailService>First-Class&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Package Service Hold For Pickup</MailService>
+      <Rate>0.00</Rate>
+      <CommercialRate>2.76</CommercialRate>
+      <CommercialPlusRate>4.05</CommercialPlusRate>
+    </Postage>
+    <Postage CLASSID="4">
+      <MailService>Standard Post&amp;lt;sup&amp;gt;&amp;#174;&amp;lt;/sup&amp;gt;</MailService>
+      <Rate>6.73</Rate>
+    </Postage>
+    <Postage CLASSID="6">
+      <MailService>Media Mail Parcel</MailService>
+      <Rate>2.69</Rate>
+    </Postage>
+    <Postage CLASSID="7">
+      <MailService>Library Mail Parcel</MailService>
+      <Rate>2.56</Rate>
+    </Postage>
+  </Package>
+</RateV4Response>

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
     :hold_for_pickup,
     :shipping_method,
     :transmit_dimensions,
-    :rectangular
+    :rectangular,
+    :return_fees
   ].each do |message|
     it { is_expected.to respond_to(message) }
   end

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -150,4 +150,17 @@ RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
       expect(node.at_xpath('Girth')).to be nil
     end
   end
+
+  context 'with return_fees set to true' do
+    let(:package_options) do
+      FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+        package_id: package.id,
+        return_fees: true
+      )
+    end
+
+    it 'includes return fees tag' do
+      expect(node.at_xpath('ReturnFees').text).to eq('true')
+    end
+  end
 end


### PR DESCRIPTION
This adds support for new USPS fees. The USPS rate request serializer includes an optional `ReturnFees` tag in the request when the package options `return_fees` boolean is set to true. If the `Fees` tag is present in the API response, each fee will be parsed and added to the `Rate` in the data hash.