### PR TITLE
Optionally include USPS dimensional weight in response

### DIFF
--- a/lib/friendly_shipping/services/usps/parse_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/parse_package_rate.rb
@@ -55,6 +55,7 @@ module FriendlyShipping
         RATE_TAG = 'Rate'
         COMMERCIAL_RATE_TAG = 'CommercialRate'
         COMMERCIAL_PLUS_RATE_TAG = 'CommercialPlusRate'
+        DIMENSIONAL_WEIGHT_RATE = 'DimensionalWeightRate'
         FEES = './/Fees/Fee'
         CURRENCY = Money::Currency.new('USD').freeze
 
@@ -120,6 +121,8 @@ module FriendlyShipping
             box_name_match = service_name.match(/#{BOX_REGEX}/)
             box_name = box_name_match ? box_name_match.named_captures.compact.keys.last.to_sym : :variable
 
+            dimensional_weight_rate = rate_node.at(DIMENSIONAL_WEIGHT_RATE)&.text&.to_i
+
             fees = rate_node.xpath(FEES).map do |fee_node|
               type = fee_node.at('FeeType').text
               price = fee_node.at('FeePrice').text.to_d
@@ -143,6 +146,7 @@ module FriendlyShipping
                 military: military,
                 full_mail_service: service_name,
                 service_code: service_code,
+                dimensional_weight_rate: dimensional_weight_rate,
                 fees: fees
               }
             )

--- a/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
@@ -8,6 +8,7 @@ module FriendlyShipping
     #
     # @param [Symbol] box_name The type of box we want to get rates for. Has to be one of the keys
     #  of FriendlyShipping::Services::Usps::CONTAINERS.
+    # @param [Symbol] return_dimensional_weight Boolean indicating whether the response should include dimensional weight.
     # @param [Symbol] return_fees Boolean indicating whether the response should include fees.
     class Usps
       class RateEstimatePackageOptions < FriendlyShipping::PackageOptions
@@ -18,6 +19,7 @@ module FriendlyShipping
                     :shipping_method,
                     :transmit_dimensions,
                     :rectangular,
+                    :return_dimensional_weight,
                     :return_fees
 
         def initialize(
@@ -28,6 +30,7 @@ module FriendlyShipping
           shipping_method: nil,
           transmit_dimensions: true,
           rectangular: true,
+          return_dimensional_weight: true,
           return_fees: false,
           **kwargs
         )
@@ -38,6 +41,7 @@ module FriendlyShipping
           @shipping_method = shipping_method
           @transmit_dimensions = transmit_dimensions
           @rectangular = rectangular
+          @return_dimensional_weight = return_dimensional_weight
           @return_fees = return_fees
           super kwargs
         end

--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -46,6 +46,7 @@ module FriendlyShipping
                       end
                     end
                     xml.Machinable(machinable(package))
+                    xml.ReturnDimensionalWeight(true) if package_options.return_dimensional_weight
                     xml.ReturnFees(true) if package_options.return_fees
                   end
                 end

--- a/spec/fixtures/usps/usps_rates_api_response_with_dimensional_weight_rate.xml
+++ b/spec/fixtures/usps/usps_rates_api_response_with_dimensional_weight_rate.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RateV4Response>
+  <Package ID="0">
+    <ZipOrigination>90210</ZipOrigination>
+    <ZipDestination>10017</ZipDestination>
+    <Pounds>0</Pounds>
+    <Ounces>8.8</Ounces>
+    <Size>REGULAR</Size>
+    <Machinable>TRUE</Machinable>
+    <Zone>8</Zone>
+    <Postage CLASSID="1">
+      <MailService>Priority Mail 2-Day&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt;</MailService>
+      <Rate>7.15</Rate>
+      <DimensionalWeightRate>12</DimensionalWeightRate>
+    </Postage>
+  </Package>
+</RateV4Response>

--- a/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_package_rate_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParsePackageRate do
         xml.Rate rate
         xml.CommercialRate commercial_rate if commercial_rate
         xml.CommercialPlusRate commercial_plus_rate if commercial_plus_rate
+        xml.DimensionalWeightRate 12
         xml.Fees do
           xml.Fee do
             xml.FeeType "Nonstandard Length fee &gt; 30 in."
@@ -44,6 +45,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ParsePackageRate do
     expect(subject.shipping_method.name).to eq("Priority Mail Express")
     expect(subject.data[:days_to_delivery]).to eq(1)
     expect(subject.data[:service_code]).to eq("3")
+    expect(subject.data[:dimensional_weight_rate]).to eq(12)
     expect(subject.data[:fees]).to eq(
       [
         {

--- a/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_rate_response_spec.rb
@@ -165,4 +165,32 @@ RSpec.describe FriendlyShipping::Services::Usps::ParseRateResponse do
       )
     end
   end
+
+  context 'with response containing dimensional weight rate' do
+    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'usps', 'usps_rates_api_response_with_dimensional_weight_rate.xml')).read }
+    let(:packages) do
+      [
+        FactoryBot.build(:physical_package, id: '0'),
+      ]
+    end
+    let(:options) do
+      FriendlyShipping::Services::Usps::RateEstimateOptions.new(
+        package_options: shipment.packages.map do |package|
+          FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+            package_id: package.id,
+            return_dimensional_weight: true
+          )
+        end
+      )
+    end
+
+    it 'returns dimensional weight' do
+      expect(subject).to be_success
+      expect(subject.value!.data.map(&:data)).to contain_exactly(
+        hash_including(
+          dimensional_weight_rate: 12
+        )
+      )
+    end
+  end
 end

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
     :shipping_method,
     :transmit_dimensions,
     :rectangular,
+    :return_dimensional_weight,
     :return_fees
   ].each do |message|
     it { is_expected.to respond_to(message) }

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -151,6 +151,19 @@ RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
     end
   end
 
+  context 'with return_dimensional_weight set to true' do
+    let(:package_options) do
+      FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+        package_id: package.id,
+        return_dimensional_weight: true
+      )
+    end
+
+    it 'includes dimensional weight rate tag' do
+      expect(node.at_xpath('ReturnDimensionalWeight').text).to eq('true')
+    end
+  end
+
   context 'with return_fees set to true' do
     let(:package_options) do
       FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(


### PR DESCRIPTION
This adds support for optionally including USPS calculated dimensional weight in the response. The USPS rate request serializer includes an optional `ReturnDimensionalWeight` tag in the request when the package options `return_dimensional_weight` boolean is set to true. If the `DimensionalWeightRate` tag is present in the API response, the value will be parsed and added to the `Rate` in the data hash.

I'm setting this to `true` by default which seems reasonable since the value is only included in the response if the package dimensions actually qualify for dimensional rates.