### PR TITLE
Add declaration statement to UPS intl labels

### DIFF
--- a/lib/friendly_shipping/services/ups/label_options.rb
+++ b/lib/friendly_shipping/services/ups/label_options.rb
@@ -41,6 +41,7 @@ module FriendlyShipping
     # @option reason_for_export [String] A reason to export the current shipment. Possible values: 'SALE', 'GIFT', 'SAMPLE',
     #   'RETURN', 'REPAIR', 'INTERCOMPANYDATA', Any other reason. Default: 'SALE'.
     # @option invoice_date [Date] The invoice date for the shipment
+    # @param declaration_statement [String ] Optional element to add customs declaration text
     #
     class Ups
       class LabelOptions < FriendlyShipping::ShipmentOptions
@@ -101,7 +102,8 @@ module FriendlyShipping
                     :carbon_neutral,
                     :paperless_invoice,
                     :reason_for_export,
-                    :invoice_date
+                    :invoice_date,
+                    :declaration_statement
 
         def initialize(
           shipping_method:,
@@ -124,6 +126,7 @@ module FriendlyShipping
           reason_for_export: 'SALE',
           invoice_date: nil,
           package_options_class: LabelPackageOptions,
+          declaration_statement: nil,
           **kwargs
         )
           raise ArgumentError, "Invalid sub-version: #{sub_version}" unless sub_version.in?(SUB_VERSIONS)
@@ -147,6 +150,7 @@ module FriendlyShipping
           @terms_of_shipment = terms_of_shipment
           @reason_for_export = reason_for_export
           @invoice_date = invoice_date
+          @declaration_statement = declaration_statement
           super(**kwargs.merge(package_options_class: package_options_class))
         end
 

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -242,6 +242,7 @@ module FriendlyShipping
               xml.InvoiceDate(invoice_date.strftime('%Y%m%d'))
               xml.ReasonForExport(reason_for_export)
               xml.CurrencyCode(options.billing_options.currency || 'USD')
+              xml.DeclarationStatement(options.declaration_statement) if options.declaration_statement
 
               if options.terms_of_shipment_code
                 xml.TermsOfShipment(options.terms_of_shipment_code)

--- a/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
@@ -362,7 +362,8 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
         shipper_number: '12345',
         paperless_invoice: true,
         terms_of_shipment: :cost_and_freight,
-        package_options: package_options
+        package_options: package_options,
+        declaration_statement: 'I hereby certify...'
       )
     end
 
@@ -391,6 +392,7 @@ RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest 
       expect(subject.at('ShipmentServiceOptions/InternationalForms/ReasonForExport').text).to eq('SALE')
       expect(subject.at('ShipmentServiceOptions/InternationalForms/CurrencyCode').text).to eq('USD')
       expect(subject.at('ShipmentServiceOptions/InternationalForms/TermsOfShipment').text).to eq('CFR')
+      expect(subject.at('ShipmentServiceOptions/InternationalForms/DeclarationStatement').text).to eq('I hereby certify...')
       expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/Description').text).to eq('Wooden block')
       expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/CommodityCode').text).to eq('6116.10.0000')
       expect(subject.at('ShipmentServiceOptions/InternationalForms/Product/OriginCountryCode').text).to eq('CA')


### PR DESCRIPTION
UPS may decide to hold a shipment for processing through customs for various reasons. Adding this statement will (hopefully) allow the shipment to go through without requiring a phone call or email.