### PR TITLE
Use `FriendlyShipping::Response` in default error handler

### DIFF
--- a/lib/friendly_shipping/api_error_handler.rb
+++ b/lib/friendly_shipping/api_error_handler.rb
@@ -14,15 +14,15 @@ module FriendlyShipping
     end
 
     # @param [StandardError] error
-    # @param [Object] original_request
-    # @param [Object] original_response
+    # @param [FriendlyShipping::Request] original_request
+    # @param [RestClient::Response] original_response
     # @return [Dry::Monads::Failure<FriendlyShipping::ApiFailure>]
     def call(error, original_request: nil, original_response: nil)
       Failure(
         ApiFailure.new(
           api_error_class.new(error),
           original_request: original_request,
-          original_response: original_response
+          original_response: Response.new_from_rest_client_response(original_response)
         )
       )
     end

--- a/lib/friendly_shipping/http_client.rb
+++ b/lib/friendly_shipping/http_client.rb
@@ -22,7 +22,7 @@ module FriendlyShipping
         request.url, request.headers
       )
 
-      Success(convert_to_friendly_response(http_response))
+      Success(Response.new_from_rest_client_response(http_response))
     rescue ::RestClient::Exception => e
       error_handler.call(e, original_request: request, original_response: e.response)
     end
@@ -34,7 +34,7 @@ module FriendlyShipping
         request.headers
       )
 
-      Success(convert_to_friendly_response(http_response))
+      Success(Response.new_from_rest_client_response(http_response))
     rescue ::RestClient::Exception => e
       error_handler.call(e, original_request: request, original_response: e.response)
     end
@@ -46,19 +46,9 @@ module FriendlyShipping
         request.headers
       )
 
-      Success(convert_to_friendly_response(http_response))
+      Success(Response.new_from_rest_client_response(http_response))
     rescue ::RestClient::Exception => e
       error_handler.call(e, original_request: request, original_response: e.response)
-    end
-
-    private
-
-    def convert_to_friendly_response(http_response)
-      FriendlyShipping::Response.new(
-        status: http_response.code,
-        body: http_response.body,
-        headers: http_response.headers
-      )
     end
   end
 end

--- a/lib/friendly_shipping/response.rb
+++ b/lib/friendly_shipping/response.rb
@@ -12,5 +12,23 @@ module FriendlyShipping
       @body = body
       @headers = headers
     end
+
+    # @param [Object] other
+    def ==(other)
+      other.class == self.class &&
+        other.attributes == attributes
+    end
+
+    alias_method :eql?, :==
+
+    def hash
+      attributes.hash
+    end
+
+    protected
+
+    def attributes
+      [status, body, headers]
+    end
   end
 end

--- a/lib/friendly_shipping/response.rb
+++ b/lib/friendly_shipping/response.rb
@@ -13,6 +13,8 @@ module FriendlyShipping
       @headers = headers || {}
     end
 
+    alias_method :code, :status
+
     # @param [RestClient::Response] response
     # @return [FriendlyShipping::Response]
     def self.new_from_rest_client_response(response)

--- a/lib/friendly_shipping/response.rb
+++ b/lib/friendly_shipping/response.rb
@@ -10,7 +10,13 @@ module FriendlyShipping
     def initialize(status:, body:, headers:)
       @status = status
       @body = body
-      @headers = headers
+      @headers = headers || {}
+    end
+
+    # @param [RestClient::Response] response
+    # @return [FriendlyShipping::Response]
+    def self.new_from_rest_client_response(response)
+      new(status: response&.code, body: response&.body, headers: response&.headers)
     end
 
     # @param [Object] other

--- a/spec/friendly_shipping/response_spec.rb
+++ b/spec/friendly_shipping/response_spec.rb
@@ -13,6 +13,28 @@ RSpec.describe FriendlyShipping::Response do
   it { is_expected.to respond_to(:body) }
   it { is_expected.to respond_to(:headers) }
 
+  describe ".new_from_rest_client_response" do
+    subject(:new_from_rest_client_response) do
+      described_class.new_from_rest_client_response(rest_client_response)
+    end
+
+    let(:rest_client_response) do
+      instance_double(
+        RestClient::Response,
+        code: status,
+        body: body,
+        headers: headers
+      )
+    end
+
+    it { is_expected.to eq(described_class.new(status: status, body: body, headers: headers)) }
+
+    context "with nil response" do
+      let(:rest_client_response) { nil }
+      it { is_expected.to eq(described_class.new(status: nil, body: nil, headers: {})) }
+    end
+  end
+
   describe "#==" do
     subject(:equality) { response == other }
 

--- a/spec/friendly_shipping/response_spec.rb
+++ b/spec/friendly_shipping/response_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe FriendlyShipping::Response do
   it { is_expected.to respond_to(:status) }
   it { is_expected.to respond_to(:body) }
   it { is_expected.to respond_to(:headers) }
+  it { is_expected.to respond_to(:code) }
 
   describe ".new_from_rest_client_response" do
     subject(:new_from_rest_client_response) do

--- a/spec/friendly_shipping/response_spec.rb
+++ b/spec/friendly_shipping/response_spec.rb
@@ -7,9 +7,35 @@ RSpec.describe FriendlyShipping::Response do
   let(:body) { "Hello!" }
   let(:headers) { { "X-Header" => "Nice" } }
 
-  subject { described_class.new(status: status, body: body, headers: headers) }
+  subject(:response) { described_class.new(status: status, body: body, headers: headers) }
 
   it { is_expected.to respond_to(:status) }
   it { is_expected.to respond_to(:body) }
   it { is_expected.to respond_to(:headers) }
+
+  describe "#==" do
+    subject(:equality) { response == other }
+
+    context "when attributes match" do
+      let(:other) { response }
+      it { is_expected.to be(true) }
+    end
+
+    context "when attributes do not match" do
+      let(:other) { described_class.new(status: 404, body: "File Not Found", headers: {}) }
+      it { is_expected.to be(false) }
+    end
+
+    context "when class does not match" do
+      let(:other) { String.new }
+      it { is_expected.to be(false) }
+    end
+  end
+
+  it { is_expected.to respond_to(:eql?) }
+
+  describe "#hash" do
+    subject(:hash) { response.hash }
+    it { is_expected.to eq([status, body, headers].hash) }
+  end
 end


### PR DESCRIPTION
This updates our default API error handler to return a `FriendlyShipping::Response` as the original response instead of the underlying `RestClient::Response` when an HTTP error occurs (i.e. 503 gateway error).

This ensures anyone using our HTTP client will receive a consistent response class whether they get a successful response from the API, an error response from the API, or an HTTP error response.

For a successful response or an API error, the value returned by the client will be a `FriendlyShipping::Response`.  For an HTTP error which triggers the error handler, the original response retrieved from the `ApiFailure` will also be a `FriendlyShipping::Response` instead of a `RestClient::Response`.