### PR TITLE
Add declared to UPS label package options

### DIFF
--- a/lib/friendly_shipping/services/ups/label_package_options.rb
+++ b/lib/friendly_shipping/services/ups/label_package_options.rb
@@ -11,8 +11,10 @@ module FriendlyShipping
       #   values are _reference number values_. Example: `{ reference_numbers: { xn: 'my_reference_1 }`
       # @option delivery_confirmation [Symbol] Can be set to any key from PACKAGE_DELIVERY_CONFIRMATION_CODES.
       #   Only possible for domestic shipments or shipments between the US and Puerto Rico.
-      # @option shipper_release [Boolean] Indicates that the package may be released by driver without a signature from the
-      #   consignee. Default: false
+      # @option shipper_release [Boolean] Indicates that the package may be released by driver without a signature from
+      #   the consignee. Default: false
+      # @option declared_value [Boolean] When true, declared value (calculated as the sum of all items in the shipment)
+      #   will be included in the request. Default: false
       class LabelPackageOptions < FriendlyShipping::PackageOptions
         PACKAGE_DELIVERY_CONFIRMATION_CODES = {
           delivery_confirmation: 1,
@@ -20,17 +22,19 @@ module FriendlyShipping
           delivery_confirmation_adult_signature_required: 3
         }.freeze
 
-        attr_reader :reference_numbers, :shipper_release
+        attr_reader :reference_numbers, :shipper_release, :declared_value
 
         def initialize(
           reference_numbers: {},
           delivery_confirmation: nil,
           shipper_release: false,
+          declared_value: false,
           **kwargs
         )
           @reference_numbers = reference_numbers
           @delivery_confirmation = delivery_confirmation
           @shipper_release = shipper_release
+          @declared_value = declared_value
           super(**kwargs.merge(item_options_class: LabelItemOptions))
         end
 

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -160,7 +160,8 @@ module FriendlyShipping
                       package: package,
                       reference_numbers: reference_numbers,
                       delivery_confirmation_code: delivery_confirmation_code,
-                      shipper_release: package_options.shipper_release
+                      shipper_release: package_options.shipper_release,
+                      declared_value: package_options.declared_value
                     )
                   end
                 end

--- a/spec/friendly_shipping/services/ups/label_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_package_options_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe FriendlyShipping::Services::Ups::LabelPackageOptions do
   [
     :delivery_confirmation_code,
     :reference_numbers,
-    :shipper_release
+    :shipper_release,
+    :declared_value
   ].each do |message|
     it { is_expected.to respond_to(message) }
   end


### PR DESCRIPTION
As a follow on to https://github.com/friendlycart/friendly_shipping/pull/168, this boolean causes the declared value (calculated as the sum of all items in the shipment) to be included in the label API request.

This change enables end users to specify whether they want declared value included when instantiating the `LabelPackageOptions` class for the API call.