### PR TITLE
Use Ruby 3.0 for CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.5
+       - image: circleci/ruby:3.0.4
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/spec/friendly_shipping/http_client_spec.rb
+++ b/spec/friendly_shipping/http_client_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe FriendlyShipping::HttpClient do
     let(:response) { double(code: 200, body: 'so much text', headers: {}) }
 
     it 'forwards the arguments to RestClient and returns a Success' do
-      expect(::RestClient).to receive(:get).with('https://example.com', "X-Token" => "s3cr3t").and_return(response)
+      expect(::RestClient).to receive(:get).with('https://example.com', { "X-Token" => "s3cr3t" }).and_return(response)
       result = subject.get(request)
       expect(result).to be_success
     end
 
     it 'wraps exceptions in Failures' do
-      expect(::RestClient).to receive(:get).with('https://example.com', "X-Token" => "s3cr3t").and_raise(RestClient::ExceptionWithResponse)
+      expect(::RestClient).to receive(:get).with('https://example.com', { "X-Token" => "s3cr3t" }).and_raise(RestClient::ExceptionWithResponse)
       result = subject.get(request)
       expect(result).to be_failure
       expect(result.failure).to be_a(FriendlyShipping::ApiFailure)
@@ -36,13 +36,13 @@ RSpec.describe FriendlyShipping::HttpClient do
     let(:response) { double(code: 200, body: 'ok', headers: {}) }
 
     it 'forwards the arguments to RestClient and returns a Success' do
-      expect(::RestClient).to receive(:post).with('https://example.com', 'body', "X-Token" => "s3cr3t").and_return(response)
+      expect(::RestClient).to receive(:post).with('https://example.com', 'body', { "X-Token" => "s3cr3t" }).and_return(response)
       result = subject.post(request)
       expect(result).to be_success
     end
 
     it 'wraps exceptions in Failures' do
-      expect(::RestClient).to receive(:post).with('https://example.com', 'body', "X-Token" => "s3cr3t").and_raise(RestClient::ExceptionWithResponse)
+      expect(::RestClient).to receive(:post).with('https://example.com', 'body', { "X-Token" => "s3cr3t" }).and_raise(RestClient::ExceptionWithResponse)
       result = subject.post(request)
       expect(result).to be_failure
       expect(result.failure).to be_a(FriendlyShipping::ApiFailure)
@@ -54,13 +54,13 @@ RSpec.describe FriendlyShipping::HttpClient do
     let(:response) { double(code: 200, body: 'ok', headers: {}) }
 
     it 'forwards the arguments to RestClient and returns a Success' do
-      expect(::RestClient).to receive(:put).with('https://example.com', 'body', "X-Token" => "s3cr3t").and_return(response)
+      expect(::RestClient).to receive(:put).with('https://example.com', 'body', { "X-Token" => "s3cr3t" }).and_return(response)
       result = subject.put(request)
       expect(result).to be_success
     end
 
     it 'wraps exceptions in Failures' do
-      expect(::RestClient).to receive(:put).with('https://example.com', 'body', "X-Token" => "s3cr3t").and_raise(RestClient::ExceptionWithResponse)
+      expect(::RestClient).to receive(:put).with('https://example.com', 'body', { "X-Token" => "s3cr3t" }).and_raise(RestClient::ExceptionWithResponse)
       result = subject.put(request)
       expect(result).to be_failure
       expect(result.failure).to be_a(FriendlyShipping::ApiFailure)


### PR DESCRIPTION
This updates our CircleCI config to use Ruby 3.0 for builds. Also fixes a spec that breaks under Ruby 3.