### PR TITLE
Add new billing options for NRI

### DIFF
--- a/lib/friendly_shipping/services/ups/label_billing_options.rb
+++ b/lib/friendly_shipping/services/ups/label_billing_options.rb
@@ -9,6 +9,8 @@ module FriendlyShipping
       # @option bill_to_consignee [Boolean] If billing a third party, bill the consignee instead of the 3rd party shipper
       # @option prepay [Boolean] If truthy the shipper will be bill immediately. Otherwise the shipper is billed
       #   when the label is used. Default: false
+      # @option sold_to_account_number [String] The account number to include in the SoldTo node of the request
+      # @option sold_to_tax_id_number [String] The tax identification number to include in the SoldTo node of the request
       class LabelBillingOptions
         attr_reader :bill_third_party,
                     :bill_to_consignee,
@@ -16,7 +18,9 @@ module FriendlyShipping
                     :billing_account,
                     :billing_zip,
                     :billing_country,
-                    :currency
+                    :currency,
+                    :sold_to_account_number,
+                    :sold_to_tax_id_number
 
         def initialize(
           bill_third_party: false,
@@ -25,7 +29,9 @@ module FriendlyShipping
           billing_account: nil,
           billing_zip: nil,
           billing_country: nil,
-          currency: nil
+          currency: nil,
+          sold_to_account_number: nil,
+          sold_to_tax_id_number: nil
         )
           @bill_third_party = bill_third_party
           @bill_to_consignee = bill_to_consignee
@@ -34,6 +40,8 @@ module FriendlyShipping
           @billing_zip = billing_zip
           @billing_country = billing_country
           @currency = currency
+          @sold_to_account_number = sold_to_account_number
+          @sold_to_tax_id_number = sold_to_tax_id_number
         end
       end
     end

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -106,6 +106,8 @@ module FriendlyShipping
                       xml.SoldTo do
                         sold_to_location = options.sold_to || shipment.destination
                         SerializeShipmentAddressSnippet.call(xml: xml, location: sold_to_location)
+                        xml.AccountNumber(options.billing_options.sold_to_account_number) if options.billing_options.sold_to_account_number.present?
+                        xml.TaxIdentificationNumber(options.billing_options.sold_to_tax_id_number) if options.billing_options.sold_to_tax_id_number.present?
                       end
                     end
 


### PR DESCRIPTION
This adds AccountNumber and TaxIdentificationNumber to the Shipment/SoldTo node for international shipments to support NRI options. 

The AccountNumber is new and was just added to the api by UPS a couple months ago.