### PR TITLE
Support Freight reference numbers

### DIFF
--- a/lib/friendly_shipping/services/ups_freight/generate_freight_ship_request_hash.rb
+++ b/lib/friendly_shipping/services/ups_freight/generate_freight_ship_request_hash.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'friendly_shipping/services/ups_freight/generate_location_hash'
+require 'friendly_shipping/services/ups_freight/generate_reference_hash'
 require 'friendly_shipping/services/ups_freight/generate_document_options_hash'
 require 'friendly_shipping/services/ups_freight/generate_email_options_hash'
 require 'friendly_shipping/services/ups_freight/generate_pickup_options_hash'
@@ -30,8 +31,10 @@ module FriendlyShipping
                   HandlingInstructions: options.handling_instructions,
                   PickupInstructions: options.pickup_instructions,
                   DeliveryInstructions: options.delivery_instructions,
-                  PickupRequest: GeneratePickupRequestHash.call(pickup_request_options: options.pickup_request_options)
-                }.compact.merge(handling_units(shipment, options).reduce(&:merge).to_h)
+                  PickupRequest: GeneratePickupRequestHash.call(pickup_request_options: options.pickup_request_options),
+                }.compact.
+                  merge(handling_units(shipment, options).reduce(&:merge).to_h).
+                  merge(GenerateReferenceHash.call(reference_numbers: options.reference_numbers))
               }
             }
           end

