### PR TITLE
Add new billing options for NRI

### DIFF
--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -106,6 +106,8 @@ module FriendlyShipping
                       xml.SoldTo do
                         sold_to_location = options.sold_to || shipment.destination
                         SerializeShipmentAddressSnippet.call(xml: xml, location: sold_to_location)
+                        xml.AccountNumber(options.sold_to.account_number) if options.sold_to.try(:account_number).present?
+                        xml.TaxIdentificationNumber(options.sold_to.tax_id_number) if options.sold_to.try(:tax_id_number).present?
                       end
                     end
 

--- a/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
@@ -248,6 +248,74 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
       expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/ShipTo/AttentionName').text).to eq("Jane Doe")
     end
 
+    context 'with NRI importer options' do
+      let(:options) do
+        FriendlyShipping::Services::Ups::LabelOptions.new(
+          shipping_method: shipping_method,
+          shipper_number: 'X234X',
+          billing_options: billing_options,
+          terms_of_shipment: :delivery_duty_paid,
+          sold_to: non_resident_importer,
+        )
+      end
+
+      let(:billing_options) do
+        FriendlyShipping::Services::Ups::LabelBillingOptions.new(
+          billing_account: '12345',
+          billing_zip: '22222',
+          billing_country: 'CA',
+        )
+      end
+
+      let(:non_resident_importer) do
+        FactoryBot.build(
+          :physical_location,
+          company_name: 'Non Resident Importer LLC',
+          address1: 'Suite 200 C/O The Agent',
+          address2: '123 Main St, New York, NY 10101 US',
+          city: 'Moncton',
+          region: 'NB',
+          zip: 'E1A7Z5',
+          country: 'CA',
+          properties: {
+            account_number: '123321',
+            tax_id_number: '123456789000',
+          }
+        )
+      end
+
+      it 'includes all of the SoldTo fields' do
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/CompanyName').text).to eq('Non Resident Importer LLC')
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/Address/AddressLine1').text).to eq('Suite 200 C/O The Agent')
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/Address/AddressLine2').text).to eq('123 Main St, New York, NY 10101 US')
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/Address/City').text).to eq('Moncton')
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/Address/StateProvinceCode').text).to eq('NB')
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/Address/PostalCode').text).to eq('E1A7Z5')
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/Address/CountryCode').text).to eq('CA')
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/TaxIdentificationNumber').text).to eq('123456789000')
+        expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/AccountNumber').text).to eq('123321')
+      end
+
+      context 'with missing fields' do
+        let(:non_resident_importer) do
+          FactoryBot.build(
+            :physical_location,
+            company_name: 'Non Resident Importer LLC',
+            address1: 'Suite 200 C/O The Agent',
+            address2: '123 Main St, New York, NY 10101 US',
+            city: 'Moncton',
+            region: 'NB',
+            zip: 'E1A7Z5',
+            country: 'CA',
+          )
+        end
+
+        it 'does not blow up' do
+          expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/SoldTo/CompanyName').text).to eq('Non Resident Importer LLC')
+        end
+      end
+    end
+
     context 'with a private address (without company)' do
       let(:destination) do
         FactoryBot.build(


### PR DESCRIPTION
This adds AccountNumber and TaxIdentificationNumber to the Shipment/SoldTo node for international shipments to support NRI options.

The AccountNumber is new and was just added to the api by UPS a couple months ago.