### PR TITLE
Update SerializeLabelShipment to avoid label printing error

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -92,7 +92,7 @@ module FriendlyShipping
                   quantity: items.count,
                   value: {
                     amount: reference_item.cost.to_d,
-                    currency: reference_item.cost.currency
+                    currency: reference_item.cost.currency.to_s
                   },
                   harmonized_tariff_code: item_options.commodity_code,
                   country_of_origin: item_options.country_of_origin


### PR DESCRIPTION
We were sending a test shipment to Canada using USPS First Class as the shipping method and the warehouse ran into this error when they tried to print the shipping label:

```
request.shipment.customs.customs_items[0].value.currency: Unexpected token StartObject when parsing enum.
```

We determined that this was because the currency being passed in was not setting to 'USD'. In updating the method `serialize_customs_items` so that the currency is always set to a string, we get rid of the `Money::Currency` object that was causing the printing error.