### PR TITLE
Use message from `cause` when API error message not set

### DIFF
--- a/lib/friendly_shipping/api_error.rb
+++ b/lib/friendly_shipping/api_error.rb
@@ -8,7 +8,7 @@ module FriendlyShipping
     # @param [String] msg
     def initialize(cause, msg = nil)
       @cause = cause
-      super msg
+      super msg || cause.message
     end
   end
 end

--- a/spec/friendly_shipping/api_error_spec.rb
+++ b/spec/friendly_shipping/api_error_spec.rb
@@ -13,5 +13,10 @@ RSpec.describe FriendlyShipping::ApiError do
   describe "#message" do
     subject { described_class.new(error, "yikes").message }
     it { is_expected.to eq("yikes") }
+
+    context "with no message provided" do
+      subject { described_class.new(error).message }
+      it { is_expected.to eq("oops") }
+    end
   end
 end


### PR DESCRIPTION
This updates the `ApiError` class to set the message from the cause when a message isn't passed to the initializer.