### PR TITLE
Include Dimensions regardless of package_code

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -53,16 +53,13 @@ module FriendlyShipping
                 ["reference#{index + 1}".to_sym, message]
               end.to_h
 
-              if package_options.package_code
-                package_hash[:package_code] = package_options.package_code
-              else
-                package_hash[:dimensions] = {
-                  unit: 'inch',
-                  width: package.container.width.convert_to(:inches).value.to_f.round(2),
-                  length: package.container.length.convert_to(:inches).value.to_f.round(2),
-                  height: package.container.height.convert_to(:inches).value.to_f.round(2)
-                }
-              end
+              package_hash[:package_code] = package_options.package_code
+              package_hash[:dimensions] = {
+                unit: 'inch',
+                width: package.container.width.convert_to(:inches).value.to_f.round(2),
+                length: package.container.length.convert_to(:inches).value.to_f.round(2),
+                height: package.container.height.convert_to(:inches).value.to_f.round(2)
+              }
               package_hash
             end
           end

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -80,12 +80,12 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
       ]
     end
 
-    it 'does not include the dimensions array' do
+    it 'still includes the dimensions array' do
       is_expected.to match(
         hash_including(
           shipment: hash_including(
             packages: array_including(
-              hash_not_including(:dimensions)
+              hash_including(:dimensions)
             )
           )
         )


### PR DESCRIPTION
# Bug Fix - Missing dimensions
[ShipEngine Documentation](https://shipengine.github.io/shipengine-openapi/#operation/create_label) PackageCode `package` is considered a custom or unknown package type. As such the dimensions should be included to ensure best rate for creating a label