### PR TITLE
Truncate long values in UPS Freight label request

### DIFF
--- a/lib/friendly_shipping/services/ups_freight/generate_location_hash.rb
+++ b/lib/friendly_shipping/services/ups_freight/generate_location_hash.rb
@@ -7,17 +7,17 @@ module FriendlyShipping
         class << self
           def call(location:)
             {
-              Name: location.company_name.presence || location.name,
+              Name: truncate(location.company_name.presence || location.name),
               Address: {
                 AddressLine: address_line(location),
-                City: location.city,
+                City: truncate(location.city, length: 29),
                 StateProvinceCode: location.region&.code,
                 PostalCode: location.zip,
                 CountryCode: location.country&.code
               },
-              AttentionName: location.name,
+              AttentionName: truncate(location.name),
               Phone: {
-                Number: location.phone
+                Number: truncate(location.phone, length: 14)
               }.compact.presence
             }.compact
           end
@@ -29,8 +29,12 @@ module FriendlyShipping
               location.address1,
               location.address2,
               location.address3
-            ].compact.reject(&:empty?)
-            address_lines.size > 1 ? address_lines : address_lines.first
+            ].compact.reject(&:empty?).map { |e| truncate(e) }
+            address_lines.size > 1 ? address_lines : truncate(address_lines.first)
+          end
+
+          def truncate(value, length: 35)
+            value && value[0..(length - 1)]
           end
         end
       end

--- a/lib/friendly_shipping/services/usps/parse_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/parse_package_rate.rb
@@ -94,7 +94,8 @@ module FriendlyShipping
 
             rate_value =
               if commercial_rate_requested_or_rate_is_zero && commercial_rate_available
-                rate_node.at(COMMERCIAL_RATE_TAG)&.text&.to_d || rate_node.at(COMMERCIAL_PLUS_RATE_TAG).text.to_d
+                commercial_rate = rate_node.at(COMMERCIAL_RATE_TAG)&.text.to_d
+                commercial_rate.zero? ? rate_node.at(COMMERCIAL_PLUS_RATE_TAG).text.to_d : commercial_rate
               else
                 rate_node.at(RATE_TAG).text.to_d
               end

--- a/lib/friendly_shipping/services/usps_international/parse_package_rate.rb
+++ b/lib/friendly_shipping/services/usps_international/parse_package_rate.rb
@@ -47,7 +47,8 @@ module FriendlyShipping
 
             rate_value =
               if commercial_rate_requested_or_rate_is_zero && commercial_rate_available
-                rate_node.at(COMMERCIAL_RATE_TAG)&.text&.to_d || rate_node.at(COMMERCIAL_PLUS_RATE_TAG).text.to_d
+                commercial_rate = rate_node.at(COMMERCIAL_RATE_TAG)&.text.to_d
+                commercial_rate.zero? ? rate_node.at(COMMERCIAL_PLUS_RATE_TAG).text.to_d : commercial_rate
               else
                 rate_node.at(RATE_TAG).text.to_d
               end

--- a/spec/friendly_shipping/services/ups_freight/generate_location_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_location_hash_spec.rb
@@ -105,4 +105,38 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
       )
     end
   end
+
+  context 'with values exceeding max length' do
+    let(:location) do
+      Physical::Location.new(
+        company_name: 'Ankunding, Bogisich, Morissette and Yost',
+        name: 'John Edward Jones Blithe Conley Smith',
+        address1: '5839 Mayfield Barton Albans Field Drive',
+        address2: '',
+        address3: '',
+        city: 'Northeast Flunkertown Nottingham Village',
+        zip: '23224',
+        region: 'VA',
+        country: 'US',
+        phone: '123-123-1234 x1234',
+      )
+    end
+
+    it 'truncates long values' do
+      is_expected.to eq(
+        Name: 'Ankunding, Bogisich, Morissette and',
+        AttentionName: 'John Edward Jones Blithe Conley Smi',
+        Address: {
+          AddressLine: '5839 Mayfield Barton Albans Field D',
+          City: 'Northeast Flunkertown Notting',
+          StateProvinceCode: 'VA',
+          PostalCode: '23224',
+          CountryCode: 'US'
+        },
+        Phone: {
+          Number: '123-123-1234 x'
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
The UPS Freight (TForce) API returns an error response if certain values in the request exceed a certain length.