### PR TITLE
Implement new TForce API rates call

### DIFF
--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -20,6 +20,7 @@ require "friendly_shipping/api_failure"
 require 'friendly_shipping/services/rl'
 require "friendly_shipping/services/ship_engine"
 require 'friendly_shipping/services/ship_engine_ltl'
+require "friendly_shipping/services/tforce_freight"
 require "friendly_shipping/services/ups"
 require "friendly_shipping/services/ups_freight"
 require "friendly_shipping/services/usps"

--- a/lib/friendly_shipping/inflections.rb
+++ b/lib/friendly_shipping/inflections.rb
@@ -5,5 +5,6 @@ if Object.const_defined?('ActiveSupport::Inflector')
   ActiveSupport::Inflector.inflections(:en) do |inflect|
     inflect.acronym 'BOL'
     inflect.acronym 'RL'
+    inflect.acronym 'TForce'
   end
 end

--- a/lib/friendly_shipping/services/tforce_freight.rb
+++ b/lib/friendly_shipping/services/tforce_freight.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'friendly_shipping/http_client'
+require 'friendly_shipping/services/tforce_freight/shipping_methods'
+require 'friendly_shipping/services/tforce_freight/rates_options'
+require 'friendly_shipping/services/tforce_freight/rates_package_options'
+require 'friendly_shipping/services/tforce_freight/rates_item_options'
+require 'friendly_shipping/services/tforce_freight/parse_rates_response'
+require 'friendly_shipping/services/tforce_freight/generate_rates_request_hash'
+require 'friendly_shipping/services/tforce_freight/api_error'
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      include Dry::Monads[:result]
+
+      attr_reader :access_token, :test, :client
+
+      CARRIER = FriendlyShipping::Carrier.new(
+        id: 'tforce_freight',
+        name: 'TForce Freight',
+        code: 'tforce_freight-freight',
+        shipping_methods: SHIPPING_METHODS
+      )
+
+      BASE_URL = 'https://api.tforcefreight.com'
+
+      RESOURCES = {
+        rates: '/rating/getRate',
+      }.freeze
+
+      def initialize(access_token:, test: true, client: nil)
+        @access_token = access_token
+        @test = test
+
+        error_handler = ApiErrorHandler.new(api_error_class: TForceFreight::ApiError)
+        @client = client || HttpClient.new(error_handler: error_handler)
+      end
+
+      def carriers
+        Success([CARRIER])
+      end
+
+      # Get rates for a shipment
+      # @param [Physical::Shipment] shipment The shipment for which we want to get rates
+      # @param [FriendlyShipping::Services::TForceFreight::RatesOptions] options Options for obtaining rates for this shipment.
+      # @return [Result<ApiResult<Array<Rate>>>] The rates returned from UPS encoded in a
+      #   `FriendlyShipping::ApiResult` object.
+      def rates(shipment, options:, debug: false)
+        freight_rate_request_hash = GenerateRatesRequestHash.call(shipment: shipment, options: options)
+        request = build_request(:rates, freight_rate_request_hash, debug)
+
+        client.post(request).fmap do |response|
+          ParseRatesResponse.call(response: response, request: request)
+        end
+      end
+
+      private
+
+      def build_request(action, payload, debug)
+        url = BASE_URL + RESOURCES[action] + "?api-version=#{api_version}"
+        FriendlyShipping::Request.new(
+          url: url,
+          http_method: "POST",
+          body: payload.to_json,
+          headers: {
+            Content_Type: "application/json",
+            Accept: "application/json",
+            Authorization: "Bearer #{access_token}"
+          },
+          debug: debug
+        )
+      end
+
+      def api_version
+        test ? "cie-v1" : "v1"
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/api_error.rb
+++ b/lib/friendly_shipping/services/tforce_freight/api_error.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/api_error'
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      class ApiError < FriendlyShipping::ApiError
+        # @param [RestClient::Exception] cause
+        def initialize(cause)
+          super(cause, parse_message(cause))
+        end
+
+        private
+
+        # @param [RestClient::Exception] error
+        # @return [String]
+        def parse_message(error)
+          return error.message unless error.response
+
+          parsed_json = JSON.parse(error.response.body)
+          status = parsed_json['statusCode']
+          message = parsed_json['message']
+          [status, message].compact.join(": ")
+        rescue JSON::ParserError, KeyError => _e
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/generate_commodity_information.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_commodity_information.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      class GenerateCommodityInformation
+        # @param [Physical::Shipment] shipment
+        # @param [FriendlyShipping::Services::TForceFreight::RatesOptions] options
+        def self.call(shipment:, options:)
+          shipment.packages.flat_map do |package|
+            package_options = options.options_for_package(package)
+            package.items.map do |item|
+              item_options = package_options.options_for_item(item)
+              {
+                class: item_options.freight_class,
+                nmfc: {
+                  prime: item_options.nmfc_primary_code,
+                  sub: item_options.nmfc_sub_code
+                },
+                pieces: 1, # We don't support grouping yet
+                weight: {
+                  weight: item.weight.convert_to(:pounds).value.to_f.round(2),
+                  weightUnit: "LBS"
+                },
+                packagingType: item_options.packaging_code,
+                dangerousGoods: false,
+                dimensions: {
+                  length: item.length.convert_to(:inches).value.to_f.round(2),
+                  width: item.width.convert_to(:inches).value.to_f.round(2),
+                  height: item.height.convert_to(:inches).value.to_f.round(2),
+                  unit: "inches"
+                }
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/generate_location_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_location_hash.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      class GenerateLocationHash
+        class << self
+          def call(location:)
+            {
+              address: {
+                city: location.city,
+                stateProvinceCode: location.region&.code,
+                postalCode: location.zip,
+                country: location.country&.code
+              }
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/generate_rates_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_rates_request_hash.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/tforce_freight/generate_location_hash'
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      class GenerateRatesRequestHash
+        class << self
+          # @param [Physical::Shipment] shipment The shipment for which we want to get rates
+          # @param [FriendlyShipping::Services::TForceFreight::RatesOptions] options Options for obtaining rates for this shipment
+          def call(shipment:, options:)
+            {
+              requestOptions: request_options(options),
+              shipFrom: GenerateLocationHash.call(location: shipment.origin),
+              shipTo: GenerateLocationHash.call(location: shipment.destination),
+              payment: payment(options),
+              serviceOptions: service_options(options),
+              commodities: options.commodity_information_generator.call(shipment: shipment, options: options)
+            }
+          end
+
+          private
+
+          def request_options(options)
+            {
+              serviceCode: options.shipping_method.service_code,
+              pickupDate: options.pickup_date.strftime('%Y-%m-%d'),
+              type: options.type_code,
+              densityEligible: options.density_eligible,
+              gfpOptions: {
+                accessorialRate: options.accessorial_rate,
+              },
+              timeInTransit: options.time_in_transit,
+              quoteNumber: options.quote_number,
+              customerContext: options.customer_context
+            }
+          end
+
+          def payment(options)
+            {
+              payer: GenerateLocationHash.call(location: options.billing_address),
+              billingCode: options.billing_code
+            }
+          end
+
+          def service_options(options)
+            {
+              pickup: options.pickup_options,
+              delivery: options.delivery_options
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/parse_rates_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_rates_response.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/rate'
+require 'friendly_shipping/api_result'
+require 'friendly_shipping/services/tforce_freight/shipping_methods'
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      class ParseRatesResponse
+        class << self
+          def call(request:, response:)
+            json = JSON.parse(response.body)
+            transaction_id = json.dig("summary", "transactionReference", "transactionId")
+
+            rates = json['detail'].map do |detail|
+              service_code = detail.dig("service", "code")
+              shipping_method = SHIPPING_METHODS.detect { |sm| sm.service_code == service_code }
+
+              total_amount = detail.dig("shipmentCharges", "total", "value")
+              total_currency = detail.dig("shipmentCharges", "total", "currency")
+              total = Money.new(total_amount.to_f * 100, total_currency)
+
+              rates = detail['rate']
+              data = rates.each_with_object({}) do |rate, result|
+                result[rate['code'].downcase.to_sym] = rate['value'].to_f
+              end
+
+              data.merge(
+                customer_context: transaction_id,
+                commodities: Array.wrap(json['commodities'])
+              )
+
+              days_in_transit = detail.dig("timeInTransit", "timeInTransit")
+              data[:days_in_transit] = days_in_transit.to_i if days_in_transit
+
+              FriendlyShipping::Rate.new(
+                amounts: { total: total },
+                shipping_method: shipping_method,
+                data: data
+              )
+            end
+
+            FriendlyShipping::ApiResult.new(
+              rates,
+              original_request: request,
+              original_response: response
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/rates_item_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_item_options.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      # Options for Items in a UPS Freight shipment
+      #
+      # @attribute [Symbol] packaging
+      # @attribute [String] freight_class
+      # @attribute [String] nmfc_primary_code
+      # @attribute [String] nmfc_sub_code
+      class RatesItemOptions < FriendlyShipping::ItemOptions
+        PACKAGING_TYPES = {
+          bag: { code: "BAG", description: "Bag" },
+          bale: { code: "BAL", description: "Bale" },
+          barrel: { code: "BAR", description: "Barrel" },
+          bundle: { code: "BDL", description: "Bundle" },
+          bin: { code: "BIN", description: "Bin" },
+          box: { code: "BOX", description: "Box" },
+          basket: { code: "BSK", description: "Basket" },
+          bunch: { code: "BUN", description: "Bunch" },
+          cabinet: { code: "CAB", description: "Cabinet" },
+          can: { code: "CAN", description: "Can" },
+          carrier: { code: "CAR", description: "Carrier" },
+          case: { code: "CAS", description: "Case" },
+          carboy: { code: "CBY", description: "Carboy" },
+          container: { code: "CON", description: "Container" },
+          crate: { code: "CRT", description: "Crate" },
+          cask: { code: "CSK", description: "Cask" },
+          carton: { code: "CTN", description: "Carton" },
+          cylinder: { code: "CYL", description: "Cylinder" },
+          drum: { code: "DRM", description: "Drum" },
+          loose: { code: "LOO", description: "Loose" },
+          other: { code: "OTH", description: "Other" },
+          pail: { code: "PAL", description: "Pail" },
+          pieces: { code: "PCS", description: "Pieces" },
+          package: { code: "PKG", description: "Package" },
+          pipe_line: { code: "PLN", description: "Pipe Line" },
+          pallet: { code: "PLT", description: "Pallet" },
+          rack: { code: "RCK", description: "Rack" },
+          reel: { code: "REL", description: "Reel" },
+          roll: { code: "ROL", description: "Roll" },
+          skid: { code: "SKD", description: "Skid" },
+          spool: { code: "SPL", description: "Spool" },
+          tube: { code: "TBE", description: "Tube" },
+          tank: { code: "TNK", description: "Tank" },
+          totes: { code: "TOT", description: "Totes" },
+          unit: { code: "UNT", description: "Unit" },
+          van_pack: { code: "VPK", description: "Van Pack" },
+          wrapped: { code: "WRP", description: "Wrapped" }
+        }.freeze
+
+        attr_reader :packaging_code,
+                    :packaging_description,
+                    :freight_class,
+                    :nmfc_primary_code,
+                    :nmfc_sub_code
+
+        def initialize(
+          packaging: :carton,
+          freight_class: nil,
+          nmfc_primary_code: nil,
+          nmfc_sub_code: nil,
+          **kwargs
+        )
+          @packaging_code = PACKAGING_TYPES.fetch(packaging).fetch(:code)
+          @packaging_description = PACKAGING_TYPES.fetch(packaging).fetch(:description)
+          @freight_class = freight_class
+          @nmfc_primary_code = nmfc_primary_code
+          @nmfc_sub_code = nmfc_sub_code
+          super(**kwargs)
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/rates_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_options.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/tforce_freight/rates_package_options'
+require 'friendly_shipping/services/tforce_freight/generate_commodity_information'
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      # Options for generating TForce Freight rates for a shipment
+      #
+
+      # @attribute [Physical::Location] billing_address The billing address
+      # @attribute [FriendlyShipping::ShippingMethod] shipping_method The shipping method to use
+      # @attribute [Date] pickup_date Date of the Pickup. Defaults to today.
+      # @attribute [Symbol] billing One of the keys in the `BILLING_CODES` constant. How the shipment
+      #     would be billed.
+      # @attribute [String] type Rating call type. Possible values are L, F, or B. Defaults to L.
+      # @attribute [Boolean] density_eligible Indicates that the rate request is density based. Defaults to `false`
+      # @attribute [Boolean] accessorial_rate Indicates that the rate is accessorial. Defaults to `false`
+      # @attribute [Boolean] time_in_transit Requests transit timing information be included in the response. Defaults to `true`
+      # @attribute [Boolean] quote_number Requests a quote number be included in the response. Defaults to `false`
+      # @attribute [String] customer_context A reference to match this request with an order or shipment. Defaults to `nil`
+      # @attribute [Array<String>] pickup_options Shipment pick up service options
+      # @attribute [Array<String] delivery_options Shipment delivery service options
+      # @attribute [Callable] commodity_information_generator A callable that takes a shipment
+      #     and an options object to create an Array of commodity fields as per the UPS docs.
+      # @attribute [RatesPackageOptions] package_options Options for each of the packages/pallets in this shipment
+      class RatesOptions < FriendlyShipping::ShipmentOptions
+        BILLING_CODES = {
+          prepaid: "10",
+          third_party: "30",
+          freight_collect: "40"
+        }.freeze
+
+        TYPE_CODES = {
+          l: "L",
+          f: "F",
+          b: "B"
+        }.freeze
+
+        PICKUP_OPTIONS = {
+          inside: "INPU",
+          liftgate: "LIFO",
+          residential: "RESP",
+          limited_access: "LAPU"
+        }.freeze
+
+        DELIVERY_OPTIONS = {
+          inside: "INDE",
+          liftgate: "LIFD",
+          residential: "RESD",
+          limited_access: "LADL"
+        }.freeze
+
+        attr_reader :billing_address,
+                    :shipping_method,
+                    :pickup_date,
+                    :billing_code,
+                    :type_code,
+                    :density_eligible,
+                    :accessorial_rate,
+                    :time_in_transit,
+                    :quote_number,
+                    :pickup_options,
+                    :delivery_options,
+                    :customer_context,
+                    :commodity_information_generator
+
+        def initialize(
+          billing_address:,
+          shipping_method:,
+          pickup_date: Date.today,
+          billing: :prepaid,
+          type: :l,
+          density_eligible: false,
+          accessorial_rate: false,
+          time_in_transit: true,
+          quote_number: false,
+          pickup_options: [],
+          delivery_options: [],
+          customer_context: nil,
+          commodity_information_generator: GenerateCommodityInformation,
+          **kwargs
+        )
+          @pickup_date = pickup_date
+          @billing_address = billing_address
+          @billing_code = BILLING_CODES.fetch(billing)
+          @shipping_method = shipping_method
+          @type_code = TYPE_CODES.fetch(type)
+          @density_eligible = density_eligible
+          @accessorial_rate = accessorial_rate
+          @time_in_transit = time_in_transit
+          @quote_number = quote_number
+          @pickup_options = pickup_options
+          @delivery_options = delivery_options
+          @customer_context = customer_context
+          @commodity_information_generator = commodity_information_generator
+
+          validate_pickup_options!
+          validate_delivery_options!
+
+          super(**kwargs.merge(package_options_class: RatesPackageOptions))
+        end
+
+        private
+
+        def validate_pickup_options!
+          invalid_options = (pickup_options - PICKUP_OPTIONS.values)
+          return unless invalid_options.any?
+
+          raise ArgumentError, "Invalid pickup option(s): #{invalid_options.join(', ')}"
+        end
+
+        def validate_delivery_options!
+          invalid_options = (delivery_options - DELIVERY_OPTIONS.values)
+          return unless invalid_options.any?
+
+          raise ArgumentError, "Invalid delivery option(s): #{invalid_options.join(', ')}"
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/tforce_freight/rates_item_options'
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      # Options for packages/pallets within a TForce Freight shipment
+      class RatesPackageOptions < FriendlyShipping::PackageOptions
+        def initialize(**kwargs)
+          super(**kwargs.merge(item_options_class: RatesItemOptions))
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/shipping_methods.rb
+++ b/lib/friendly_shipping/services/tforce_freight/shipping_methods.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      ORIGIN_COUNTRIES = %w(
+        CA MX PR US
+      ).map { |country_code| Carmen::Country.coded(country_code) }.freeze
+
+      SHIPPING_METHODS = [
+        ['308', 'TForce Freight LTL'],
+        ['309', 'TForce Freight LTL - Guaranteed'],
+        ['334', 'TForce Freight LTL - Guaranteed A.M.'],
+        ['349', 'TForce Standard LTL']
+      ].freeze.map do |code, name|
+        FriendlyShipping::ShippingMethod.new(
+          name: name,
+          service_code: code,
+          origin_countries: ORIGIN_COUNTRIES,
+          multi_package: true
+        ).freeze
+      end
+    end
+  end
+end

--- a/spec/cassettes/tforce_freight/rates/failure.yml
+++ b/spec/cassettes/tforce_freight/rates/failure.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.tforcefreight.com/rating/getRate?api-version=cie-v1
+    body:
+      encoding: UTF-8
+      string: '{"requestOptions":{"serviceCode":"308","pickupDate":"2023-12-06","type":"L","densityEligible":false,"gfpOptions":{"accessorialRate":false},"timeInTransit":true,"quoteNumber":false,"customerContext":"order-12345"},"shipFrom":{"address":{"city":"Richmond","stateProvinceCode":"VA","postalCode":"23224","country":"US"}},"shipTo":{"address":{"city":"Allanton","stateProvinceCode":"MO","postalCode":null,"country":"US"}},"payment":{"payer":{"address":{"city":"Durham","stateProvinceCode":"NC","postalCode":"27703","country":"US"}},"billingCode":"10"},"serviceOptions":{"pickup":["INPU","LIFO"],"delivery":["INDE","LIFD"]},"commodities":[{"class":"92.5","nmfc":{"prime":"16030","sub":"1"},"pieces":1,"weight":{"weight":500.0,"weightUnit":"LBS"},"packagingType":"CTN","dangerousGoods":false,"dimensions":{"length":0.0,"width":0.0,"height":0.0,"unit":"inches"}},{"class":"92.5","nmfc":{"prime":"16030","sub":"1"},"pieces":1,"weight":{"weight":500.0,"weightUnit":"LBS"},"packagingType":"PLT","dangerousGoods":false,"dimensions":{"length":0.0,"width":0.0,"height":0.0,"unit":"inches"}}]}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (darwin22 x86_64) ruby/3.2.2p53
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer secret-token
+      Content-Length:
+      - '1077'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - api.tforcefreight.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Length:
+      - '217'
+      Content-Type:
+      - application/json
+      Request-Context:
+      - appId=cid-v1:2851e6bf-1dfd-43fd-837a-37e3cd142cdd
+      Date:
+      - Wed, 06 Dec 2023 21:25:15 GMT
+    body:
+      encoding: UTF-8
+      string: '{ "statusCode": 400, "message": "Body of the request does not conform
+        to the definition which is associated with the content type application/json.
+        Invalid type. Expected String but got Null. Line: 1, Position: 398" }'
+  recorded_at: Wed, 06 Dec 2023 21:25:15 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/tforce_freight/rates/success.yml
+++ b/spec/cassettes/tforce_freight/rates/success.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.tforcefreight.com/rating/getRate?api-version=cie-v1
+    body:
+      encoding: UTF-8
+      string: '{"requestOptions":{"serviceCode":"308","pickupDate":"2023-12-06","type":"L","densityEligible":false,"gfpOptions":{"accessorialRate":false},"timeInTransit":true,"quoteNumber":false,"customerContext":"order-12345"},"shipFrom":{"address":{"city":"Richmond","stateProvinceCode":"VA","postalCode":"23224","country":"US"}},"shipTo":{"address":{"city":"Eureka","stateProvinceCode":"MO","postalCode":"63025","country":"US"}},"payment":{"payer":{"address":{"city":"Durham","stateProvinceCode":"NC","postalCode":"27703","country":"US"}},"billingCode":"10"},"serviceOptions":{"pickup":["INPU","LIFO"],"delivery":["INDE","LIFD"]},"commodities":[{"class":"92.5","nmfc":{"prime":"16030","sub":"1"},"pieces":1,"weight":{"weight":500.0,"weightUnit":"LBS"},"packagingType":"CTN","dangerousGoods":false,"dimensions":{"length":0.0,"width":0.0,"height":0.0,"unit":"inches"}},{"class":"92.5","nmfc":{"prime":"16030","sub":"1"},"pieces":1,"weight":{"weight":500.0,"weightUnit":"LBS"},"packagingType":"PLT","dangerousGoods":false,"dimensions":{"length":0.0,"width":0.0,"height":0.0,"unit":"inches"}}]}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (darwin22 x86_64) ruby/3.2.2p53
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer secret-token
+      Content-Length:
+      - '1078'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - api.tforcefreight.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache,no-store,must-revalidate,max-age=0,no-cache="set-cookie"
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '1748'
+      Content-Type:
+      - application/json
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1;mode=block
+      Request-Context:
+      - appId=cid-v1:2851e6bf-1dfd-43fd-837a-37e3cd142cdd
+      Date:
+      - Wed, 06 Dec 2023 21:25:14 GMT
+    body:
+      encoding: UTF-8
+      string: '{"summary":{"responseStatus":{"code":"PRT","message":"1 of 3 Rate(s)
+        returned."},"transactionReference":{"transactionId":"140fdff5-3df5-419e-bc3f-84b781f55cc9"},"classDensityIndicatior":"CC"},"detail":[{"detailStatus":{"code":"1","message":"success"},"alerts":[{"code":"688","message":"FBR688:
+        FULL RATES RETURNED. CUSTOMER COULD NOT BE FOUND FOR THAT ZIP CODE."}],"service":{"code":"308","description":"LTL"},"rate":[{"code":"DSCNT","description":"Discount","value":"1987.05","unit":"USD"},{"code":"DSCNT_RATE","description":"Discount
+        Rate","value":"75.00","unit":"%"},{"code":"INDE","description":"INSIDE_DL","value":"169.00","unit":"USD"},{"code":"INPU","description":"INSIDE_PU","value":"169.00","unit":"USD"},{"code":"LIFD","description":"LIFT_GATE_DL","value":"175.00","unit":"USD"},{"code":"LIFO","description":"LIFT_GATE_PU","value":"175.00","unit":"USD"},{"code":"FUEL_SUR","description":"Fuel
+        Surcharge Fee","value":"223.21","unit":"USD"},{"code":"LND_GROSS","description":"LND_GROSS","value":"2649.40","unit":"USD"},{"code":"AFTR_DSCNT","description":"AFTR_DSCNT","value":"662.35","unit":"USD"}],"commodities":[{"description":"MISC","weight":{"weight":"500","adjustedWeight":"500","weightUnit":"LBS"}},{"description":"MISC","weight":{"weight":"500","adjustedWeight":"500","weightUnit":"LBS"}}],"shipmentCharges":{"total":{"value":"1573.56","currency":"USD"}},"shipmentWeights":{"billable":{"value":"1000","unit":"LBS"}},"timeInTransit":{"timeInTransit":"3","unit":"DAY"}},{"detailStatus":{"code":"NFO","message":"Rate
+        not found."},"service":{"code":"309","description":"GRTD"},"rate":[]},{"detailStatus":{"code":"NFO","message":"Rate
+        not found."},"service":{"code":"334","description":"GRAM"},"rate":[]}],"customerContext":"order-12345"}'
+  recorded_at: Wed, 06 Dec 2023 21:25:14 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/tforce_freight/failure_with_http_error.json
+++ b/spec/fixtures/tforce_freight/failure_with_http_error.json
@@ -1,0 +1,4 @@
+{
+  "statusCode": 400,
+  "message": "Body of the request does not conform to the definition which is associated with the content type application/json. Invalid type. Expected String but got Null. Line: 1, Position: 398"
+}

--- a/spec/fixtures/tforce_freight/rates/success.json
+++ b/spec/fixtures/tforce_freight/rates/success.json
@@ -1,0 +1,143 @@
+{
+  "summary": {
+    "responseStatus": {
+      "code": "PRT",
+      "message": "1 of 3 Rate(s) returned."
+    },
+    "transactionReference": {
+      "transactionId": "140fdff5-3df5-419e-bc3f-84b781f55cc9"
+    },
+    "classDensityIndicatior": "CC"
+  },
+  "detail": [
+    {
+      "detailStatus": {
+        "code": "1",
+        "message": "success"
+      },
+      "alerts": [
+        {
+          "code": "688",
+          "message": "FBR688: FULL RATES RETURNED. CUSTOMER COULD NOT BE FOUND FOR THAT ZIP CODE."
+        }
+      ],
+      "service": {
+        "code": "308",
+        "description": "LTL"
+      },
+      "rate": [
+        {
+          "code": "DSCNT",
+          "description": "Discount",
+          "value": "1987.05",
+          "unit": "USD"
+        },
+        {
+          "code": "DSCNT_RATE",
+          "description": "DiscountRate",
+          "value": "75.00",
+          "unit": "%"
+        },
+        {
+          "code": "INDE",
+          "description": "INSIDE_DL",
+          "value": "169.00",
+          "unit": "USD"
+        },
+        {
+          "code": "INPU",
+          "description": "INSIDE_PU",
+          "value": "169.00",
+          "unit": "USD"
+        },
+        {
+          "code": "LIFD",
+          "description": "LIFT_GATE_DL",
+          "value": "175.00",
+          "unit": "USD"
+        },
+        {
+          "code": "LIFO",
+          "description": "LIFT_GATE_PU",
+          "value": "175.00",
+          "unit": "USD"
+        },
+        {
+          "code": "FUEL_SUR",
+          "description": "FuelSurcharge Fee",
+          "value": "223.21",
+          "unit": "USD"
+        },
+        {
+          "code": "LND_GROSS",
+          "description": "LND_GROSS",
+          "value": "2649.40",
+          "unit": "USD"
+        },
+        {
+          "code": "AFTR_DSCNT",
+          "description": "AFTR_DSCNT",
+          "value": "662.35",
+          "unit": "USD"
+        }
+      ],
+      "commodities": [
+        {
+          "description": "MISC",
+          "weight": {
+            "weight": "500",
+            "adjustedWeight": "500",
+            "weightUnit": "LBS"
+          }
+        },
+        {
+          "description": "MISC",
+          "weight": {
+            "weight": "500",
+            "adjustedWeight": "500",
+            "weightUnit": "LBS"
+          }
+        }
+      ],
+      "shipmentCharges": {
+        "total": {
+          "value": "1573.56",
+          "currency": "USD"
+        }
+      },
+      "shipmentWeights": {
+        "billable": {
+          "value": "1000",
+          "unit": "LBS"
+        }
+      },
+      "timeInTransit": {
+        "timeInTransit": "3",
+        "unit": "DAY"
+      }
+    },
+    {
+      "detailStatus": {
+        "code": "NFO",
+        "message": "Rate not found."
+      },
+      "service": {
+        "code": "309",
+        "description": "GRTD"
+      },
+      "rate": []
+    },
+    {
+      "detailStatus": {
+        "code": "NFO",
+        "message": "Rate not found."
+      },
+      "service": {
+        "code": "334",
+        "description": "GRAM"
+      },
+      "rate": []
+    }
+  ],
+  "customerContext": "order-12345"
+}

--- a/spec/friendly_shipping/services/tforce_freight/api_error_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/api_error_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::ApiError do
+  describe "#message" do
+    subject(:message) { described_class.new(error).message }
+
+    let(:body) { File.read(File.join(gem_root, 'spec', 'fixtures', 'tforce_freight', fixture)) }
+    let(:error) { RestClient::Exception.new(double(body: body)) }
+
+    context "with HTTP error response" do
+      let(:fixture) { "failure_with_http_error.json" }
+
+      it do
+        is_expected.to eq(
+          "400: Body of the request does not conform to the definition which is associated with the content " \
+          "type application/json. Invalid type. Expected String but got Null. Line: 1, Position: 398"
+        )
+      end
+    end
+
+    context "with timeout error response" do
+      let(:error) { RestClient::Exceptions::ReadTimeout.new("Timed out reading data from server") }
+      it { is_expected.to eq("Timed out reading data from server") }
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/generate_commodity_information_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_commodity_information_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCommodityInformation do
+  describe ".call" do
+    subject(:call) { described_class.call(shipment: shipment, options: options) }
+
+    let(:shipment) { Physical::Shipment.new(packages: packages) }
+    let(:packages) { [package_one, package_two] }
+
+    let(:package_one) do
+      Physical::Package.new(
+        id: "my_package_1",
+        items: [item_one]
+      )
+    end
+
+    let(:package_two) do
+      Physical::Package.new(
+        id: "my_package_2",
+        items: [item_two]
+      )
+    end
+
+    let(:item_one) do
+      Physical::Item.new(
+        id: "item_one",
+        weight: Measured::Weight(10.523, :lbs),
+        dimensions: [
+          Measured::Length(1.874, :in),
+          Measured::Length(3.906, :in),
+          Measured::Length(5.811, :in)
+        ]
+      )
+    end
+
+    let(:item_two) do
+      Physical::Item.new(
+        id: "item_two",
+        weight: Measured::Weight(8.243, :lbs),
+        dimensions: [
+          Measured::Length(1.341, :in),
+          Measured::Length(3.294, :in),
+          Measured::Length(5.912, :in)
+        ]
+      )
+    end
+
+    let(:options) do
+      FriendlyShipping::Services::TForceFreight::RatesOptions.new(
+        pickup_date: pickup_date,
+        billing_address: billing_address,
+        shipping_method: shipping_method,
+        package_options: shipment.packages.map do |package|
+          FriendlyShipping::Services::TForceFreight::RatesPackageOptions.new(
+            package_id: package.id,
+            item_options: package.items.map do |item|
+              FriendlyShipping::Services::TForceFreight::RatesItemOptions.new(
+                item_id: item.id,
+                packaging: :package,
+                freight_class: "92.5",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07"
+              )
+            end
+          )
+        end
+      )
+    end
+
+    let(:pickup_date) { Date.today }
+
+    let(:billing_address) do
+      Physical::Location.new(
+        city: "Durham",
+        zip: "27703",
+        region: "NC",
+        country: "US"
+      )
+    end
+
+    let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: "03") }
+
+    it do
+      is_expected.to eq(
+        [
+          {
+            class: "92.5",
+            dangerousGoods: false,
+            dimensions: {
+              length: 1.87,
+              width: 3.91,
+              height: 5.81,
+              unit: "inches"
+            },
+            nmfc: {
+              prime: "87700",
+              sub: "07"
+            },
+            packagingType: "PKG",
+            pieces: 1,
+            weight: {
+              weight: 10.52,
+              weightUnit: "LBS"
+            }
+          }, {
+            class: "92.5",
+            dangerousGoods: false,
+            dimensions: {
+              length: 1.34,
+              width: 3.29,
+              height: 5.91,
+              unit: "inches"
+            },
+            nmfc: {
+              prime: "87700",
+              sub: "07"
+            },
+            packagingType: "PKG",
+            pieces: 1,
+            weight: {
+              weight: 8.24,
+              weightUnit: "LBS"
+            }
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/generate_location_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_location_hash_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/tforce_freight/generate_location_hash'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateLocationHash do
+  describe ".call" do
+    subject(:call) { described_class.call(location: location) }
+
+    let(:location) do
+      Physical::Location.new(
+        city: "Richmond",
+        zip: "23224",
+        region: "VA",
+        country: "US"
+      )
+    end
+
+    it "has all the right things" do
+      is_expected.to eq(
+        address: {
+          city: "Richmond",
+          stateProvinceCode: "VA",
+          postalCode: "23224",
+          country: "US"
+        }
+      )
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/generate_rates_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_rates_request_hash_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/tforce_freight/generate_rates_request_hash'
+require 'friendly_shipping/services/tforce_freight/rates_options'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateRatesRequestHash do
+  describe ".call" do
+    subject(:call) { described_class.call(shipment: shipment, options: options) }
+
+    let(:shipment) { Physical::Shipment.new(packages: packages, origin: origin, destination: destination) }
+
+    let(:origin) do
+      Physical::Location.new(
+        city: "Richmond",
+        zip: "23224",
+        region: "VA",
+        country: "US"
+      )
+    end
+
+    let(:destination) do
+      Physical::Location.new(
+        city: "Allanton",
+        zip: "63025",
+        region: "MO",
+        country: "US"
+      )
+    end
+
+    let(:packages) { [package_one] }
+
+    let(:package_one) do
+      Physical::Package.new(
+        id: "my_package_1",
+        items: [item_one]
+      )
+    end
+
+    let(:item_one) do
+      Physical::Item.new(
+        id: "item_one",
+        weight: Measured::Weight(500, :lbs),
+        description: "Can of Socks"
+      )
+    end
+
+    let(:options) do
+      FriendlyShipping::Services::TForceFreight::RatesOptions.new(
+        pickup_date: Date.parse("2023-05-18"),
+        billing_address: billing_location,
+        shipping_method: FriendlyShipping::ShippingMethod.new(service_code: "308"),
+        billing: :prepaid,
+        type: :l,
+        density_eligible: true,
+        accessorial_rate: true,
+        time_in_transit: false,
+        quote_number: true,
+        pickup_options: %w[INPU LIFO],
+        delivery_options: %w[INDE LIFD],
+        customer_context: customer_context
+      )
+    end
+
+    let(:customer_context) { "order-12345" }
+
+    let(:billing_location) do
+      Physical::Location.new(
+        city: "Ducktown",
+        zip: "54321",
+        region: "NC",
+        country: "US"
+      )
+    end
+
+    let(:package_options) do
+      [
+        FriendlyShipping::Services::TForceFreight::RatesPackageOptions.new(
+          package_id: package_one.id,
+          item_options: item_one_options
+        )
+      ]
+    end
+
+    let(:item_one_options) do
+      [
+        FriendlyShipping::Services::TForceFreight::RatesItemOptions.new(
+          item_id: "item_one",
+          packaging: commodity_packaging,
+          freight_class: "92.5",
+          nmfc_primary_code: "16030",
+          nmfc_sub_code: "01"
+        )
+      ]
+    end
+
+    let(:commodity_packaging) { :pallet }
+
+    describe "keys" do
+      subject(:keys) { call.keys }
+
+      it do
+        is_expected.to eq(
+          %i[
+            requestOptions
+            shipFrom
+            shipTo
+            payment
+            serviceOptions
+            commodities
+          ]
+        )
+      end
+    end
+
+    describe "requestOptions" do
+      subject(:request_options) { call[:requestOptions] }
+
+      it do
+        is_expected.to eq(
+          serviceCode: "308",
+          pickupDate: "2023-05-18",
+          type: "L",
+          densityEligible: true,
+          gfpOptions: {
+            accessorialRate: true,
+          },
+          timeInTransit: false,
+          quoteNumber: true,
+          customerContext: "order-12345"
+        )
+      end
+    end
+
+    describe "shipFrom" do
+      subject(:ship_from) { call[:shipFrom] }
+
+      it do
+        is_expected.to eq(
+          address: {
+            city: "Richmond",
+            country: "US",
+            postalCode: "23224",
+            stateProvinceCode: "VA"
+          }
+        )
+      end
+    end
+
+    describe "shipTo" do
+      subject(:ship_to) { call[:shipTo] }
+
+      it do
+        is_expected.to eq(
+          address: {
+            city: "Allanton",
+            country: "US",
+            postalCode: "63025",
+            stateProvinceCode: "MO"
+          }
+        )
+      end
+    end
+
+    describe "payment" do
+      subject(:payment) { call[:payment] }
+
+      it do
+        is_expected.to eq(
+          billingCode: "10",
+          payer: {
+            address: {
+              city: "Ducktown",
+              stateProvinceCode: "NC",
+              postalCode: "54321",
+              country: "US"
+            }
+          }
+        )
+      end
+    end
+
+    describe "serviceOptions" do
+      subject(:service_options) { call[:serviceOptions] }
+
+      it do
+        is_expected.to eq(
+          pickup: %w[INPU LIFO],
+          delivery: %w[INDE LIFD]
+        )
+      end
+    end
+
+    describe "commodities" do
+      subject(:commodity) { call[:commodities] }
+
+      before do
+        expect(FriendlyShipping::Services::TForceFreight::GenerateCommodityInformation).
+          to receive(:call).with(shipment: shipment, options: options).and_return("results").once
+      end
+
+      it { is_expected.to eq("results") }
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/parse_rates_response_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/parse_rates_response_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/tforce_freight/parse_rates_response'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::ParseRatesResponse do
+  describe ".call" do
+    subject(:call) { described_class.call(request: nil, response: response) }
+
+    let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "tforce_freight", "rates", "success.json")) }
+    let(:response) { double(body: response_body) }
+
+    it "has the right data" do
+      rates = call.data
+      expect(rates.length).to eq(3)
+      rate = rates.first
+      expect(rate).to be_a(FriendlyShipping::Rate)
+      expect(rate.total_amount).to eq(Money.new(157_356, "USD"))
+      expect(rate.shipping_method.name).to eq("TForce Freight LTL")
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/rates_item_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/rates_item_options_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/tforce_freight/rates_item_options'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::RatesItemOptions do
+  subject(:rates_item_options) do
+    described_class.new(
+      item_id: nil,
+      packaging: :carton,
+      freight_class: "92.5",
+      nmfc_primary_code: "16030",
+      nmfc_sub_code: "01"
+    )
+  end
+
+  it "has the right attributes" do
+    expect(rates_item_options.freight_class).to eq("92.5")
+    expect(rates_item_options.nmfc_primary_code).to eq("16030")
+    expect(rates_item_options.nmfc_sub_code).to eq("01")
+    expect(rates_item_options.packaging_code).to eq("CTN")
+    expect(rates_item_options.packaging_description).to eq("Carton")
+  end
+
+  context "with loose packaging" do
+    subject(:rates_item_options) do
+      described_class.new(
+        item_id: nil,
+        packaging: :loose
+      )
+    end
+
+    it "has the right attributes" do
+      expect(rates_item_options.packaging_code).to eq("LOO")
+      expect(rates_item_options.packaging_description).to eq("Loose")
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/rates_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/rates_options_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/tforce_freight/rates_options'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::RatesOptions do
+  subject(:rates_options) do
+    described_class.new(
+      pickup_date: Date.parse("2023-05-18"),
+      billing_address: billing_location,
+      shipping_method: shipping_method,
+      billing: :prepaid,
+      type: :l,
+      density_eligible: true,
+      accessorial_rate: true,
+      time_in_transit: false,
+      quote_number: true,
+      pickup_options: %w[LIFO],
+      delivery_options: %w[LIFD],
+      customer_context: "order-12345"
+    )
+  end
+
+  let(:billing_location) do
+    Physical::Location.new(
+      city: "Durham",
+      zip: "27703",
+      region: "NC",
+      country: "US"
+    )
+  end
+
+  let(:shipping_method) { FriendlyShipping::ShippingMethod.new }
+
+  it { is_expected.to be_a(FriendlyShipping::ShipmentOptions) }
+
+  [
+    :pickup_date,
+    :billing_address,
+    :billing_code,
+    :shipping_method,
+    :type_code,
+    :density_eligible,
+    :accessorial_rate,
+    :time_in_transit,
+    :quote_number,
+    :pickup_options,
+    :delivery_options,
+    :customer_context,
+    :commodity_information_generator
+  ].each do |option|
+    it { is_expected.to respond_to(option) }
+  end
+
+  it "has the right attributes" do
+    expect(rates_options.pickup_date).to eq(Date.parse("2023-05-18"))
+    expect(rates_options.billing_address).to eq(billing_location)
+    expect(rates_options.billing_code).to eq("10")
+    expect(rates_options.shipping_method).to eq(shipping_method)
+    expect(rates_options.type_code).to eq("L")
+    expect(rates_options.density_eligible).to be(true)
+    expect(rates_options.accessorial_rate).to be(true)
+    expect(rates_options.time_in_transit).to be(false)
+    expect(rates_options.quote_number).to be(true)
+    expect(rates_options.pickup_options).to eq(%w[LIFO])
+    expect(rates_options.delivery_options).to eq(%w[LIFD])
+    expect(rates_options.customer_context).to eq("order-12345")
+    expect(rates_options.commodity_information_generator).
+      to eq(FriendlyShipping::Services::TForceFreight::GenerateCommodityInformation)
+  end
+
+  describe "package options" do
+    subject(:package_options) { rates_options.options_for_package(package) }
+
+    let(:package) { double(package_id: nil) }
+
+    it { is_expected.to be_a(FriendlyShipping::Services::TForceFreight::RatesPackageOptions) }
+  end
+
+  describe "pickup option validation" do
+    subject(:rates_options) do
+      described_class.new(
+        billing_address: billing_location,
+        shipping_method: shipping_method,
+        pickup_options: %w[bogus invalid]
+      )
+    end
+
+    it do
+      expect { rates_options }.to raise_error(ArgumentError, "Invalid pickup option(s): bogus, invalid")
+    end
+  end
+
+  describe "delivery option validation" do
+    subject(:rates_options) do
+      described_class.new(
+        billing_address: billing_location,
+        shipping_method: shipping_method,
+        delivery_options: %w[bogus invalid]
+      )
+    end
+
+    it do
+      expect { rates_options }.to raise_error(ArgumentError, "Invalid delivery option(s): bogus, invalid")
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/rates_package_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/rates_package_options_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/tforce_freight/rates_package_options'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::RatesPackageOptions do
+  subject(:rates_package_options) { described_class.new(package_id: nil) }
+
+  describe 'item options' do
+    subject(:item_options) { rates_package_options.options_for_item(item) }
+
+    let(:item) { double(item_id: nil) }
+
+    it { is_expected.to be_a(FriendlyShipping::Services::TForceFreight::RatesItemOptions) }
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/shipping_methods_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/shipping_methods_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::SHIPPING_METHODS do
+  subject(:shipping_methods) { described_class }
+
+  it { expect(shipping_methods.size).to eq(4) }
+  it { expect(shipping_methods).to all(be_a(FriendlyShipping::ShippingMethod)) }
+end

--- a/spec/friendly_shipping/services/tforce_freight_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/tforce_freight'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight do
+  let(:service) { described_class.new(access_token: "secret-token") }
+
+  describe "carriers" do
+    subject { service.carriers.value! }
+
+    it "has only one carrier with four shipping methods" do
+      expect(subject.length).to eq(1)
+      expect(subject.first.shipping_methods.map(&:service_code)).to contain_exactly(
+        "308", "309", "334", "349"
+      )
+      expect(subject.first.shipping_methods.map(&:name)).to contain_exactly(
+        "TForce Freight LTL",
+        "TForce Freight LTL - Guaranteed",
+        "TForce Freight LTL - Guaranteed A.M.",
+        "TForce Standard LTL",
+      )
+    end
+  end
+
+  describe "#rates" do
+    let(:shipment) { Physical::Shipment.new(packages: packages, origin: origin, destination: destination) }
+
+    let(:origin) do
+      Physical::Location.new(
+        city: "Richmond",
+        zip: "23224",
+        region: "VA",
+        country: "US"
+      )
+    end
+
+    let(:destination) do
+      Physical::Location.new(
+        city: "Eureka",
+        zip: "63025",
+        region: "MO",
+        country: "US"
+      )
+    end
+
+    let(:packages) { [package_one, package_two] }
+
+    let(:package_one) do
+      Physical::Package.new(
+        id: "my_package_1",
+        items: [item_one]
+      )
+    end
+
+    let(:package_two) do
+      Physical::Package.new(
+        id: "my_package_2",
+        items: [item_two]
+      )
+    end
+
+    let(:item_one) do
+      Physical::Item.new(
+        id: "item_one",
+        weight: Measured::Weight(500, :lbs)
+      )
+    end
+
+    let(:item_two) do
+      Physical::Item.new(
+        id: "item_two",
+        weight: Measured::Weight(500, :lbs)
+      )
+    end
+
+    let(:options) do
+      FriendlyShipping::Services::TForceFreight::RatesOptions.new(
+        pickup_date: Date.today,
+        shipping_method: FriendlyShipping::ShippingMethod.new(service_code: "308"),
+        billing_address: billing_location,
+        customer_context: customer_context,
+        package_options: package_options
+      )
+    end
+
+    let(:customer_context) { "order-12345" }
+
+    let(:billing_location) do
+      Physical::Location.new(
+        city: "Durham",
+        zip: "27703",
+        region: "NC",
+        country: "US"
+      )
+    end
+
+    let(:package_options) do
+      [
+        FriendlyShipping::Services::TForceFreight::RatesPackageOptions.new(
+          package_id: package_one.id,
+          item_options: item_one_options
+        ),
+        FriendlyShipping::Services::TForceFreight::RatesPackageOptions.new(
+          package_id: package_two.id,
+          item_options: item_two_options
+        )
+      ]
+    end
+
+    let(:item_one_options) do
+      [
+        FriendlyShipping::Services::TForceFreight::RatesItemOptions.new(
+          item_id: "item_one",
+          packaging: :carton,
+          freight_class: "92.5",
+          nmfc_primary_code: "16030",
+          nmfc_sub_code: "1"
+        )
+      ]
+    end
+
+    let(:item_two_options) do
+      [
+        FriendlyShipping::Services::TForceFreight::RatesItemOptions.new(
+          item_id: "item_two",
+          packaging: :pallet,
+          freight_class: "92.5",
+          nmfc_primary_code: "16030",
+          nmfc_sub_code: "1"
+        )
+      ]
+    end
+
+    subject { service.rates(shipment, options: options) }
+
+    context "with a valid request", vcr: { cassette_name: "tforce_freight/rates/success", match_requests_on: [:method, :uri, :content_type] } do
+      it { is_expected.to be_success }
+
+      it "has all the right data" do
+        rates = subject.value!.data
+        expect(rates.length).to eq(3)
+        rate = rates.first
+        expect(rate).to be_a(FriendlyShipping::Rate)
+        expect(rate.total_amount).to eq(Money.new(157_356, "USD"))
+        expect(rate.shipping_method.name).to eq("TForce Freight LTL")
+        expect(rate.data[:days_in_transit]).to eq(3)
+      end
+    end
+
+    context "with a missing destination postal code", vcr: { cassette_name: "tforce_freight/rates/failure", match_requests_on: [:method, :uri, :content_type] } do
+      let(:destination) do
+        Physical::Location.new(
+          company_name: "Consignee Test 1",
+          city: "Allanton",
+          region: "MO",
+          country: "US"
+        )
+      end
+
+      it { is_expected.to be_failure }
+
+      it "has the correct error message" do
+        expect(subject.failure.to_s).to include("Invalid type. Expected String but got Null.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
TForce (formerly UPS Freight) is building [a new API](https://developer.tforcefreight.com/) distinct from UPS. This commit introduces a new service class for this API and implements the [Get Rate](https://developer.tforcefreight.com/api-details#api=rating&operation=get-rate) call.