### PR TITLE
USPS international package weight ounces is remainder after pounds conversion

### DIFF
--- a/lib/friendly_shipping/services/usps_international/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps_international/serialize_rate_request.rb
@@ -56,12 +56,12 @@ module FriendlyShipping
           end
 
           def ounces_for(package)
-            ounces = package.weight.convert_to(:ounces).value.to_f.round(2).ceil
+            ounces = (package.weight.convert_to(:ounces).value.to_f % 16).round(2).ceil
             ounces == 16 ? 15.999 : [ounces, 1].max
           end
 
           def pounds_for(package)
-            package.weight.convert_to(:pounds).value.to_f.round(2).ceil
+            package.weight.convert_to(:pounds).value.to_f.floor
           end
 
           def girth(package)

--- a/spec/friendly_shipping/services/usps_international/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps_international/serialize_rate_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FriendlyShipping::Services::UspsInternational::SerializeRateReque
   let(:node) { Nokogiri::XML(subject).xpath('//IntlRateV2Request/Package') }
 
   it 'serializes the request' do
-    expect(node.at_xpath('Pounds').text).to eq('1')
+    expect(node.at_xpath('Pounds').text).to eq('0')
     expect(node.at_xpath('Ounces').text).to eq('15')
     expect(node.at_xpath('Machinable').text).to eq('false')
     expect(node.at_xpath('MailType').text).to eq('ALL')
@@ -38,6 +38,15 @@ RSpec.describe FriendlyShipping::Services::UspsInternational::SerializeRateReque
 
     it 'returns 15.999 oz' do
       expect(node.at_xpath('Ounces').text).to eq('15.999')
+    end
+  end
+
+  context 'ounces of package weight does not include pounds' do
+    let(:weight) { Measured::Weight(40.5, :pounds) }
+
+    it 'returns 40 pounds and 8 ounces' do
+      expect(node.at_xpath('Pounds').text).to eq('40')
+      expect(node.at_xpath('Ounces').text).to eq('8')
     end
   end
 


### PR DESCRIPTION
Before this change, a package that weighs 3 pounds would get quoted as a package that weighs 3 pounds and 48 ounces (6 pounds).