--- a/lib/friendly_shipping/services/ups_freight/generate_reference_hash.rb
+++ b/lib/friendly_shipping/services/ups_freight/generate_reference_hash.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class UpsFreight
+      class GenerateReferenceHash
+        class << self
+          # @param [Array] reference_numbers Reference numbers for the Bill of Lading
+          # @return [Hash] Reference hash suitable for JSON request
+          def call(reference_numbers:)
+            return {} unless reference_numbers
+
+            references = reference_numbers.map do |reference_number|
+              {
+                Number: {
+                  Code: reference_number[:code],
+                  Value: reference_number[:value]
+                }
+              }
+            end
+            references.any? ? { Reference: references } : {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups_freight/label_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/label_options.rb
@@ -4,14 +4,30 @@ module FriendlyShipping
   module Services
     class UpsFreight
       class LabelOptions < RatesOptions
+        REFERENCE_NUMBER_CODES = {
+          bill_of_lading_number: "57",
+          purchase_order_number: "28",
+          shipper_reference: "SH",
+          consignee_reference: "CO",
+          pm: "PM",
+          proj: "PROJ",
+          quote: "QUOTE",
+          sid: "SID",
+          task: "TASK",
+          vprc: "VPRC",
+          other: "OTHER"
+        }.freeze
+
         attr_reader :document_options,
                     :email_options,
                     :pickup_options,
                     :delivery_options,
                     :pickup_instructions,
                     :delivery_instructions,
-                    :handling_instructions
+                    :handling_instructions,
+                    :reference_numbers
 
+        # @param [Array] reference_numbers Reference numbers for the Bill of Lading
         def initialize(
           document_options: [],
           email_options: [],
@@ -20,6 +36,7 @@ module FriendlyShipping
           pickup_instructions: nil,
           delivery_instructions: nil,
           handling_instructions: nil,
+          reference_numbers: [],
           **kwargs
         )
           @pickup_options = pickup_options
@@ -29,7 +46,16 @@ module FriendlyShipping
           @pickup_instructions = pickup_instructions
           @delivery_instructions = delivery_instructions
           @handling_instructions = handling_instructions
+          @reference_numbers = fill_codes(reference_numbers)
           super kwargs
+        end
+
+        private
+
+        def fill_codes(reference_numbers)
+          reference_numbers.each do |reference_number|
+            reference_number[:code] = REFERENCE_NUMBER_CODES.fetch(reference_number[:code])
+          end
         end
       end
     end

--- a/spec/friendly_shipping/services/ups_freight/generate_freight_ship_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_freight_ship_request_hash_spec.rb
@@ -375,5 +375,33 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateFreightShipReques
         end
       end
     end
+
+    describe "Reference information" do
+      let(:options) do
+        FriendlyShipping::Services::UpsFreight::LabelOptions.new(
+          shipping_method: FriendlyShipping::ShippingMethod.new(service_code: '308'),
+          shipper_number: 'xxx1234',
+          billing_address: billing_location,
+          reference_numbers: [
+            { code: :purchase_order_number, value: "H123456" },
+            { code: :consignee_reference, value: "55473" }
+          ]
+        )
+      end
+
+      subject(:references) { freight_ship_request["Reference"] }
+
+      it { is_expected.to be_a(Array) }
+
+      context "first reference" do
+        subject(:first_reference) { references.first }
+        it { is_expected.to eq("Number" => { "Code" => "28", "Value" => "H123456" }) }
+      end
+
+      context "second reference" do
+        subject(:second_reference) { references.last }
+        it { is_expected.to eq("Number" => { "Code" => "CO", "Value" => "55473" }) }
+      end
+    end
   end
 end

--- a/spec/friendly_shipping/services/ups_freight/generate_reference_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_reference_hash_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ups_freight/generate_reference_hash'
+
+RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateReferenceHash do
+  let(:reference_numbers) do
+    [
+      { code: "57", value: "1234" },
+      { code: "CO", value: "5678" }
+    ]
+  end
+
+  subject { described_class.call(reference_numbers: reference_numbers) }
+
+  it "has all the right things" do
+    is_expected.to eq(
+      Reference: [
+        {
+          Number: {
+            Code: "57",
+            Value: "1234"
+          }
+        }, {
+          Number: {
+            Code: "CO",
+            Value: "5678"
+          }
+        }
+      ]
+    )
+  end
+
+  context "with nil reference numbers" do
+    let(:reference_numbers) { nil }
+    it { is_expected.to eq({}) }
+  end
+
+  context "with empty reference numbers" do
+    let(:reference_numbers) { [] }
+    it { is_expected.to eq({}) }
+  end
+end

--- a/spec/friendly_shipping/services/ups_freight/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/label_options_spec.rb
@@ -4,11 +4,13 @@ require 'spec_helper'
 require 'friendly_shipping/services/ups_freight/label_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::LabelOptions do
+  let(:reference_numbers) { [] }
   subject do
     described_class.new(
       shipper_number: 'my_shipper_number',
       billing_address: double,
-      shipping_method: double
+      shipping_method: double,
+      reference_numbers: reference_numbers
     )
   end
 
@@ -16,4 +18,22 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::LabelOptions do
   it { is_expected.to respond_to(:pickup_instructions) }
   it { is_expected.to respond_to(:delivery_instructions) }
   it { is_expected.to respond_to(:handling_instructions) }
+
+  describe "#reference_numbers" do
+    let(:reference_numbers) do
+      [
+        { code: :bill_of_lading_number, value: "123" },
+        { code: :consignee_reference, value: "456" }
+      ]
+    end
+
+    it "fills codes from lookup table" do
+      expect(subject.reference_numbers).to eq(
+        [
+          { code: "57", value: "123" },
+          { code: "CO", value: "456" }
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
This adds support for passing reference numbers in Freight label options. These reference numbers appear on the Bill of Lading. Each reference number has a code and a value. Reference numbers are passed into the label options as an array of hashes, each hash containing code and value keys. For example:

```ruby
FriendlyShipping::Services::UpsFreight::LabelOptions.new(
  reference_numbers: [
    {
      code: :bill_of_lading_number,
      value: "43195814"
    },{
      code: :consignee_reference,
      value: "A983194"
    }
  ]
)
```

A table of reference number codes can be found in the TForce API documentation, as well as at `FriendlyShipping::Services::UpsFreight::GenerateReferenceHash::REFERENCE_NUMBER_CODES`