### PR TITLE
Fix UPS bug causing inflated international product costs

### DIFF
--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -124,7 +124,7 @@ module FriendlyShipping
 
                     contents_description = shipment.packages.flat_map do |package|
                       package.items.map(&:description)
-                    end.compact.join(', ').slice(0, 50)
+                    end.compact.uniq.join(', ').slice(0, 50)
 
                     unless contents_description.empty?
                       xml.Description(contents_description)
@@ -263,7 +263,7 @@ module FriendlyShipping
                   xml.CommodityCode(item_options.commodity_code)
                   xml.OriginCountryCode(item_options.country_of_origin || shipment.origin.country.code)
                   xml.Unit do
-                    xml.Value(cost * items.length)
+                    xml.Value(cost)
                     xml.Number(items.length)
                     xml.UnitOfMeasurement do
                       xml.Code(item_options.product_unit_of_measure_code)

--- a/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
   let(:package) do
     Physical::Package.new(
       id: 'package_1',
-      items: [
+      items: Array.new(2) {
         Physical::Item.new(
           weight: Measured::Weight.new(5, :pounds),
           description: 'Wooden block',
           cost: Money.new(495, 'USD')
         )
-      ],
+      },
       container: Physical::Box.new(
         dimensions: [
           Measured::Length.new(10, :centimeters),
@@ -93,7 +93,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
       expect(
         subject.at_xpath('//ShipmentConfirmRequest/Shipment/Package/PackageWeight/UnitOfMeasurement/Code').text
       ).to eq('LBS')
-      expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/Package/PackageWeight/Weight').text).to eq('5')
+      expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/Package/PackageWeight/Weight').text).to eq('10')
     end
   end
 
@@ -326,7 +326,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
       expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/CommodityCode').text).to eq('6116.10.0000')
       expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/OriginCountryCode').text).to eq('CA')
       expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/Unit/Value').text).to eq('4.95')
-      expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/Unit/Number').text).to eq('1')
+      expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/Unit/Number').text).to eq('2')
       expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/Unit/UnitOfMeasurement/Code').text).to eq('NMB')
     end
 
@@ -334,13 +334,13 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
       let(:package) do
         Physical::Package.new(
           id: 'package_1',
-          items: [
+          items: Array.new(2) {
             Physical::Item.new(
               weight: Measured::Weight.new(5, :pounds),
               description: 'Wooden block with a terribly long description',
               cost: Money.new(495, 'USD')
             )
-          ],
+          },
           container: Physical::Box.new(
             dimensions: [
               Measured::Length.new(10, :centimeters),


### PR DESCRIPTION
Fixes a bug in the UPS shipment confirm request serializer where the international forms product cost was being inadvertantly inflated by multiplying the cost by the product quantity. The API documentation is not clear, but apparently UPS expects us to pass the cost of a single product in this field, **_not_** cost multiplied by quantity.