### PR TITLE
Parse Freight label responses with missing rates

### DIFF
--- a/spec/fixtures/ups_freight/labels/success_without_rates.json
+++ b/spec/fixtures/ups_freight/labels/success_without_rates.json
@@ -1,0 +1,51 @@
+{
+  "FreightShipResponse": {
+    "Response": {
+      "Alert": {
+        "Code": "9369056",
+        "Description": "No rates available."
+      },
+      "ResponseStatus": {
+        "Code": "1",
+        "Description": "Success"
+      }
+    },
+    "ShipmentResults": {
+      "OriginServiceCenterCode": "RIC",
+      "ShipmentNumber": "022438065",
+      "PickupRequestConfirmationNumber": "348742132",
+      "BOLID": "45760188",
+      "BillableShipmentWeight": {
+        "UnitOfMeasurement": {
+          "Code": "LBS"
+        },
+        "Value": "500"
+      },
+      "Service": {
+        "Code": "308"
+      },
+      "Documents": {
+        "Image": [
+          {
+            "Type": {
+              "Code": "30"
+            },
+            "GraphicImage": "JVBERi0xLjMKJf",
+            "Format": {
+              "Code": "PDF"
+            }
+          },
+          {
+            "Type": {
+              "Code": "20"
+            },
+            "GraphicImage": "JVBERi0xLjUKJf",
+            "Format": {
+              "Code": "PDF"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
@@ -51,4 +51,43 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ParseFreightLabelResponse
       }
     )
   end
+
+  context 'when rates are missing from response' do
+    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ups_freight', 'labels', 'success_without_rates.json')).read }
+
+    it 'has the right shipment information' do
+      shipment_information = subject.data
+      expect(shipment_information).to be_a(FriendlyShipping::Services::UpsFreight::ShipmentInformation)
+
+      expect(shipment_information.documents.size).to eq(2)
+      expect(shipment_information.documents).to all(be_a(FriendlyShipping::Services::UpsFreight::ShipmentDocument))
+
+      expect(shipment_information.documents.first.format).to eq(:pdf)
+      expect(shipment_information.documents.first.document_type).to eq(:label)
+      expect(shipment_information.documents.first.binary).to be_present
+
+      expect(shipment_information.documents.last.format).to eq(:pdf)
+      expect(shipment_information.documents.last.document_type).to eq(:ups_bol)
+      expect(shipment_information.documents.last.binary).to be_present
+
+      expect(shipment_information.number).to eq("022438065")
+      expect(shipment_information.pickup_request_number).to eq("348742132")
+      expect(shipment_information.total).to be_nil
+      expect(shipment_information.bol_id).to eq("45760188")
+
+      expect(shipment_information.shipping_method).to be_a(FriendlyShipping::ShippingMethod)
+      expect(shipment_information.shipping_method.name).to eq("UPS Freight LTL")
+      expect(shipment_information.shipping_method.service_code).to eq("308")
+
+      expect(shipment_information.warnings).to eq("9369056: No rates available.")
+      expect(shipment_information.data).to eq(
+        {
+          cost_breakdown: {
+            "BillableShipmentWeight" => "500",
+            "Rates" => {}
+          }
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
This updates the Freight rate response parser to gracefully handle responses with missing rates. TForce/UPS is not able to include rates in label responses when the `ResidentialDeliveryIndicator` and `CallBeforeDeliveryIndicator` are both set in the request. This means we cannot attach a cost breakdown to the `ApiResult` returned from the parser.