### PR TITLE
Truncate UPS international product description

### DIFF
--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -259,7 +259,7 @@ module FriendlyShipping
 
                 xml.Product do
                   cost = reference_item.cost || Money.new(0, 'USD')
-                  xml.Description(description)
+                  xml.Description(description&.slice(0, 35))
                   xml.CommodityCode(item_options.commodity_code)
                   xml.OriginCountryCode(item_options.country_of_origin || shipment.origin.country.code)
                   xml.Unit do

--- a/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
@@ -329,5 +329,31 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
       expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/Unit/Number').text).to eq('1')
       expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/Unit/UnitOfMeasurement/Code').text).to eq('NMB')
     end
+
+    context 'with a product containing a long description' do
+      let(:package) do
+        Physical::Package.new(
+          id: 'package_1',
+          items: [
+            Physical::Item.new(
+              weight: Measured::Weight.new(5, :pounds),
+              description: 'Wooden block with a terribly long description',
+              cost: Money.new(495, 'USD')
+            )
+          ],
+          container: Physical::Box.new(
+            dimensions: [
+              Measured::Length.new(10, :centimeters),
+              Measured::Length.new(10, :centimeters),
+              Measured::Length.new(10, :centimeters),
+            ]
+          )
+        )
+      end
+
+      it 'limits the product description length to the UPS limit of 35 characters' do
+        expect(subject.at('InternationalForms/Product/Description').text).to eq('Wooden block with a terribly long d')
+      end
+    end
   end
 end


### PR DESCRIPTION
For the ups shipment confirm request, truncate the product description for international products to 35 characters (the UPS limit). UPS will reject the request if the product description is too long.