### PR TITLE
Restrict URI gem to < 0.11.0

### DIFF
--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "nokogiri", "~> 1.6"
   spec.add_runtime_dependency "physical", "~> 0.4", ">= 0.4.4"
   spec.add_runtime_dependency "rest-client", "~> 2.0"
+  spec.add_runtime_dependency "uri", "< 0.11.0"
   spec.required_ruby_version = '>= 2.5'
 
   spec.add_development_dependency "bundler", ">= 2.1.4", "< 3"


### PR DESCRIPTION
The URI gem has changed its public API with this version, breaking compatibility with the largely unmaintained `data_uri` gem. This fixes the co-dependency issue for now; once this PR in `data_uri` is merged we can update to the newest `uri` gem:

https://github.com/dball/data_uri/pull/10