### PR TITLE
Add reference numbers to R+L BOL options class

### DIFF
--- a/lib/friendly_shipping/services/rl/bol_options.rb
+++ b/lib/friendly_shipping/services/rl/bol_options.rb
@@ -9,12 +9,14 @@ module FriendlyShipping
       class BOLOptions < ShipmentOptions
         attr_reader :pickup_time_window,
                     :declared_value,
+                    :reference_numbers,
                     :additional_service_codes,
                     :generate_universal_pro,
                     :packages_serializer
 
         # @param [Range] pickup_time_window
         # @param [Numeric] declared_value
+        # @param [Hash] reference_numbers
         # @param [Array<String>] additional_service_codes
         # @param [Boolean] generate_universal_pro
         # @param [Callable] packages_serializer A callable that takes packages
@@ -23,6 +25,7 @@ module FriendlyShipping
         def initialize(
           pickup_time_window:,
           declared_value: nil,
+          reference_numbers: {},
           additional_service_codes: [],
           packages_serializer: BOLPackagesSerializer,
           generate_universal_pro: false,
@@ -30,6 +33,7 @@ module FriendlyShipping
         )
           @pickup_time_window = pickup_time_window
           @declared_value = declared_value
+          @reference_numbers = reference_numbers
           @additional_service_codes = additional_service_codes
           @packages_serializer = packages_serializer
           @generate_universal_pro = generate_universal_pro

--- a/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
+++ b/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
@@ -16,11 +16,11 @@ module FriendlyShipping
                 Consignee: serialize_location(shipment.destination),
                 BillTo: serialize_location(shipment.origin),
                 Items: options.packages_serializer.call(packages: shipment.packages, options: options),
-                DeclaredValue: serialize_declared_value(options),
+                DeclaredValue: serialize_declared_value(options.declared_value),
                 ReferenceNumbers: serialize_reference_numbers(options.reference_numbers),
                 AdditionalServices: options.additional_service_codes
               }.compact,
-              PickupRequest: serialize_pickup_request(options),
+              PickupRequest: serialize_pickup_request(options.pickup_time_window),
               GenerateUniversalPro: !!options.generate_universal_pro
             }.compact
           end
@@ -43,13 +43,13 @@ module FriendlyShipping
             }.compact
           end
 
-          # @param [FriendlyShipping::Services::RL::QuoteOptions] options
+          # @param [Numeric] declared_value
           # @return [Hash, nil]
-          def serialize_declared_value(options)
-            return if options.declared_value.blank?
+          def serialize_declared_value(declared_value)
+            return if declared_value.blank?
 
             {
-              Amount: options.declared_value,
+              Amount: declared_value,
               Per: "1"
             }
           end
@@ -66,16 +66,16 @@ module FriendlyShipping
             }.compact
           end
 
-          # @param [FriendlyShipping::Services::RL::QuoteOptions] options
+          # @param [Range] pickup_time_window
           # @return [Hash, nil]
-          def serialize_pickup_request(options)
-            return if options.pickup_time_window.nil?
+          def serialize_pickup_request(pickup_time_window)
+            return if pickup_time_window.nil?
 
             {
               PickupInformation: {
-                PickupDate: options.pickup_time_window.begin.strftime('%m/%d/%Y'),
-                ReadyTime: options.pickup_time_window.begin.strftime('%I:%M %p'),
-                CloseTime: options.pickup_time_window.end.strftime('%I:%M %p')
+                PickupDate: pickup_time_window.begin.strftime('%m/%d/%Y'),
+                ReadyTime: pickup_time_window.begin.strftime('%I:%M %p'),
+                CloseTime: pickup_time_window.end.strftime('%I:%M %p')
               }
             }
           end

--- a/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
+++ b/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
@@ -17,6 +17,7 @@ module FriendlyShipping
                 BillTo: serialize_location(shipment.origin),
                 Items: options.packages_serializer.call(packages: shipment.packages, options: options),
                 DeclaredValue: serialize_declared_value(options),
+                ReferenceNumbers: serialize_reference_numbers(options.reference_numbers),
                 AdditionalServices: options.additional_service_codes
               }.compact,
               PickupRequest: serialize_pickup_request(options),
@@ -51,6 +52,18 @@ module FriendlyShipping
               Amount: options.declared_value,
               Per: "1"
             }
+          end
+
+          # @param [Hash] reference_numbers
+          # @return [Hash, nil]
+          def serialize_reference_numbers(reference_numbers)
+            return if reference_numbers.blank?
+
+            {
+              ShipperNumber: reference_numbers[:shipper_number],
+              RateQuoteNumber: reference_numbers[:rate_quote_number],
+              PONumber: reference_numbers[:po_number]
+            }.compact
           end
 
           # @param [FriendlyShipping::Services::RL::QuoteOptions] options

--- a/spec/friendly_shipping/services/rl/bol_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/bol_options_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe FriendlyShipping::Services::RL::BOLOptions do
 
   it { is_expected.to respond_to(:pickup_time_window) }
   it { is_expected.to respond_to(:declared_value) }
+  it { is_expected.to respond_to(:reference_numbers) }
   it { is_expected.to respond_to(:additional_service_codes) }
   it { is_expected.to respond_to(:generate_universal_pro) }
   it { is_expected.to respond_to(:packages_serializer) }

--- a/spec/friendly_shipping/services/rl/serialize_create_bol_request_spec.rb
+++ b/spec/friendly_shipping/services/rl/serialize_create_bol_request_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe FriendlyShipping::Services::RL::SerializeCreateBOLRequest do
   let(:options) do
     FriendlyShipping::Services::RL::BOLOptions.new(
       pickup_time_window: pickup_time_window,
+      reference_numbers: {
+        shipper_number: "A4234592",
+        po_number: "123456"
+      },
       additional_service_codes: %w[OriginLiftgate],
       generate_universal_pro: true,
       package_options: [
@@ -171,6 +175,10 @@ RSpec.describe FriendlyShipping::Services::RL::SerializeCreateBOLRequest do
             EmailAddress: "acme@example.com"
           },
           Items: serialized_packages,
+          ReferenceNumbers: {
+            ShipperNumber: "A4234592",
+            PONumber: "123456"
+          },
           AdditionalServices: %w[OriginLiftgate]
         },
         PickupRequest: {


### PR DESCRIPTION
Reference numbers appear on the Bill of Lading itself and can be anything the user wants them to be.