### PR TITLE
Add sub-version option to UPS rate/shipping requests

### DIFF
--- a/lib/friendly_shipping/services/ups/label_options.rb
+++ b/lib/friendly_shipping/services/ups/label_options.rb
@@ -16,6 +16,7 @@ module FriendlyShipping
     # Optional:
     #
     # @param shipper [Physical::Location] The company sending the shipment. Defaults to the shipment's origin.
+    # @param sub_version [String] The UPS API sub-version to use for requests. Default: 1707
     # @param customer_context [String ] Optional element to identify transactions between client and server
     # @param validate_address [Boolean] Validate the city field with ZIP code and state. If false, only ZIP code
     #   and state are validated. Default: true
@@ -83,9 +84,12 @@ module FriendlyShipping
           ups_pack_collect_3_attemt_box_5: 20 # UPS Pack & Collect Service 1-Attempt Box 5
         }.freeze
 
+        SUB_VERSIONS = %w[1601 1607 1701 1707 1801 1807 2108 2205].freeze
+
         attr_reader :shipping_method,
                     :shipper_number,
                     :shipper,
+                    :sub_version,
                     :customer_context,
                     :validate_address,
                     :negotiated_rates,
@@ -103,6 +107,7 @@ module FriendlyShipping
           shipping_method:,
           shipper_number:,
           shipper: nil,
+          sub_version: '1707',
           customer_context: nil,
           validate_address: true,
           negotiated_rates: false,
@@ -121,9 +126,12 @@ module FriendlyShipping
           package_options_class: LabelPackageOptions,
           **kwargs
         )
+          raise ArgumentError, "Invalid sub-version: #{sub_version}" unless sub_version.in?(SUB_VERSIONS)
+
           @shipping_method = shipping_method
           @shipper_number = shipper_number
           @shipper = shipper
+          @sub_version = sub_version
           @customer_context = customer_context
           @validate_address = validate_address
           @negotiated_rates = negotiated_rates

--- a/lib/friendly_shipping/services/ups/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/ups/rate_estimate_options.rb
@@ -21,6 +21,7 @@ module FriendlyShipping
     # @option saturday_pickup [Boolean] should we request Saturday pickup?. Default: false
     # @option shipping_method [FriendlyShipping::ShippingMethod] Request rates for a particular shipping method only?
     #   Default is `nil`, which translates to 'All shipping methods' (The "Shop" option in UPS parlance)
+    # @option sub_version [String] The UPS API sub-version to use for requests. Default: 1707
     # @option with_time_in_transit [Boolean] Whether to request timing information alongside the rates
     # @option package_options_class [Class] See FriendlyShipping::ShipmentOptions
     #
@@ -45,6 +46,8 @@ module FriendlyShipping
           standard_rates: "53"
         }.freeze
 
+        SUB_VERSIONS = %w[1601 1607 1701 1707 1801 2108 2201 2205].freeze
+
         attr_reader :carbon_neutral,
                     :customer_context,
                     :destination_account,
@@ -54,6 +57,7 @@ module FriendlyShipping
                     :shipper,
                     :shipper_number,
                     :shipping_method,
+                    :sub_version,
                     :with_time_in_transit
 
         def initialize(
@@ -68,10 +72,13 @@ module FriendlyShipping
           saturday_pickup: false,
           shipper: nil,
           shipping_method: nil,
+          sub_version: "1707",
           with_time_in_transit: false,
           package_options_class: FriendlyShipping::Services::Ups::RateEstimatePackageOptions,
           **kwargs
         )
+          raise ArgumentError, "Invalid sub-version: #{sub_version}" unless sub_version.in?(SUB_VERSIONS)
+
           @carbon_neutral = carbon_neutral
           @customer_context = customer_context
           @customer_classification = customer_classification
@@ -83,6 +90,7 @@ module FriendlyShipping
           @saturday_pickup = saturday_pickup
           @shipper = shipper
           @shipping_method = shipping_method
+          @sub_version = sub_version
           @with_time_in_transit = with_time_in_transit
           super(**kwargs.merge(package_options_class: package_options_class))
         end

--- a/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
@@ -18,7 +18,7 @@ module FriendlyShipping
                 # If no shipping method is given, request all of them
                 # I one is given, omit the request option. It then becomes "Rate", the default.
                 xml.RequestOption('Shop') unless options.shipping_method
-                xml.SubVersion('1707')
+                xml.SubVersion(options.sub_version)
                 # Optional element to identify transactions between client and server.
                 if options.customer_context
                   xml.TransactionReference do

--- a/lib/friendly_shipping/services/ups/serialize_shipment_accept_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_accept_request.rb
@@ -9,7 +9,7 @@ module FriendlyShipping
             xml.ShipmentAcceptRequest do
               xml.Request do
                 xml.RequestAction('ShipAccept')
-                xml.SubVersion('1707')
+                xml.SubVersion(options.sub_version)
                 if options.customer_context
                   xml.TransactionReference do
                     xml.CustomerContext(options.customer_context)

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -27,7 +27,7 @@ module FriendlyShipping
                   xml.RequestAction('ShipConfirm')
                   # Required element controls level of address validation.
                   xml.RequestOption(options.validate_address ? 'validate' : 'nonvalidate')
-                  xml.SubVersion('1707')
+                  xml.SubVersion(options.sub_version)
                   # Optional element to identify transactions between client and server.
                   if options.customer_context
                     xml.TransactionReference do

--- a/spec/friendly_shipping/services/ups/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_options_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe FriendlyShipping::Services::Ups::LabelOptions do
     :shipping_method,
     :shipper_number,
     :shipper,
+    :sub_version,
     :customer_context,
     :validate_address,
     :negotiated_rates,
