### PR TITLE
Add optional `http_method` attr to `Request` class

### DIFF
--- a/lib/friendly_shipping/request.rb
+++ b/lib/friendly_shipping/request.rb
@@ -2,15 +2,17 @@
 
 module FriendlyShipping
   class Request
-    attr_reader :url, :body, :headers, :debug
+    attr_reader :url, :http_method, :body, :headers, :debug
 
     # @param [String] url The HTTP request URL
+    # @param [String] http_method The HTTP request method
     # @param [String] body The HTTP request body
-    # # @param [String] readable_body Human-readable HTTP request body
+    # @param [String] readable_body Human-readable HTTP request body
     # @param [Hash] headers The HTTP request headers
     # @param [Boolean] debug Whether to debug the request
-    def initialize(url:, body: nil, readable_body: nil, headers: {}, debug: false)
+    def initialize(url:, http_method: nil, body: nil, readable_body: nil, headers: {}, debug: false)
       @url = url
+      @http_method = http_method
       @body = body
       @readable_body = readable_body
       @headers = headers

--- a/lib/friendly_shipping/services/ship_engine.rb
+++ b/lib/friendly_shipping/services/ship_engine.rb
@@ -34,6 +34,7 @@ module FriendlyShipping
       def carriers(debug: false)
         request = FriendlyShipping::Request.new(
           url: API_BASE + API_PATHS[:carriers],
+          http_method: "GET",
           headers: request_headers,
           debug: debug
         )
@@ -54,6 +55,7 @@ module FriendlyShipping
       def rate_estimates(shipment, options: FriendlyShipping::Services::ShipEngine::RateEstimatesOptions.new, debug: false)
         request = FriendlyShipping::Request.new(
           url: API_BASE + 'rates/estimate',
+          http_method: "POST",
           body: SerializeRateEstimateRequest.call(shipment: shipment, options: options).to_json,
           headers: request_headers,
           debug: debug
@@ -75,6 +77,7 @@ module FriendlyShipping
       def labels(shipment, options:)
         request = FriendlyShipping::Request.new(
           url: API_BASE + API_PATHS[:labels],
+          http_method: "POST",
           body: SerializeLabelShipment.call(shipment: shipment, options: options, test: test).to_json,
           headers: request_headers
         )
@@ -86,6 +89,7 @@ module FriendlyShipping
       def void(label, debug: false)
         request = FriendlyShipping::Request.new(
           url: "#{API_BASE}labels/#{label.id}/void",
+          http_method: "PUT",
           body: '',
           headers: request_headers,
           debug: debug

--- a/lib/friendly_shipping/services/ups.rb
+++ b/lib/friendly_shipping/services/ups.rb
@@ -73,6 +73,7 @@ module FriendlyShipping
         url = base_url + RESOURCES[:rates]
         request = FriendlyShipping::Request.new(
           url: url,
+          http_method: "POST",
           body: access_request_xml + rate_request_xml,
           readable_body: rate_request_xml,
           debug: debug
@@ -95,6 +96,7 @@ module FriendlyShipping
 
         request = FriendlyShipping::Request.new(
           url: time_in_transit_url,
+          http_method: "POST",
           body: access_request_xml + time_in_transit_request_xml,
           readable_body: time_in_transit_request_xml,
           debug: debug
@@ -115,6 +117,7 @@ module FriendlyShipping
 
         ship_confirm_request = FriendlyShipping::Request.new(
           url: ship_confirm_url,
+          http_method: "POST",
           body: access_request_xml + ship_confirm_request_xml,
           readable_body: ship_confirm_request_xml,
           debug: debug
@@ -134,6 +137,7 @@ module FriendlyShipping
 
           ship_accept_request = FriendlyShipping::Request.new(
             url: ship_accept_url,
+            http_method: "POST",
             body: access_request_xml + ship_accept_request_xml,
             readable_body: ship_accept_request_xml,
             debug: debug
@@ -156,6 +160,7 @@ module FriendlyShipping
         url = base_url + RESOURCES[:address_validation]
         request = FriendlyShipping::Request.new(
           url: url,
+          http_method: "POST",
           body: access_request_xml + address_validation_request_xml,
           readable_body: address_validation_request_xml,
           debug: debug
@@ -174,6 +179,7 @@ module FriendlyShipping
         url = base_url + RESOURCES[:address_validation]
         request = FriendlyShipping::Request.new(
           url: url,
+          http_method: "POST",
           body: access_request_xml + address_validation_request_xml,
           readable_body: address_validation_request_xml,
           debug: debug
@@ -193,6 +199,7 @@ module FriendlyShipping
         url = base_url + RESOURCES[:city_state_lookup]
         request = FriendlyShipping::Request.new(
           url: url,
+          http_method: "POST",
           body: access_request_xml + city_state_lookup_request_xml,
           readable_body: city_state_lookup_request_xml,
           debug: debug
@@ -208,6 +215,7 @@ module FriendlyShipping
         void_request_xml = SerializeVoidShipmentRequest.call(label: label)
         request = FriendlyShipping::Request.new(
           url: url,
+          http_method: "POST",
           body: access_request_xml + void_request_xml,
           readable_body: void_request_xml,
           debug: debug

--- a/lib/friendly_shipping/services/ups_freight.rb
+++ b/lib/friendly_shipping/services/ups_freight.rb
@@ -87,6 +87,7 @@ module FriendlyShipping
         url = base_url + RESOURCES[action]
         FriendlyShipping::Request.new(
           url: url,
+          http_method: "POST",
           body: payload.to_json,
           headers: {
             Content_Type: 'application/json',

--- a/lib/friendly_shipping/services/usps.rb
+++ b/lib/friendly_shipping/services/usps.rb
@@ -111,6 +111,7 @@ module FriendlyShipping
       def build_request(api:, xml:, debug:)
         FriendlyShipping::Request.new(
           url: base_url,
+          http_method: "POST",
           body: "API=#{RESOURCES[api]}&XML=#{CGI.escape xml}",
           readable_body: xml,
           debug: debug


### PR DESCRIPTION
This optional attr indicates which HTTP method was used for a given request. It can be returned in a `Request` object.

This is useful for logging or displaying details about API requests/responses without having to assume which HTTP method Friendly Shipping is using for a given carrier API request.