### PR TITLE
Add optional pickup date to UPS rate requests

### DIFF
--- a/lib/friendly_shipping/services/ups/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/ups/rate_estimate_options.rb
@@ -17,6 +17,8 @@ module FriendlyShipping
     # @option customer_classification [Symbol] Which kind of rates to request. See UPS docs for more details. Default: `shipper_number`
     # @option negotiated_rates [Boolean] if truthy negotiated rates will be requested from ups. Only valid if
     #   shipper account has negotiated rates. Default: false
+    # @option pickup_type [String] UPS pickup type. See UPS docs for more details. Default: `daily_pickup`
+    # @option pickup_date [Time] UPS pickup date/time. Default: nil
     # @option saturday_delivery [Boolean] should we request Saturday delivery?. Default: false
     # @option saturday_pickup [Boolean] should we request Saturday pickup?. Default: false
     # @option shipping_method [FriendlyShipping::ShippingMethod] Request rates for a particular shipping method only?
@@ -52,6 +54,7 @@ module FriendlyShipping
                     :customer_context,
                     :destination_account,
                     :negotiated_rates,
+                    :pickup_date,
                     :saturday_delivery,
                     :saturday_pickup,
                     :shipper,
@@ -68,6 +71,7 @@ module FriendlyShipping
           destination_account: nil,
           negotiated_rates: false,
           pickup_type: :daily_pickup,
+          pickup_date: nil,
           saturday_delivery: false,
           saturday_pickup: false,
           shipper: nil,
@@ -86,6 +90,7 @@ module FriendlyShipping
           @negotiated_rates = negotiated_rates
           @shipper_number = shipper_number
           @pickup_type = pickup_type
+          @pickup_date = pickup_date
           @saturday_delivery = saturday_delivery
           @saturday_pickup = saturday_pickup
           @shipper = shipper

--- a/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
@@ -56,6 +56,15 @@ module FriendlyShipping
                   end
                 end
 
