### PR TITLE
Rename `ShipmentInformation#number` attribute

### DIFF
--- a/lib/friendly_shipping/services/ups_freight/parse_freight_label_response.rb
+++ b/lib/friendly_shipping/services/ups_freight/parse_freight_label_response.rb
@@ -33,7 +33,7 @@ module FriendlyShipping
             images_data = Array.wrap(shipment_results.dig("Documents", "Image"))
 
             bol_id = shipment_results["BOLID"]
-            shipment_number = shipment_results["ShipmentNumber"]
+            pro_number = shipment_results["ShipmentNumber"]
             pickup_request_number = shipment_results["PickupRequestConfirmationNumber"]
 
             documents = images_data.map { |image_data| ParseShipmentDocument.call(image_data: image_data) }
@@ -44,7 +44,7 @@ module FriendlyShipping
               ShipmentInformation.new(
                 total: total_money,
                 bol_id: bol_id,
-                number: shipment_number,
+                pro_number: pro_number,
                 pickup_request_number: pickup_request_number,
                 shipping_method: shipping_method,
                 warnings: warnings,

--- a/lib/friendly_shipping/services/ups_freight/shipment_information.rb
+++ b/lib/friendly_shipping/services/ups_freight/shipment_information.rb
@@ -5,7 +5,7 @@ module FriendlyShipping
     class UpsFreight
       class ShipmentInformation
         attr_reader :documents,
-                    :number,
+                    :pro_number,
                     :pickup_request_number,
                     :total,
                     :bol_id,
@@ -13,10 +13,13 @@ module FriendlyShipping
                     :warnings,
                     :data
 
+        # Backwards compatibility after renaming this attribute
+        alias_method :number, :pro_number
+
         def initialize(
           total:,
           bol_id:,
-          number:,
+          pro_number:,
           pickup_request_number: nil,
           documents: [],
           shipping_method: nil,
@@ -25,7 +28,7 @@ module FriendlyShipping
         )
           @total = total
           @bol_id = bol_id
-          @number = number
+          @pro_number = pro_number
           @pickup_request_number = pickup_request_number
           @documents = documents
           @shipping_method = shipping_method

--- a/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ParseFreightLabelResponse
     expect(shipment_information.documents.last.document_type).to eq(:ups_bol)
     expect(shipment_information.documents.last.binary).to be_present
 
-    expect(shipment_information.number).to eq("022438065")
+    expect(shipment_information.pro_number).to eq("022438065")
     expect(shipment_information.pickup_request_number).to eq("348742132")
     expect(shipment_information.total).to eq(Money.new(17_989, "USD"))
     expect(shipment_information.bol_id).to eq("45760188")
@@ -70,7 +70,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ParseFreightLabelResponse
       expect(shipment_information.documents.last.document_type).to eq(:ups_bol)
       expect(shipment_information.documents.last.binary).to be_present
 
-      expect(shipment_information.number).to eq("022438065")
+      expect(shipment_information.pro_number).to eq("022438065")
       expect(shipment_information.pickup_request_number).to eq("348742132")
       expect(shipment_information.total).to be_nil
       expect(shipment_information.bol_id).to eq("45760188")

--- a/spec/friendly_shipping/services/ups_freight/shipment_information_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/shipment_information_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ShipmentInformation do
   subject do
     described_class.new(
       total: Money.new(1, "USD"),
-      number: '1234',
+      pro_number: '1234',
       bol_id: '2345',
       pickup_request_number: '4321',
       documents: docs,
@@ -20,11 +20,13 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ShipmentInformation do
     )
   end
 
+  it { is_expected.to respond_to(:number) }
+
   it 'stores passed information' do
     expect(subject.total).to eq(Money.new(1, "USD"))
     expect(subject.documents).to eq(docs)
     expect(subject.bol_id).to eq('2345')
-    expect(subject.number).to eq('1234')
+    expect(subject.pro_number).to eq('1234')
     expect(subject.pickup_request_number).to eq('4321')
     expect(subject.documents).to eq(docs)
     expect(subject.data).to eq({ cost_breakdown: { "Rate" => "520.75" } })


### PR DESCRIPTION
This renames the TForce (UPS Freight) attr from `number` to `pro_number` to better represent what it actually is.

An alias is added to ensure backwards compatibility.