### PR TITLE
ShipEngine Label Image

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/label_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_options.rb
@@ -10,22 +10,26 @@ module FriendlyShipping
       # @attribute label_format [Symbol] The format for the label. Possible Values: :png, :zpl and :pdf. Default :pdf
       # @attribute label_download_type [Symbol] Whether to download directly (`:inline`) or
       #   obtain a URL to the label (`:url`). Default :url
+      # @attribute label_image_id [String] Identifier for image uploaded to ShipEngine. Default: nil
       # @attribute package_options [Enumberable<LabelPackageOptions>] Package options for the packages in the shipment
       #
       class LabelOptions < FriendlyShipping::ShipmentOptions
         attr_reader :shipping_method,
+                    :label_download_type,
                     :label_format,
-                    :label_download_type
+                    :label_image_id
 
         def initialize(
           shipping_method:,
-          label_format: :pdf,
           label_download_type: :url,
+          label_format: :pdf,
+          label_image_id: nil,
           **kwargs
         )
           @shipping_method = shipping_method
-          @label_format = label_format
           @label_download_type = label_download_type
+          @label_format = label_format
+          @label_image_id = label_image_id
           super(**kwargs.merge(package_options_class: LabelPackageOptions))
         end
       end

--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -25,6 +25,10 @@ module FriendlyShipping
               shipment_hash[:test_label] = true
             end
 
+            if options.label_image_id
+              shipment_hash[:label_image_id] = options.label_image_id
+            end
+
             shipment_hash
           end
 

--- a/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ship_engine/label_options'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::LabelOptions do
+  subject(:options) { described_class.new(shipping_method: double) }
+
+  [
+    :shipping_method,
+    :label_format,
+    :label_download_type,
+    :label_image_id
+  ].each do |message|
+    it { is_expected.to respond_to(message) }
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
     )
   end
 
+  it 'does not include label_image_id by default' do
+    is_expected.not_to match(hash_including(:label_image_id))
+  end
+
   context 'if the container is a special USPS thing' do
     let(:package_options) do
       [
@@ -199,6 +203,21 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
           )
         )
       )
+    end
+  end
+
+  context 'if passing a label image id' do
+    let(:options) do
+      FriendlyShipping::Services::ShipEngine::LabelOptions.new(
+        shipping_method: shipping_method,
+        label_image_id: "img_DtBXupDBxREpHnwEXhTfgK",
+        label_format: :zpl,
+        package_options: package_options
+      )
+    end
+
+    it do
+      is_expected.to match(hash_including(label_image_id: "img_DtBXupDBxREpHnwEXhTfgK"))
     end
   end
 end


### PR DESCRIPTION
To print an image on labels with ShipEngine you need to include label_image_id with Label options 

[ShipEngine Documentation](https://www.shipengine.com/docs/labels/branding/#example)