### PR TITLE
Handle TForce API timeout responses

### DIFF
--- a/lib/friendly_shipping/services/ups_freight/api_error.rb
+++ b/lib/friendly_shipping/services/ups_freight/api_error.rb
@@ -15,6 +15,8 @@ module FriendlyShipping
 
         # @param [RestClient::Exception] cause
         def parse_message(cause)
+          return cause.message unless cause.response
+
           parsed_json = JSON.parse(cause.response.body)
 
           if parsed_json['httpCode'].present?

--- a/spec/friendly_shipping/services/ups_freight/api_error_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/api_error_spec.rb
@@ -18,5 +18,10 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ApiError do
       let(:fixture) { "failure_with_http_error.json" }
       it { is_expected.to eq("400 Bad Request: The body of the request, which was expected to be JSON, was invalid.") }
     end
+
+    context "with timeout error response" do
+      let(:error) { RestClient::Exceptions::ReadTimeout.new("Timed out reading data from server") }
+      it { is_expected.to eq("Timed out reading data from server") }
+    end
   end
 end


### PR DESCRIPTION
If a timeout error occurs, we won't have a response body to parse. We can use the timeout exception's message instead.