### PR TITLE
Add ShipEngine support for international labels

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/label_customs_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_customs_options.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class ShipEngine
+      # Represents customs options for obtaining international shipment labels.
+      # @option contents [String] The contents of the shipment.
+      #  Valid values are: gift, merchandise, returned_goods, documents, sample
+      # @option non_delivery [String] Indicates what should be done if the shipment cannot be delivered.
+      #  Valid values are: treat_as_abandoned, return_to_sender
+      class LabelCustomsOptions
+        attr_reader :contents,
+                    :non_delivery
+
+        def initialize(
+          contents: "merchandise",
+          non_delivery: "return_to_sender"
+        )
+          @contents = contents
+          @non_delivery = non_delivery
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ship_engine/label_item_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_item_options.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/item_options'
+
+module FriendlyShipping
+  module Services
+    class ShipEngine
+      # Represents item options for obtaining shipment labels.
+      # @option commodity_code [String] This item's HS or NMFC code for international shipments.
+      # @option country_of_origin [String] This item's country of origin for international shipments.
+      class LabelItemOptions < FriendlyShipping::ItemOptions
+        attr_reader :commodity_code,
+                    :country_of_origin
+
+        def initialize(
+          commodity_code: nil,
+          country_of_origin: nil,
+          **kwargs
+        )
+          @commodity_code = commodity_code
+          @country_of_origin = country_of_origin
+          super(**kwargs)
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ship_engine/label_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_options.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'friendly_shipping/shipment_options'
+require 'friendly_shipping/services/ship_engine/label_customs_options'
 
 module FriendlyShipping
   module Services
@@ -17,19 +18,22 @@ module FriendlyShipping
         attr_reader :shipping_method,
                     :label_download_type,
                     :label_format,
-                    :label_image_id
+                    :label_image_id,
+                    :customs_options
 
         def initialize(
           shipping_method:,
           label_download_type: :url,
           label_format: :pdf,
           label_image_id: nil,
+          customs_options: LabelCustomsOptions.new,
           **kwargs
         )
           @shipping_method = shipping_method
           @label_download_type = label_download_type
           @label_format = label_format
           @label_image_id = label_image_id
+          @customs_options = customs_options
           super(**kwargs.merge(package_options_class: LabelPackageOptions))
         end
       end

--- a/lib/friendly_shipping/services/ship_engine/label_package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_package_options.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'friendly_shipping/package_options'
+require 'friendly_shipping/services/ship_engine/label_item_options'
 
 module FriendlyShipping
   module Services
@@ -20,7 +21,7 @@ module FriendlyShipping
         def initialize(package_code: nil, messages: [], **kwargs)
           @package_code = package_code
           @messages = messages
-          super(**kwargs)
+          super(**kwargs.merge(item_options_class: LabelItemOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/usps_international.rb
+++ b/lib/friendly_shipping/services/usps_international.rb
@@ -17,7 +17,7 @@ module FriendlyShipping
         rectanglular: 'RECTANGULAR',
         roll: 'ROLL',
         variable: 'VARIABLE'
-      }
+      }.freeze
 
       MAIL_TYPES = {
         all: 'ALL',
@@ -28,7 +28,7 @@ module FriendlyShipping
         large_envelope: 'LARGEENVELOPE',
         package: 'PACKAGE',
         post_cards: 'POSTCARDS'
-      }
+      }.freeze
 
       TEST_URL = 'https://stg-secure.shippingapis.com/ShippingAPI.dll'
       LIVE_URL = 'https://secure.shippingapis.com/ShippingAPI.dll'

--- a/lib/friendly_shipping/services/usps_international/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/usps_international/parse_rate_response.rb
@@ -30,7 +30,7 @@ module FriendlyShipping
 
               rates = SHIPPING_METHODS.map do |shipping_method|
                 # For every package ...
