### PR TITLE
UPS ShipTo International Constraint

### DIFF
--- a/lib/friendly_shipping/services/ups/serialize_address_snippet.rb
+++ b/lib/friendly_shipping/services/ups/serialize_address_snippet.rb
@@ -5,8 +5,11 @@ module FriendlyShipping
     class Ups
       class SerializeAddressSnippet
         class << self
-          def call(xml:, location:)
-            if location.company_name # Is this a business address?
+          def call(xml:, location:, international: false)
+            if international
+              name = (location.company_name || location.name)[0..34]
+              attention_name = location.name
+            elsif location.company_name # Is this a business address?
               name = location.company_name[0..34]
               attention_name = location.name
             else

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -9,6 +9,7 @@ module FriendlyShipping
       class SerializeShipmentConfirmRequest
         class << self
           # Item options (only necessary for international shipping)
+          # ShipTo CompanyName & AttentionName required for international shipping
           #
           # @option description [String] A description of the item for the intl. invoice
           # @option commodity_code [String] Commodity code for the item. See https://www.tariffnumber.com/
@@ -41,7 +42,7 @@ module FriendlyShipping
                   end
 
                   xml.ShipTo do
-                    SerializeShipmentAddressSnippet.call(xml: xml, location: shipment.destination)
+                    SerializeShipmentAddressSnippet.call(xml: xml, location: shipment.destination, international: international?(shipment))
                   end
 
                   # Required element. The company whose account is responsible for the label(s).

--- a/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
@@ -141,9 +141,8 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
     end
 
     it "contains the name of the recipient instead of the company" do
-      expect(
-        subject.at_xpath('//ShipmentConfirmRequest/Shipment/ShipTo/CompanyName').text
-      ).to eq("Jane Doe")
+      expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/ShipTo/CompanyName').text).to eq("Jane Doe")
+      expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/ShipTo/AttentionName')).not_to be_present
     end
   end
 
@@ -244,6 +243,27 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
       expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/ItemizedPaymentInformation/ShipmentCharge/BillShipper/AccountNumber').text).to eq('X234X')
       expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/ItemizedPaymentInformation/ShipmentCharge/BillThirdParty/BillThirdPartyConsignee/AccountNumber').text).to eq('12345')
       expect(subject.at('Shipment/Description').text).to eq('Wooden block')
+      expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/ShipTo/CompanyName').text).to eq("Company")
+      expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/ShipTo/AttentionName').text).to eq("Jane Doe")
+    end
+
+    context 'with a private address (without company)' do
+      let(:destination) do
+        FactoryBot.build(
+          :physical_location,
+          company_name: nil,
+          address1: '1000 Airport Rd',
+          city: 'Edmonton',
+          region: 'AB',
+          zip: 'T9E 0V3',
+          country: 'CA'
+        )
+      end
+
+      it 'contains the relevant xml elements' do
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/ShipTo/CompanyName').text).to eq("Jane Doe")
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/ShipTo/AttentionName').text).to eq("Jane Doe")
+      end
     end
   end
 end


### PR DESCRIPTION
UPS International Shipping requires both CompanyName and AttentionName for ShipTo address