### PR TITLE
Extract R&L Freight package serializer classes

### DIFF
--- a/lib/friendly_shipping/services/rl/bol_options.rb
+++ b/lib/friendly_shipping/services/rl/bol_options.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'friendly_shipping/shipment_options'
+require 'friendly_shipping/services/rl/bol_packages_serializer'
 
 module FriendlyShipping
   module Services
@@ -9,23 +10,28 @@ module FriendlyShipping
         attr_reader :pickup_time_window,
                     :declared_value,
                     :additional_service_codes,
-                    :generate_universal_pro
+                    :generate_universal_pro,
+                    :packages_serializer
 
         # @param [Range] pickup_time_window
         # @param [Numeric] declared_value
         # @param [Array<String>] additional_service_codes
         # @param [Boolean] generate_universal_pro
+        # @param [Callable] packages_serializer A callable that takes packages
+        #   and an options object to create an Array of item hashes per the R&L docs
         # @param [Array<Object>] **kwargs
         def initialize(
           pickup_time_window:,
           declared_value: nil,
           additional_service_codes: [],
+          packages_serializer: BOLPackagesSerializer,
           generate_universal_pro: false,
           **kwargs
         )
           @pickup_time_window = pickup_time_window
           @declared_value = declared_value
           @additional_service_codes = additional_service_codes
+          @packages_serializer = packages_serializer
           @generate_universal_pro = generate_universal_pro
           validate_additional_service_codes!
           super(**kwargs.merge(package_options_class: PackageOptions))

--- a/lib/friendly_shipping/services/rl/bol_packages_serializer.rb
+++ b/lib/friendly_shipping/services/rl/bol_packages_serializer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class RL
+      class BOLPackagesSerializer
+        # @param [Array<Physical::Package>] packages
+        # @param [FriendlyShipping::Services::RL::BOLOptions] options
+        # @return [Array<Hash>]
+        def self.call(packages:, options:)
+          packages.flat_map do |package|
+            package_options = options.options_for_package(package)
+            package.items.map do |item|
+              item_options = package_options.options_for_item(item)
+              {
+                IsHazmat: false,
+                Pieces: 1,
+                PackageType: "BOX",
+                NMFCItemNumber: item_options.nmfc_primary_code,
+                NMFCSubNumber: item_options.nmfc_sub_code,
+                Class: item_options.freight_class,
+                Weight: item.weight.convert_to(:pounds).value.ceil,
+                Description: item.description.presence || "Commodities"
+              }.compact
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/rl/rate_quote_options.rb
+++ b/lib/friendly_shipping/services/rl/rate_quote_options.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'friendly_shipping/shipment_options'
+require 'friendly_shipping/services/rl/rate_quote_packages_serializer'
 
 module FriendlyShipping
   module Services
@@ -8,21 +9,26 @@ module FriendlyShipping
       class RateQuoteOptions < ShipmentOptions
         attr_reader :pickup_date,
                     :declared_value,
-                    :additional_service_codes
+                    :additional_service_codes,
+                    :packages_serializer
 
         # @param [Time] pickup_date
         # @param [Numeric] declared_value
         # @param [Array<String>] additional_service_codes
+        # @param [Callable] packages_serializer A callable that takes packages
+        #   and an options object to create an Array of item hashes per the R&L docs
         # @param [Array<Object>] **kwargs
         def initialize(
           pickup_date:,
           declared_value: nil,
           additional_service_codes: [],
+          packages_serializer: RateQuotePackagesSerializer,
           **kwargs
         )
           @pickup_date = pickup_date
           @declared_value = declared_value
           @additional_service_codes = additional_service_codes
+          @packages_serializer = packages_serializer
           validate_additional_service_codes!
           super(**kwargs.merge(package_options_class: PackageOptions))
         end

