### PR TITLE
Fix Rails 7 deprecation warning

### DIFF
--- a/lib/friendly_shipping/rate.rb
+++ b/lib/friendly_shipping/rate.rb
@@ -39,7 +39,7 @@ module FriendlyShipping
     def total_amount
       raise NoAmountsGiven if amounts.empty?
 
-      amounts.map { |_name, amount| amount }.sum
+      amounts.map { |_name, amount| amount }.sum(Money.new(0, 'USD'))
     end
   end
 end


### PR DESCRIPTION
Fixes a deprecation warning that appears when using Rails 7 with this gem.

```
DEPRECATION WARNING: Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4. Sum of non-numeric elements requires an initial argument.
```