@@ -23,6 +24,24 @@ RSpec.describe FriendlyShipping::Services::Ups::LabelOptions do
     :invoice_date
   ].each do |message|
     it { is_expected.to respond_to(message) }
+  end
+
+  describe 'sub-version validation' do
+    subject(:options) { described_class.new(sub_version: 'bogus', shipping_method: double, shipper_number: double) }
+
+    it { expect { options }.to raise_error(ArgumentError, 'Invalid sub-version: bogus') }
+  end
+
+  describe 'default options' do
+    it { expect(options.sub_version).to eq('1707') }
+    it { expect(options.validate_address).to be(true) }
+    it { expect(options.negotiated_rates).to be(false) }
+    it { expect(options.saturday_delivery).to be(false) }
+    it { expect(options.label_format).to eq('GIF') }
+    it { expect(options.label_size).to eq([4, 6]) }
+    it { expect(options.carbon_neutral).to be(true) }
+    it { expect(options.paperless_invoice).to be(false) }
+    it { expect(options.reason_for_export).to eq('SALE') }
   end
 
   describe 'delivery_confirmation_code' do

--- a/spec/friendly_shipping/services/ups/rate_estimates_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/rate_estimates_options_spec.rb
@@ -15,9 +15,25 @@ RSpec.describe FriendlyShipping::Services::Ups::RateEstimateOptions do
     :shipper,
     :shipper_number,
     :shipping_method,
+    :sub_version,
     :with_time_in_transit
   ].each do |message|
     it { is_expected.to respond_to(message) }
+  end
+
+  describe 'sub-version validation' do
+    subject(:options) { described_class.new(sub_version: 'bogus', shipper_number: 'SECRET') }
+
+    it { expect { options }.to raise_error(ArgumentError, 'Invalid sub-version: bogus') }
+  end
+
+  describe 'default options' do
+    it { expect(options.carbon_neutral).to be(true) }
+    it { expect(options.negotiated_rates).to be(false) }
+    it { expect(options.saturday_delivery).to be(false) }
+    it { expect(options.saturday_pickup).to be(false) }
+    it { expect(options.sub_version).to eq('1707') }
+    it { expect(options.with_time_in_transit).to be(false) }
   end
 
   describe '#options_for_package' do

--- a/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
   end
 
   let(:options) do
-    FriendlyShipping::Services::Ups::RateEstimateOptions.new(shipper_number: "12345")
+    FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+      sub_version: "2205",
+      shipper_number: "12345"
+    )
   end
 
   subject do
@@ -49,7 +52,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
       expect(subject.at_xpath('//RatingServiceSelectionRequest/Request')).to be_present
       expect(subject.at_xpath('//RatingServiceSelectionRequest/Request/RequestAction').text).to eq('Rate')
       expect(subject.at_xpath('//RatingServiceSelectionRequest/Request/RequestOption').text).to eq('Shop')
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Request/SubVersion').text).to eq('1707')
+      expect(subject.at_xpath('//RatingServiceSelectionRequest/Request/SubVersion').text).to eq('2205')
       expect(subject.at_xpath('//RatingServiceSelectionRequest/PickupType/Code').text).to eq('01')
       expect(subject.at_xpath('//RatingServiceSelectionRequest/CustomerClassification/Code').text).to eq('01')
       expect(

--- a/spec/friendly_shipping/services/ups/serialize_shipment_accept_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_accept_request_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentAcceptRequest d
     FriendlyShipping::Services::Ups::LabelOptions.new(
       shipping_method: double,
       shipper_number: '12345',
+      sub_version: '2205',
       customer_context: 'my_request_id'
     )
   end
@@ -19,7 +20,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentAcceptRequest d
     it 'has the right data in the right places' do
       expect(subject.at_xpath('//ShipmentAcceptRequest')).to be_present
       expect(subject.at_xpath('//ShipmentAcceptRequest/Request/RequestAction').text).to eq('ShipAccept')
-      expect(subject.at_xpath('//ShipmentAcceptRequest/Request/SubVersion').text).to eq('1707')
+      expect(subject.at_xpath('//ShipmentAcceptRequest/Request/SubVersion').text).to eq('2205')
       expect(subject.at_xpath('//ShipmentAcceptRequest/Request/TransactionReference/CustomerContext').text).to eq('my_request_id')
       expect(subject.at_xpath('//ShipmentAcceptRequest/ShipmentDigest').text).to eq('supers3cret')
     end

--- a/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
   let(:options) do
     FriendlyShipping::Services::Ups::LabelOptions.new(
       shipping_method: shipping_method,
-      shipper_number: '12345'
+      shipper_number: '12345',
+      sub_version: '2205'
     )
   end
 
@@ -77,7 +78,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
       expect(subject.at_xpath('//ShipmentConfirmRequest/Request')).to be_present
       expect(subject.at_xpath('//ShipmentConfirmRequest/Request/RequestAction').text).to eq('ShipConfirm')
       expect(subject.at_xpath('//ShipmentConfirmRequest/Request/RequestOption').text).to eq('validate')
-      expect(subject.at_xpath('//ShipmentConfirmRequest/Request/SubVersion').text).to eq('1707')
+      expect(subject.at_xpath('//ShipmentConfirmRequest/Request/SubVersion').text).to eq('2205')
       expect(subject.at_xpath('//ShipmentConfirmRequest/Shipment/Service/Code').text).to eq('03')
       expect(
         subject.at_xpath('//ShipmentConfirmRequest/Shipment/Shipper/Address/AddressLine1').text


### PR DESCRIPTION
The sub-version (default 1707) specifies which version of the UPS API to use. This controls which features are available/visible in requests and responses. Being able to pass a non-default sub-version is desirable.