--- a/lib/friendly_shipping/services/rl/rate_quote_packages_serializer.rb
+++ b/lib/friendly_shipping/services/rl/rate_quote_packages_serializer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class RL
+      class RateQuotePackagesSerializer
+        class << self
+          # @param [Array<Physical::Package>] packages
+          # @param [FriendlyShipping::Services::RL::RateQuoteOptions] options
+          # @return [Array<Hash>]
+          def call(packages:, options:)
+            item_hashes = packages.flat_map do |package|
+              package_options = options.options_for_package(package)
+              package.items.map do |item|
+                item_options = package_options.options_for_item(item)
+                {
+                  Class: item_options.freight_class,
+                  Weight: item.weight.convert_to(:pounds)
+                }
+              end
+            end
+            group_items(item_hashes)
+          end
+
+          private
+
+          # Group items by freight class. The R&L API has a limit on the number of items
+          # we can submit to the API, so this helps reduce the number of items.
+          #
+          # @param [Array<Hash>] item_hashes
+          # @return [Array<Hash>]
+          def group_items(item_hashes)
+            item_hashes.group_by do |item_hash|
+              item_hash[:Class]
+            end.map do |freight_class, grouped_item_hashes|
+              {
+                Class: freight_class,
+                Weight: grouped_item_hashes.sum { |e| e[:Weight] }.value.ceil,
+                Quantity: grouped_item_hashes.size
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
+++ b/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
@@ -15,7 +15,7 @@ module FriendlyShipping
                 Shipper: serialize_location(shipment.origin),
                 Consignee: serialize_location(shipment.destination),
                 BillTo: serialize_location(shipment.origin),
-                Items: serialize_items(shipment.packages, options),
+                Items: options.packages_serializer.call(packages: shipment.packages, options: options),
                 DeclaredValue: serialize_declared_value(options),
                 AdditionalServices: options.additional_service_codes
               }.compact,
@@ -40,28 +40,6 @@ module FriendlyShipping
               PhoneNumber: location.phone,
               EmailAddress: location.email
             }.compact
-          end
-
-          # @param [Array<Physical::Package>] packages
-          # @param [FriendlyShipping::Services::RL::QuoteOptions] options
-          # @return [Array<Hash>]
-          def serialize_items(packages, options)
-            packages.flat_map do |package|
-              package_options = options.options_for_package(package)
-              package.items.map do |item|
-                item_options = package_options.options_for_item(item)
-                {
-                  IsHazmat: false,
-                  Pieces: 1,
-                  PackageType: "BOX",
-                  NMFCItemNumber: item_options.nmfc_primary_code,
-                  NMFCSubNumber: item_options.nmfc_sub_code,
-                  Class: item_options.freight_class,
-                  Weight: item.weight.convert_to(:pounds).value.ceil,
-                  Description: item.description.presence || "Commodities"
-                }.compact
-              end
-            end
           end
 
           # @param [FriendlyShipping::Services::RL::QuoteOptions] options

--- a/lib/friendly_shipping/services/rl/serialize_rate_quote_request.rb
+++ b/lib/friendly_shipping/services/rl/serialize_rate_quote_request.rb
@@ -14,7 +14,7 @@ module FriendlyShipping
                 PickupDate: options.pickup_date.strftime('%m/%d/%Y'),
                 Origin: serialize_location(shipment.origin),
                 Destination: serialize_location(shipment.destination),
-                Items: serialize_items(shipment.packages, options),
+                Items: options.packages_serializer.call(packages: shipment.packages, options: options),
                 DeclaredValue: options.declared_value,
                 AdditionalServices: options.additional_service_codes,
                 Pallets: serialize_pallets(shipment.pallets)
@@ -50,23 +50,6 @@ module FriendlyShipping
               end
             end
             group_items(item_hashes)
-          end
-
-          # Group items by freight class. The R&L API has a limit on the number of items
-          # we can submit to the API, so this helps reduce the number of items.
-          #
-          # @param [Array<Hash>] item_hashes
-          # @return [Array<Hash>]
-          def group_items(item_hashes)
-            item_hashes.group_by do |item_hash|
-              item_hash[:Class]
-            end.map do |freight_class, grouped_item_hashes|
-              {
-                Class: freight_class,
-                Weight: grouped_item_hashes.sum { |e| e[:Weight] }.value.ceil,
-                Quantity: grouped_item_hashes.size
-              }
-            end
           end
 
           # @param [Array<Physical::Pallet>] pallets

--- a/spec/friendly_shipping/services/rl/bol_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/bol_options_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe FriendlyShipping::Services::RL::BOLOptions do
   it { is_expected.to respond_to(:declared_value) }
   it { is_expected.to respond_to(:additional_service_codes) }
   it { is_expected.to respond_to(:generate_universal_pro) }
+  it { is_expected.to respond_to(:packages_serializer) }
+
+  describe "#packages_serializer" do
+    subject { options.packages_serializer }
+
+    it { is_expected.to eq(FriendlyShipping::Services::RL::BOLPackagesSerializer) }
+  end
 
   describe "validate additional service codes" do
     context "with invalid additional service code" do

