### PR TITLE
Use person name when company name is blank

### DIFF
--- a/lib/friendly_shipping/services/ups_freight/generate_location_hash.rb
+++ b/lib/friendly_shipping/services/ups_freight/generate_location_hash.rb
@@ -6,16 +6,14 @@ module FriendlyShipping
       class GenerateLocationHash
         class << self
           def call(location:)
-            # We ship freight here, which will mostly be used for businesses.
-            # If a personal name is given, treat is as the contact person ("AttentionName")
             {
-              Name: location.company_name,
+              Name: location.company_name.presence || location.name,
               Address: {
                 AddressLine: address_line(location),
                 City: location.city,
-                StateProvinceCode: location.region.code,
+                StateProvinceCode: location.region&.code,
                 PostalCode: location.zip,
-                CountryCode: location.country.code
+                CountryCode: location.country&.code
               },
               AttentionName: location.name,
               Phone: {

--- a/spec/friendly_shipping/services/ups_freight/generate_location_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_location_hash_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
   let(:location) do
     Physical::Location.new(
       company_name: 'Developer Test 1',
+      name: 'John Smith',
       address1: '01 Developer Way',
       address2: 'North',
       address3: 'In the Attic',
@@ -22,6 +23,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
   it 'has all the right things' do
     is_expected.to eq(
       Name: 'Developer Test 1',
+      AttentionName: 'John Smith',
       Address: {
         AddressLine: '01 Developer Way, North, In the Attic',
         City: 'Richmond',
@@ -36,6 +38,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
     let(:location) do
       Physical::Location.new(
         company_name: 'Developer Test 1',
+        name: 'John Smith',
         address1: '01 Developer Way',
         address2: 'North',
         address3: 'In the Attic',
@@ -50,6 +53,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
     it 'has all the right things' do
       is_expected.to eq(
         Name: 'Developer Test 1',
+        AttentionName: 'John Smith',
         Address: {
           AddressLine: '01 Developer Way, North, In the Attic',
           City: 'Richmond',
@@ -60,6 +64,22 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
         Phone: {
           Number: '999999999'
         }
+      )
+    end
+  end
+
+  context 'with a blank company name' do
+    let(:location) do
+      Physical::Location.new(
+        company_name: '',
+        name: 'John Smith'
+      )
+    end
+
+    it 'uses person name instead' do
+      is_expected.to include(
+        Name: 'John Smith',
+        AttentionName: 'John Smith'
       )
     end
   end


### PR DESCRIPTION
When generating location hashes for TForce Freight, fall back on the person's name if the company name is blank. This avoids errors from the API about a missing name in `ShipTo` when company is not provided.