### PR TITLE
Use item options country of origin in UPS label requests

### DIFF
--- a/lib/friendly_shipping/services/ups/label_item_options.rb
+++ b/lib/friendly_shipping/services/ups/label_item_options.rb
@@ -49,14 +49,17 @@ module FriendlyShipping
           other: 'OTH'
         }.freeze
 
-        attr_reader :commodity_code
+        attr_reader :commodity_code,
+                    :country_of_origin
 
         def initialize(
           commodity_code: nil,
+          country_of_origin: nil,
           product_unit_of_measure: :number,
           **kwargs
         )
           @commodity_code = commodity_code
+          @country_of_origin = country_of_origin
           @product_unit_of_measure = product_unit_of_measure
           super(**kwargs)
         end

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -261,7 +261,7 @@ module FriendlyShipping
                   cost = reference_item.cost || Money.new(0, 'USD')
                   xml.Description(description)
                   xml.CommodityCode(item_options.commodity_code)
-                  xml.OriginCountryCode(shipment.origin.country.code)
+                  xml.OriginCountryCode(item_options.country_of_origin || shipment.origin.country.code)
                   xml.Unit do
                     xml.Value(cost * items.length)
                     xml.Number(items.length)

--- a/spec/friendly_shipping/services/ship_engine/label_item_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_item_options_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::LabelItemOptions do
   subject(:options) { described_class.new(item_id: "123") }
 
   [
+    :item_id,
     :commodity_code,
     :country_of_origin
   ].each do |message|

--- a/spec/friendly_shipping/services/ups/label_item_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_item_options_spec.rb
@@ -6,8 +6,13 @@ require 'friendly_shipping/services/ups/label_item_options'
 RSpec.describe FriendlyShipping::Services::Ups::LabelItemOptions do
   subject { described_class.new(item_id: nil) }
 
-  it { is_expected.to respond_to(:item_id) }
-  it { is_expected.to respond_to(:commodity_code) }
+  [
+    :item_id,
+    :commodity_code,
+    :country_of_origin
+  ].each do |message|
+    it { is_expected.to respond_to(message) }
+  end
 
   describe '#product_unit_of_measure_code' do
     it 'returns product unit of measure code' do


### PR DESCRIPTION
This adds country of origin to the item options used when serializing UPS label requests, enabling different origin countries to be used for different products in the package when requesting paperless invoicing.