--- a/spec/friendly_shipping/services/rl/bol_packages_serializer_spec.rb
+++ b/spec/friendly_shipping/services/rl/bol_packages_serializer_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::RL::BOLPackagesSerializer do
+  subject do
+    described_class.call(
+      packages: [package_1, package_2],
+      options: options
+    )
+  end
+
+  let(:pickup_time_window) do
+    Time.parse("2023-08-01 09:00:00 UTC")..Time.parse("2023-08-01 17:00:00 UTC")
+  end
+
+  let(:options) do
+    FriendlyShipping::Services::RL::BOLOptions.new(
+      pickup_time_window: pickup_time_window,
+      package_options: [
+        FriendlyShipping::Services::RL::PackageOptions.new(
+          package_id: "package 1",
+          item_options: [
+            FriendlyShipping::Services::RL::ItemOptions.new(
+              item_id: "item 1",
+              nmfc_primary_code: "87700",
+              nmfc_sub_code: "07",
+              freight_class: "92.5"
+            )
+          ]
+        ),
+        FriendlyShipping::Services::RL::PackageOptions.new(
+          package_id: "package 2",
+          item_options: [
+            FriendlyShipping::Services::RL::ItemOptions.new(
+              item_id: "item 2",
+              nmfc_primary_code: "87700",
+              nmfc_sub_code: "07",
+              freight_class: "92.5"
+            )
+          ]
+        )
+      ]
+    )
+  end
+
+  let(:package_1) do
+    FactoryBot.build(
+      :physical_package,
+      id: "package 1",
+      items: [item_1],
+      container: container
+    )
+  end
+
+  let(:package_2) do
+    FactoryBot.build(
+      :physical_package,
+      id: "package 2",
+      items: [item_2],
+      container: container
+    )
+  end
+
+  let(:container) do
+    FactoryBot.build(:physical_box)
+  end
+
+  let(:item_1) do
+    FactoryBot.build(
+      :physical_item,
+      id: "item 1",
+      description: "Tumblers",
+      weight: Measured::Weight(10.53, :lb),
+      dimensions: [
+        Measured::Length(7.874, :in),
+        Measured::Length(5.906, :in),
+        Measured::Length(11.811, :in)
+      ]
+    )
+  end
+
+  let(:item_2) do
+    FactoryBot.build(
+      :physical_item,
+      id: "item 2",
+      description: "Wicks",
+      weight: Measured::Weight(1.06, :lb),
+      dimensions: [
+        Measured::Length(4.341, :in),
+        Measured::Length(2.354, :in),
+        Measured::Length(1.902, :in)
+      ]
+    )
+  end
+
+  it do
+    is_expected.to eq(
+      [{
+        IsHazmat: false,
+        PackageType: "BOX",
+        Pieces: 1,
+        NMFCItemNumber: "87700",
+        NMFCSubNumber: "07",
+        Class: "92.5",
+        Weight: 11,
+        Description: "Tumblers"
+      }, {
+        IsHazmat: false,
+        PackageType: "BOX",
+        Pieces: 1,
+        NMFCItemNumber: "87700",
+        NMFCSubNumber: "07",
+        Class: "92.5",
+        Weight: 2,
+        Description: "Wicks"
+      }]
+    )
+  end
+end

--- a/spec/friendly_shipping/services/rl/rate_quote_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/rate_quote_options_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe FriendlyShipping::Services::RL::RateQuoteOptions do
   it { is_expected.to respond_to(:pickup_date) }
   it { is_expected.to respond_to(:declared_value) }
   it { is_expected.to respond_to(:additional_service_codes) }
+  it { is_expected.to respond_to(:packages_serializer) }
+
+  describe "#packages_serializer" do
+    subject { options.packages_serializer }
+
+    it { is_expected.to eq(FriendlyShipping::Services::RL::RateQuotePackagesSerializer) }
+  end
 
   describe "validate additional service codes" do
     context "with invalid additional service code" do

--- a/spec/friendly_shipping/services/rl/rate_quote_packages_serializer_spec.rb
+++ b/spec/friendly_shipping/services/rl/rate_quote_packages_serializer_spec.rb
@@ -2,24 +2,17 @@
 
 require 'spec_helper'
 
