### PR TITLE
Parse UPS Freight cost breakdown from shipping label API response

### DIFF
--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -18,6 +18,7 @@ require "friendly_shipping/api_failure"
 
 require "friendly_shipping/services/ship_engine"
 require "friendly_shipping/services/ups"
+require "friendly_shipping/services/ups_freight"
 require "friendly_shipping/services/usps"
 
 module FriendlyShipping

--- a/lib/friendly_shipping/services/ups_freight/shipment_information.rb
+++ b/lib/friendly_shipping/services/ups_freight/shipment_information.rb
@@ -10,7 +10,8 @@ module FriendlyShipping
                     :total,
                     :bol_id,
                     :shipping_method,
-                    :warnings
+                    :warnings,
+                    :data
 
         def initialize(
           total:,
@@ -19,7 +20,8 @@ module FriendlyShipping
           pickup_request_number: nil,
           documents: [],
           shipping_method: nil,
-          warnings: nil
+          warnings: nil,
+          data: {}
         )
           @total = total
           @bol_id = bol_id
@@ -28,6 +30,7 @@ module FriendlyShipping
           @documents = documents
           @shipping_method = shipping_method
           @warnings = warnings
+          @data = data
         end
       end
     end

--- a/spec/fixtures/ups_freight/labels/success.json
+++ b/spec/fixtures/ups_freight/labels/success.json
@@ -1,0 +1,117 @@
+{
+  "FreightShipResponse": {
+    "Response": {
+      "ResponseStatus": {
+        "Code": "1",
+        "Description": "Success"
+      },
+      "Alert": {
+        "Code": "3289315415",
+        "Description": "Bogus warning for test purposes"
+      }
+    },
+    "ShipmentResults": {
+      "OriginServiceCenterCode": "RIC",
+      "ShipmentNumber": "022438065",
+      "PickupRequestConfirmationNumber": "348742132",
+      "BOLID": "45760188",
+      "Rate": [
+        {
+          "Type": {
+            "Code": "DSCNT",
+            "Description": "DSCNT"
+          },
+          "Factor": {
+            "Value": "490.61",
+            "UnitOfMeasurement": {
+              "Code": "USD"
+            }
+          }
+        },
+        {
+          "Type": {
+            "Code": "DSCNT_RATE",
+            "Description": "DSCNT_RATE"
+          },
+          "Factor": {
+            "Value": "75.00",
+            "UnitOfMeasurement": {
+              "Code": "%"
+            }
+          }
+        },
+        {
+          "Type": {
+            "Code": "2",
+            "Description": "2"
+          },
+          "Factor": {
+            "Value": "16.35",
+            "UnitOfMeasurement": {
+              "Code": "USD"
+            }
+          }
+        },
+        {
+          "Type": {
+            "Code": "LND_GROSS",
+            "Description": "LND_GROSS"
+          },
+          "Factor": {
+            "Value": "654.15",
+            "UnitOfMeasurement": {
+              "Code": "USD"
+            }
+          }
+        },
+        {
+          "Type": {
+            "Code": "AFTR_DSCNT",
+            "Description": "AFTR_DSCNT"
+          },
+          "Factor": {
+            "Value": "163.54",
+            "UnitOfMeasurement": {
+              "Code": "USD"
+            }
+          }
+        }
+      ],
+      "TotalShipmentCharge": {
+        "CurrencyCode": "USD",
+        "MonetaryValue": "179.89"
+      },
+      "BillableShipmentWeight": {
+        "UnitOfMeasurement": {
+          "Code": "LBS"
+        },
+        "Value": "500"
+      },
+      "Service": {
+        "Code": "308"
+      },
+      "Documents": {
+        "Image": [
+          {
+            "Type": {
+              "Code": "30"
+            },
+            "GraphicImage": "JVBERi0xLjMKJf",
+            "Format": {
+              "Code": "PDF"
+            }
+          },
+          {
+            "Type": {
+              "Code": "20"
+            },
+            "GraphicImage": "JVBERi0xLjUKJf",
+            "Format": {
+              "Code": "PDF"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ups_freight/parse_freight_label_response'
+
+RSpec.describe FriendlyShipping::Services::UpsFreight::ParseFreightLabelResponse do
+  let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups_freight', 'labels', 'success.json')).read }
+  let(:response) { double(body: response_body) }
+  let(:request) { FriendlyShipping::Request.new(url: 'http://www.example.com') }
+
+  subject { described_class.call(request: request, response: response) }
+
+  it 'has the right shipment information' do
+    shipment_information = subject.data
+    expect(shipment_information).to be_a(FriendlyShipping::Services::UpsFreight::ShipmentInformation)
+
+    expect(shipment_information.documents.size).to eq(2)
+    expect(shipment_information.documents).to all(be_a(FriendlyShipping::Services::UpsFreight::ShipmentDocument))
+
+    expect(shipment_information.documents.first.format).to eq(:pdf)
+    expect(shipment_information.documents.first.document_type).to eq(:label)
+    expect(shipment_information.documents.first.binary).to be_present
+
+    expect(shipment_information.documents.last.format).to eq(:pdf)
+    expect(shipment_information.documents.last.document_type).to eq(:ups_bol)
+    expect(shipment_information.documents.last.binary).to be_present
+
+    expect(shipment_information.number).to eq("022438065")
+    expect(shipment_information.pickup_request_number).to eq("348742132")
+    expect(shipment_information.total).to eq(Money.new(17989, "USD"))
+    expect(shipment_information.bol_id).to eq("45760188")
+
+    expect(shipment_information.shipping_method).to be_a(FriendlyShipping::ShippingMethod)
+    expect(shipment_information.shipping_method.name).to eq("UPS Freight LTL")
+    expect(shipment_information.shipping_method.service_code).to eq("308")
+
+    expect(shipment_information.warnings).to eq("3289315415: Bogus warning for test purposes")
+  end
+end

--- a/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ParseFreightLabelResponse
 
     expect(shipment_information.number).to eq("022438065")
     expect(shipment_information.pickup_request_number).to eq("348742132")
-    expect(shipment_information.total).to eq(Money.new(17989, "USD"))
+    expect(shipment_information.total).to eq(Money.new(17_989, "USD"))
     expect(shipment_information.bol_id).to eq("45760188")
 
     expect(shipment_information.shipping_method).to be_a(FriendlyShipping::ShippingMethod)
@@ -35,5 +35,20 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ParseFreightLabelResponse
     expect(shipment_information.shipping_method.service_code).to eq("308")
 
     expect(shipment_information.warnings).to eq("3289315415: Bogus warning for test purposes")
+    expect(shipment_information.data).to eq(
+      {
+        cost_breakdown: {
+          "BillableShipmentWeight" => "500",
+          "TotalShipmentCharge" => "179.89",
+          "Rates" => {
+            "2" => "16.35",
+            "DSCNT" => "490.61",
+            "DSCNT_RATE" => "75.00",
+            "LND_GROSS" => "654.15",
+            "AFTR_DSCNT" => "163.54"
+          }
+        }
+      }
+    )
   end
 end

--- a/spec/friendly_shipping/services/ups_freight/shipment_information_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/shipment_information_spec.rb
@@ -11,7 +11,12 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ShipmentInformation do
       number: '1234',
       bol_id: '2345',
       pickup_request_number: '4321',
-      documents: docs
+      documents: docs,
+      data: {
+        cost_breakdown: {
+          "Rate" => "520.75"
+        }
+      }
     )
   end
 
@@ -21,5 +26,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ShipmentInformation do
     expect(subject.bol_id).to eq('2345')
     expect(subject.number).to eq('1234')
     expect(subject.pickup_request_number).to eq('4321')
+    expect(subject.documents).to eq(docs)
+    expect(subject.data).to eq({ cost_breakdown: { "Rate" => "520.75" } })
   end
 end


### PR DESCRIPTION
This updates how we parse the UPS Freight shipping label response to include a cost breakdown on the `ShippingInformation` instance that's returned.