### PR TITLE
R+L Shipping outside of Domestic USA & Canada requires dimensions

### DIFF
--- a/lib/friendly_shipping/services/rl/rate_quote_packages_serializer.rb
+++ b/lib/friendly_shipping/services/rl/rate_quote_packages_serializer.rb
@@ -15,7 +15,10 @@ module FriendlyShipping
                 item_options = package_options.options_for_item(item)
                 {
                   Class: item_options.freight_class,
-                  Weight: item.weight.convert_to(:pounds)
+                  Height: item.height.convert_to(:inches),
+                  Length: item.length.convert_to(:inches),
+                  Weight: item.weight.convert_to(:pounds),
+                  Width: item.width.convert_to(:inches)
                 }
               end
             end
@@ -35,7 +38,10 @@ module FriendlyShipping
             end.map do |freight_class, grouped_item_hashes|
               {
                 Class: freight_class,
-                Weight: grouped_item_hashes.sum { |e| e[:Weight] }.value.ceil,
+                Height: grouped_item_hashes.map { _1[:Height].value.ceil }.max,
+                Length: grouped_item_hashes.map { _1[:Length].value.ceil }.max,
+                Weight: grouped_item_hashes.sum { _1[:Weight] }.value.ceil,
+                Width: grouped_item_hashes.map { _1[:Width].value.ceil }.max,
                 Quantity: grouped_item_hashes.size
               }
             end

--- a/spec/friendly_shipping/services/rl/rate_quote_packages_serializer_spec.rb
+++ b/spec/friendly_shipping/services/rl/rate_quote_packages_serializer_spec.rb
@@ -90,7 +90,10 @@ RSpec.describe FriendlyShipping::Services::RL::RateQuotePackagesSerializer do
     is_expected.to eq(
       [{
         Class: "92.5",
+        Height: 12,
+        Length: 8,
         Weight: 12,
+        Width: 6,
         Quantity: 2
       }]
     )


### PR DESCRIPTION
Include dimensions when serializing packages to ensure we are able to generate quotes from R+L for destinations outside of domestic USA and Canada