-RSpec.describe FriendlyShipping::Services::RL::SerializeRateQuoteRequest do
-  subject { described_class.call(shipment: shipment, options: options) }
-
-  let(:shipment) do
-    FactoryBot.build(
-      :physical_shipment,
-      origin: origin,
-      destination: destination,
-      pallets: [pallet_1, pallet_2],
-      packages: [package_1, package_2]
+RSpec.describe FriendlyShipping::Services::RL::RateQuotePackagesSerializer do
+  subject do
+    described_class.call(
+      packages: [package_1, package_2],
+      options: options
     )
   end
 
   let(:options) do
     FriendlyShipping::Services::RL::RateQuoteOptions.new(
       pickup_date: Time.parse("2023-07-19 10:30:00 UTC"),
-      declared_value: 124.35,
-      additional_service_codes: %w[DestinationLiftgate LimitedAccessDelivery],
       package_options: [
         FriendlyShipping::Services::RL::PackageOptions.new(
           package_id: "package 1",
@@ -40,20 +33,6 @@ RSpec.describe FriendlyShipping::Services::RL::SerializeRateQuoteRequest do
           ]
         )
       ]
-    )
-  end
-
-  let(:pallet_1) do
-    FactoryBot.build(
-      :physical_pallet,
-      id: "pallet 1"
-    )
-  end
-
-  let(:pallet_2) do
-    FactoryBot.build(
-      :physical_pallet,
-      id: "pallet 1"
     )
   end
 
@@ -107,60 +86,13 @@ RSpec.describe FriendlyShipping::Services::RL::SerializeRateQuoteRequest do
     )
   end
 
-  let(:origin) do
-    FactoryBot.build(
-      :physical_location,
-      address1: "123 Maple St",
-      city: "New York",
-      region: "NY",
-      zip: "10001"
-    )
-  end
-
-  let(:destination) do
-    FactoryBot.build(
-      :physical_location,
-      address1: "456 Oak St",
-      city: "Boulder",
-      region: "CO",
-      zip: "80301"
-    )
-  end
-
-  let(:serialized_packages) do
-    options.packages_serializer.call(packages: shipment.packages, options: options)
-  end
-
   it do
     is_expected.to eq(
-      {
-        RateQuote: {
-          PickupDate: "07/19/2023",
-          Origin: {
-            City: "New York",
-            StateOrProvince: "NY",
-            ZipOrPostalCode: "10001",
-            CountryCode: "USA"
-          },
-          Destination: {
-            City: "Boulder",
-            StateOrProvince: "CO",
-            ZipOrPostalCode: "80301",
-            CountryCode: "USA"
-          },
-          Items: serialized_packages,
-          DeclaredValue: 124.35,
-          AdditionalServices: %w[
-            DestinationLiftgate
-            LimitedAccessDelivery
-          ],
-          Pallets: [{
-            Code: "0001",
-            Weight: 49,
-            Quantity: 2
-          }]
-        }
-      }
+      [{
+        Class: "92.5",
+        Weight: 12,
+        Quantity: 2
+      }]
     )
   end
 end

--- a/spec/friendly_shipping/services/rl/serialize_create_bol_request_spec.rb
+++ b/spec/friendly_shipping/services/rl/serialize_create_bol_request_spec.rb
@@ -128,6 +128,10 @@ RSpec.describe FriendlyShipping::Services::RL::SerializeCreateBOLRequest do
     )
   end
 
+  let(:serialized_packages) do
+    options.packages_serializer.call(packages: shipment.packages, options: options)
+  end
+
   it do
     is_expected.to eq(
       {
@@ -166,25 +170,7 @@ RSpec.describe FriendlyShipping::Services::RL::SerializeCreateBOLRequest do
             PhoneNumber: "123-123-1234",
             EmailAddress: "acme@example.com"
           },
-          Items: [{
-            IsHazmat: false,
-            PackageType: "BOX",
-            Pieces: 1,
-            NMFCItemNumber: "87700",
-            NMFCSubNumber: "07",
-            Class: "92.5",
-            Weight: 11,
-            Description: "Tumblers"
-          }, {
-            IsHazmat: false,
-            PackageType: "BOX",
-            Pieces: 1,
-            NMFCItemNumber: "87700",
-            NMFCSubNumber: "07",
-            Class: "92.5",
-            Weight: 2,
-            Description: "Wicks"
-          }],
+          Items: serialized_packages,
           AdditionalServices: %w[OriginLiftgate]
         },
         PickupRequest: {


### PR DESCRIPTION
This enables alternate package serializer behavior to be provided by configuring the options with a callable class.