-                matching_rates = rates_by_package.map do |package, package_rates|
+                matching_rates = rates_by_package.map do |_package, package_rates|
                   # ... choose the rate that matches the shipping method for this package
                   package_rates.select { |r| r.shipping_method == shipping_method }.first
                 end.compact # Some shipping rates are not available for every shipping method.

--- a/spec/friendly_shipping/services/ship_engine/label_customs_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_customs_options_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ship_engine/label_customs_options'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::LabelCustomsOptions do
+  subject(:options) { described_class.new }
+
+  [
+    :contents,
+    :non_delivery
+  ].each do |message|
+    it { is_expected.to respond_to(message) }
+  end
+
+  context "contents" do
+    subject(:contents) { options.contents }
+    it { is_expected.to eq("merchandise") }
+  end
+
+  context "non_delivery" do
+    subject(:contents) { options.non_delivery }
+    it { is_expected.to eq("return_to_sender") }
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine/label_item_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_item_options_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ship_engine/label_item_options'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::LabelItemOptions do
+  subject(:options) { described_class.new(item_id: "123") }
+
+  [
+    :commodity_code,
+    :country_of_origin
+  ].each do |message|
+    it { is_expected.to respond_to(message) }
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'friendly_shipping/services/ship_engine/label_options'
+require 'friendly_shipping/services/ship_engine/label_customs_options'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::LabelOptions do
   subject(:options) { described_class.new(shipping_method: double) }
@@ -10,8 +11,14 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::LabelOptions do
     :shipping_method,
     :label_format,
     :label_download_type,
-    :label_image_id
+    :label_image_id,
+    :customs_options
   ].each do |message|
     it { is_expected.to respond_to(message) }
+  end
+
+  context "customs_options" do
+    subject(:customs_options) { options.customs_options }
+    it { is_expected.to be_a(FriendlyShipping::Services::ShipEngine::LabelCustomsOptions) }
   end
 end

--- a/spec/friendly_shipping/services/ship_engine/label_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_package_options_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ship_engine/label_package_options'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::LabelPackageOptions do
+  subject(:options) { described_class.new(package_id: "123") }
+
+  [
+    :package_code,
+    :messages
+  ].each do |message|
+    it { is_expected.to respond_to(message) }
+  end
+end

--- a/spec/friendly_shipping/services/usps_international/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps_international/rate_estimate_package_options_spec.rb
@@ -21,31 +21,39 @@ RSpec.describe FriendlyShipping::Services::UspsInternational::RateEstimatePackag
 
   describe 'commercial_pricing' do
     it 'is Y when true' do
-      expect(described_class.new(
+      expect(
+        described_class.new(
           package_id: package_id,
           commercial_pricing: true,
-        ).commercial_pricing).to eq("Y")
+        ).commercial_pricing
+      ).to eq("Y")
     end
 
     it 'is N when false' do
-      expect(described_class.new(
+      expect(
+        described_class.new(
           package_id: package_id,
-        ).commercial_pricing).to eq("N")
+        ).commercial_pricing
+      ).to eq("N")
     end
   end
 
   describe 'commercial_plus_pricing' do
     it 'is Y when true' do
-      expect(described_class.new(
+      expect(
+        described_class.new(
           package_id: package_id,
           commercial_plus_pricing: true,
-        ).commercial_plus_pricing).to eq("Y")
+        ).commercial_plus_pricing
+      ).to eq("Y")
     end
 
     it 'is N when false' do
-      expect(described_class.new(
+      expect(
+        described_class.new(
           package_id: package_id,
-        ).commercial_plus_pricing).to eq("N")
+        ).commercial_plus_pricing
+      ).to eq("N")
     end
   end
 end


### PR DESCRIPTION
This serializes customs information as part of the ShipEngine label request, thus enabling us to generate international shipping labels. Without the customs information, ShipEngine rejects the request if an international shipping method is being used (i.e. USPS First-Class Package International, USPS Priority Mail International, etc).