+                if options.pickup_date && options.sub_version.to_i >= 2205
+                  xml.DeliveryTimeInformation do
+                    xml.Pickup do
+                      xml.Date options.pickup_date.strftime('%Y%m%d')
+                      xml.Time options.pickup_date.strftime('%H%M')
+                    end
+                  end
+                end
+
                 shipment.packages.each do |package|
                   package_options = options.options_for_package(package)
                   SerializePackageNode.call(

--- a/spec/friendly_shipping/services/ups/rate_estimate_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/rate_estimate_options_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe FriendlyShipping::Services::Ups::RateEstimateOptions do
     :customer_context,
     :destination_account,
     :negotiated_rates,
+    :pickup_date,
     :saturday_delivery,
     :saturday_pickup,
     :shipper,
@@ -30,6 +31,7 @@ RSpec.describe FriendlyShipping::Services::Ups::RateEstimateOptions do
   describe 'default options' do
     it { expect(options.carbon_neutral).to be(true) }
     it { expect(options.negotiated_rates).to be(false) }
+    it { expect(options.pickup_date).to be_nil }
     it { expect(options.saturday_delivery).to be(false) }
     it { expect(options.saturday_pickup).to be(false) }
     it { expect(options.sub_version).to eq('1707') }

--- a/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
@@ -48,29 +48,29 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
   it 'contains the right data' do
     aggregate_failures do
-      expect(subject.at_xpath('//RatingServiceSelectionRequest')).to be_present
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Request')).to be_present
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Request/RequestAction').text).to eq('Rate')
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Request/RequestOption').text).to eq('Shop')
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Request/SubVersion').text).to eq('2205')
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/PickupType/Code').text).to eq('01')
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/CustomerClassification/Code').text).to eq('01')
+      expect(xml.at_xpath('//RatingServiceSelectionRequest')).to be_present
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Request')).to be_present
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Request/RequestAction').text).to eq('Rate')
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Request/RequestOption').text).to eq('Shop')
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Request/SubVersion').text).to eq('2205')
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/PickupType/Code').text).to eq('01')
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/CustomerClassification/Code').text).to eq('01')
       expect(
-        subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Shipper/Address/AddressLine1').text
+        xml.at_xpath('//RatingServiceSelectionRequest/Shipment/Shipper/Address/AddressLine1').text
       ).to eq('11 Lovely Street')
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Shipper/ShipperNumber').text).to be_present
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Shipment/Shipper/ShipperNumber').text).to be_present
       expect(
-        subject.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipTo/ShipperAssignedIdentificationNumber')
+        xml.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipTo/ShipperAssignedIdentificationNumber')
       ).not_to be_present
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipFrom')).not_to be_present
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package')).to be_present
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/Dimensions')).to be_present
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipFrom')).not_to be_present
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Shipment/Package')).to be_present
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/Dimensions')).to be_present
 
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/PackagingType/Code').text).to eq('02')
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/PackagingType/Code').text).to eq('02')
       expect(
-        subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/PackageWeight/UnitOfMeasurement/Code').text
+        xml.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/PackageWeight/UnitOfMeasurement/Code').text
       ).to eq('LBS')
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/PackageWeight/Weight').text).to eq('5')
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/PackageWeight/Weight').text).to eq('5')
     end
   end
 
@@ -84,12 +84,12 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
     it 'contains an extra ShipFrom element' do
       aggregate_failures do
-        expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipFrom')).to be_present
+        expect(xml.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipFrom')).to be_present
         expect(
-          subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Shipper/Address/AddressLine1').text
+          xml.at_xpath('//RatingServiceSelectionRequest/Shipment/Shipper/Address/AddressLine1').text
         ).to eq('Another Street')
         expect(
-          subject.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipFrom/Address/AddressLine1').text
+          xml.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipFrom/Address/AddressLine1').text
         ).to eq('11 Lovely Street')
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
     it 'contains a ShipperAssignedIdentificationNumber element' do
       expect(
-        subject.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipTo/ShipperAssignedIdentificationNumber').text
+        xml.at_xpath('//RatingServiceSelectionRequest/Shipment/ShipTo/ShipperAssignedIdentificationNumber').text
       ).to eq('98765')
     end
   end
@@ -120,7 +120,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
     it 'contains a UPScarbonneutralIndicator element' do
       expect(
-        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/ShipmentServiceOptions/UPScarbonneutralIndicator')
+        xml.at_xpath('/RatingServiceSelectionRequest/Shipment/ShipmentServiceOptions/UPScarbonneutralIndicator')
       ).to be_present
     end
   end
@@ -135,7 +135,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
     it 'contains a CustomerContext element' do
       expect(
-        subject.at_xpath('/RatingServiceSelectionRequest/Request/TransactionReference/CustomerContext').text
+        xml.at_xpath('/RatingServiceSelectionRequest/Request/TransactionReference/CustomerContext').text
       ).to eq('MYORDER!!')
     end
   end
@@ -150,7 +150,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
     it 'contains the right option' do
       expect(
-        subject.at_xpath('/RatingServiceSelectionRequest/CustomerClassification/Code').text
+        xml.at_xpath('/RatingServiceSelectionRequest/CustomerClassification/Code').text
       ).to eq('05')
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
     it 'contains the right option' do
       expect(
-        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/RateInformation/NegotiatedRatesIndicator')
+        xml.at_xpath('/RatingServiceSelectionRequest/Shipment/RateInformation/NegotiatedRatesIndicator')
       ).to be_present
     end
   end
@@ -180,7 +180,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
     it 'contains the right option' do
       expect(
-        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/ShipmentServiceOptions/SaturdayDelivery')
+        xml.at_xpath('/RatingServiceSelectionRequest/Shipment/ShipmentServiceOptions/SaturdayDelivery')
       ).to be_present
     end
   end
@@ -195,7 +195,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
     it 'contains the right option' do
       expect(
-        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/ShipmentServiceOptions/SaturdayPickup')
+        xml.at_xpath('/RatingServiceSelectionRequest/Shipment/ShipmentServiceOptions/SaturdayPickup')
       ).to be_present
     end
   end
@@ -209,9 +209,9 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
     end
 
     it 'contains the right option' do
-      expect(subject.at_xpath('/RatingServiceSelectionRequest/Request/RequestOption')).not_to be_present
+      expect(xml.at_xpath('/RatingServiceSelectionRequest/Request/RequestOption')).not_to be_present
       expect(
-        subject.at_xpath('/RatingServiceSelectionRequest/Shipment/Service/Code').text
+        xml.at_xpath('/RatingServiceSelectionRequest/Shipment/Service/Code').text
       ).to eq('44')
     end
   end
@@ -230,7 +230,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
     end
 
     it 'does not transmit dimensions' do
-      expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/Dimensions')).not_to be_present
+      expect(xml.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/Dimensions')).not_to be_present
     end
   end
 

--- a/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
     )
   end
 
-  subject do
+  subject(:xml) do
     Nokogiri::XML(
       described_class.call(shipment: shipment, options: options)
     )
@@ -231,6 +231,22 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionR
 
     it 'does not transmit dimensions' do
       expect(subject.at_xpath('//RatingServiceSelectionRequest/Shipment/Package/Dimensions')).not_to be_present
+    end
+  end
+
+  context 'with a pickup date' do
+    let(:options) do
+      FriendlyShipping::Services::Ups::RateEstimateOptions.new(
+        sub_version: '2205',
+        shipper_number: '12345',
+        pickup_date: Time.parse('2023-11-13 16:00:00 UTC')
+      )
+    end
+
+    it 'contains the right data' do
+      pickup = xml.xpath('//RatingServiceSelectionRequest/Shipment/DeliveryTimeInformation/Pickup')
+      expect(pickup.at_xpath('Date').text).to eq('20231113')
+      expect(pickup.at_xpath('Time').text).to eq('1600')
     end
   end
 end


### PR DESCRIPTION
The pickup date can be used to get a rate quote for a date up to 35 days into the past or 60 days into the future.

If a date is not provided or is invalid, it will be defaulted to the current system date.