### PR TITLE
Add new USPS Ground Advantage shipping method

### DIFF
--- a/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
@@ -106,10 +106,12 @@ module FriendlyShipping
           # “0” = All Mail Classes
           # “1” = Priority Mail Express
           # “2” = Priority Mail
-          # “3” = First Class Mail
+          # “3” = First-Class - replaced by Ground Advantage (up to 15.999 oz)
           # “4” = Marketing Mail
           # “5” = Periodicals
           # “6” = Package Services
+          # “7” = Parcel Select Ground - replaced by Ground Advantage (1-70 lbs)
+          # “9” = Ground Advantage (1-70 lbs)
           #
           # However, no shipping methods really map to "Marketing Mail" or "Periodicals".
           # This will likely be somewhat more work in the future.
@@ -117,7 +119,9 @@ module FriendlyShipping
             '1' => 'Priority Mail Express',
             '2' => 'Priority Mail',
             '3' => 'First-Class',
-            '6' => 'Package Services'
+            '6' => 'Package Services',
+            '7' => 'Parcel Select Ground',
+            '9' => 'Ground Advantage'
           }.freeze
 
           # This code carries a few details about the shipment:

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -35,11 +35,13 @@ module FriendlyShipping
           hold_for_pickup: '2',
           sunday_holiday_delivery: '23'
         },
-        priority_mail_cubic: '999'
+        priority_mail_cubic: '999',
+        ground_advantage: '1058'
       }.freeze
 
       SHIPPING_METHODS = [
         ['FIRST CLASS', 'First-Class'],
+        ['GROUND ADVANTAGE', 'Ground Advantage', CLASS_IDS[:ground_advantage]],
         ['PACKAGE SERVICES', 'Package Services'],
         ['PRIORITY', 'Priority Mail'],
         ['PRIORITY MAIL EXPRESS', 'Priority Mail Express', CLASS_IDS[:priority_mail_express].values],
@@ -55,7 +57,7 @@ module FriendlyShipping
           service_code: code,
           domestic: true,
           international: false,
-          data: { class_ids: class_ids }
+          data: { class_ids: Array(class_ids) }
         )
       end.freeze
     end


### PR DESCRIPTION
This adds support for the new USPS Ground Advantage shipping method scheduled to become active on July 9, 2023. This new shipping method replaces the existing First Class Package Service shipping method, although the API will continue responding to FCPS requests but with rates and timings for Ground Advantage.