### PR TITLE
Rubocop fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,4 +72,4 @@ workflows:
             parameters:
               # https://github.com/CircleCI-Public/cimg-ruby
               # only supports the last three ruby versions
-              ruby-version: ["3.1", "3.0", "2.7"]
+              ruby-version: ["3.2", "3.1", "3.0"]

--- a/lib/friendly_shipping/api_error.rb
+++ b/lib/friendly_shipping/api_error.rb
@@ -8,7 +8,7 @@ module FriendlyShipping
     # @param [String] message
     def initialize(cause, message = nil)
       @cause = cause
-      super message || cause.message
+      super(message || cause.message)
     end
   end
 end

--- a/lib/friendly_shipping/services/rl/api_error.rb
+++ b/lib/friendly_shipping/services/rl/api_error.rb
@@ -8,7 +8,7 @@ module FriendlyShipping
       class ApiError < FriendlyShipping::ApiError
         # @param [RestClient::Exception] cause
         def initialize(cause)
-          super cause, parse_message(cause)
+          super(cause, parse_message(cause))
         end
 
         private

--- a/lib/friendly_shipping/services/ship_engine/api_error.rb
+++ b/lib/friendly_shipping/services/ship_engine/api_error.rb
@@ -8,7 +8,7 @@ module FriendlyShipping
       class ApiError < FriendlyShipping::ApiError
         # @param [RestClient::Exception] cause
         def initialize(cause)
-          super cause, parse_message(cause)
+          super(cause, parse_message(cause))
         end
 
         private

--- a/lib/friendly_shipping/services/ship_engine/parse_rates_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_rates_response.rb
@@ -77,14 +77,14 @@ module FriendlyShipping
           end
 
           def get_amounts(rate_hash)
-            [:shipping, :other, :insurance, :confirmation].map do |name|
+            [:shipping, :other, :insurance, :confirmation].to_h do |name|
               currency = Money::Currency.new(rate_hash["#{name}_amount"]["currency"])
               amount = rate_hash["#{name}_amount"]["amount"] * currency.subunit_to_unit
               [
                 name,
                 Money.new(amount, currency)
               ]
-            end.to_h
+            end
           end
         end
       end

--- a/lib/friendly_shipping/services/ship_engine/rates_package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_package_options.rb
@@ -9,7 +9,6 @@ module FriendlyShipping
       #
       # @attribute [RatesItemOptions] item_options Options for each of the items in the package
       class RatesPackageOptions < FriendlyShipping::PackageOptions
-
         def initialize(**kwargs)
           super(**kwargs.merge(item_options_class: RatesItemOptions))
         end

--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -59,7 +59,7 @@ module FriendlyShipping
               package_options = options.options_for_package(package)
               package_hash = serialize_weight(package.weight)
               package_hash[:label_messages] = package_options.messages.map.with_index do |message, index|
-                ["reference#{index + 1}".to_sym, message]
+                [:"reference#{index + 1}", message]
               end.to_h
 
               package_hash[:package_code] = package_options.package_code

--- a/lib/friendly_shipping/services/ups_freight/api_error.rb
+++ b/lib/friendly_shipping/services/ups_freight/api_error.rb
@@ -8,7 +8,7 @@ module FriendlyShipping
       class ApiError < FriendlyShipping::ApiError
         # @param [RestClient::Exception] cause
         def initialize(cause)
-          super cause, parse_message(cause)
+          super(cause, parse_message(cause))
         end
 
         private

--- a/spec/friendly_shipping/services/ship_engine/parse_label_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_label_response_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::ParseLabelResponse, vcr: 
   end
 
   context "apc label" do
-    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_labels_success.json')).read }
+    let(:response_body) { File.read(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_labels_success.json')) }
 
     it "contains the correct data" do
       expect(label.id).to be_present

--- a/spec/friendly_shipping/services/ship_engine/parse_rate_estimates_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_rate_estimates_response_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::ParseRateEstimatesRespons
   end
 
   context "apc rate estimates" do
-    let(:carrier_json) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_carriers.json')).read }
-    let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_rate_estimates_success.json')).read }
+    let(:carrier_json) { File.read(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_carriers.json')) }
+    let(:response_body) { File.read(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_rate_estimates_success.json')) }
 
     it "contains correct data" do
       expect(rate_estimate.shipping_method).to be_a(FriendlyShipping::ShippingMethod)

--- a/spec/friendly_shipping/services/ship_engine/parse_rates_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_rates_response_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::ParseRatesResponse do
-  let(:carrier_json) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_carriers.json')).read }
+  let(:carrier_json) { File.read(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_carriers.json')) }
   let(:request) { double(debug: true) }
   let(:response) { double(body: response_body) }
-  let(:response_body) { File.open(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_rates_success.json')).read }
+  let(:response_body) { File.read(File.join(gem_root, 'spec', 'fixtures', 'ship_engine', 'apc_rates_success.json')) }
   let(:carriers) { FriendlyShipping::Services::ShipEngine::ParseCarrierResponse.call(request: request, response: double(body: carrier_json)).data }
   let(:options) { FriendlyShipping::Services::ShipEngine::RatesOptions.new(carriers: carriers, service_code: "se-666777") }
   let(:rate_estimate) { subject.value!.data.first }


### PR DESCRIPTION
Updates the CI to run Ruby 3.2 instead of 2.7, and fixes a few rubocop offenses.