### PR TITLE
Pass multiple address lines to TForce correctly

### DIFF
--- a/lib/friendly_shipping/services/ups_freight/generate_location_hash.rb
+++ b/lib/friendly_shipping/services/ups_freight/generate_location_hash.rb
@@ -25,13 +25,12 @@ module FriendlyShipping
           private
 
           def address_line(location)
-            [
+            address_lines = [
               location.address1,
               location.address2,
               location.address3
-            ].compact.
-              reject(&:empty?).
-              join(", ")
+            ].compact.reject(&:empty?)
+            address_lines.size > 1 ? address_lines : address_lines.first
           end
         end
       end

--- a/spec/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateFreightRateReques
     ::Physical::Location.new(
       name: "Donald Duck",
       company_name: "Duck Science",
-      address1: "Duck Street, Duck Window 2",
+      address1: "Duck Street",
+      address2: "Duck Window 2",
       city: "Ducktown",
       zip: "54321",
       region: "NC",
@@ -174,7 +175,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateFreightRateReques
             "ShipperNumber" => "xxx1234",
             "AttentionName" => "Donald Duck",
             "Address" => hash_including(
-              "AddressLine" => "Duck Street, Duck Window 2",
+              "AddressLine" => ["Duck Street", "Duck Window 2"],
               "City" => "Ducktown",
               "StateProvinceCode" => "NC",
               "PostalCode" => "54321",

--- a/spec/friendly_shipping/services/ups_freight/generate_location_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_location_hash_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
       company_name: 'Developer Test 1',
       name: 'John Smith',
       address1: '01 Developer Way',
-      address2: 'North',
-      address3: 'In the Attic',
       city: 'Richmond',
       zip: '23224',
       region: 'VA',
@@ -25,7 +23,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
       Name: 'Developer Test 1',
       AttentionName: 'John Smith',
       Address: {
-        AddressLine: '01 Developer Way, North, In the Attic',
+        AddressLine: '01 Developer Way',
         City: 'Richmond',
         StateProvinceCode: 'VA',
         PostalCode: '23224',
@@ -40,8 +38,6 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
         company_name: 'Developer Test 1',
         name: 'John Smith',
         address1: '01 Developer Way',
-        address2: 'North',
-        address3: 'In the Attic',
         phone: '999999999',
         city: 'Richmond',
         zip: '23224',
@@ -55,7 +51,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
         Name: 'Developer Test 1',
         AttentionName: 'John Smith',
         Address: {
-          AddressLine: '01 Developer Way, North, In the Attic',
+          AddressLine: '01 Developer Way',
           City: 'Richmond',
           StateProvinceCode: 'VA',
           PostalCode: '23224',
@@ -80,6 +76,32 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
       is_expected.to include(
         Name: 'John Smith',
         AttentionName: 'John Smith'
+      )
+    end
+  end
+
+  context 'with multiple address lines' do
+    let(:location) do
+      Physical::Location.new(
+        address1: '01 Developer Way',
+        address2: 'North',
+        address3: 'In the Attic',
+        city: 'Richmond',
+        zip: '23224',
+        region: 'VA',
+        country: 'US'
+      )
+    end
+
+    it 'has all the right things' do
+      is_expected.to eq(
+        Address: {
+          AddressLine: ['01 Developer Way', 'North', 'In the Attic'],
+          City: 'Richmond',
+          StateProvinceCode: 'VA',
+          PostalCode: '23224',
+          CountryCode: 'US'
+        }
       )
     end
   end


### PR DESCRIPTION
TForce (formerly UPS Freight) accepts multiple address lines as an array. The first and second address lines, when provided, will appear on the shipping label and BOL shipping documents.