### PR TITLE
Allow ups international billing for duties and fees only 

### DIFF
--- a/lib/friendly_shipping/services/ups/parse_shipment_accept_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_shipment_accept_response.rb
@@ -66,7 +66,7 @@ module FriendlyShipping
 
           def get_shipment_cost(shipment_xml)
             total_charges_element = shipment_xml.at('ShipmentResults/ShipmentCharges/TotalCharges')
-            ParseMoneyElement.call(total_charges_element).last
+            ParseMoneyElement.call(total_charges_element)&.last
           end
 
           def get_negotiated_rate(shipment_xml)

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -123,7 +123,7 @@ module FriendlyShipping
 
                     contents_description = shipment.packages.flat_map do |package|
                       package.items.map(&:description)
-                    end.compact.join(', ')
+                    end.compact.join(', ').slice(0, 50)
 
                     unless contents_description.empty?
                       xml.Description(contents_description)
@@ -207,7 +207,7 @@ module FriendlyShipping
 
           def build_billing_info_node(xml, options, bill_to_consignee: false)
             billing_options = options.billing_options
-            if billing_options.bill_third_party
+            if billing_options.bill_third_party || bill_to_consignee
               xml.BillThirdParty do
                 node_type = bill_to_consignee ? :BillThirdPartyConsignee : :BillThirdPartyShipper
                 xml.public_send(node_type) do


### PR DESCRIPTION
This change allows billing for international shipments to have first party billing for the shipping and third party for the duties and fees.

There are a couple of small changes for conditions that UPS enforces: truncate contents description to UPS max, protect against nil shipment cost