### PR TITLE
Allow setting `ShipmentInformation#number` value

### DIFF
--- a/lib/friendly_shipping/services/ups_freight/shipment_information.rb
+++ b/lib/friendly_shipping/services/ups_freight/shipment_information.rb
@@ -19,7 +19,8 @@ module FriendlyShipping
         def initialize(
           total:,
           bol_id:,
-          pro_number:,
+          number: nil,
+          pro_number: nil,
           pickup_request_number: nil,
           documents: [],
           shipping_method: nil,
@@ -28,7 +29,7 @@ module FriendlyShipping
         )
           @total = total
           @bol_id = bol_id
-          @pro_number = pro_number
+          @pro_number = pro_number || number
           @pickup_request_number = pickup_request_number
           @documents = documents
           @shipping_method = shipping_method

--- a/spec/friendly_shipping/services/ups_freight/shipment_information_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/shipment_information_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ShipmentInformation do
     )
   end
 
-  it { is_expected.to respond_to(:number) }
-
   it 'stores passed information' do
     expect(subject.total).to eq(Money.new(1, "USD"))
     expect(subject.documents).to eq(docs)
@@ -30,5 +28,17 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::ShipmentInformation do
     expect(subject.pickup_request_number).to eq('4321')
     expect(subject.documents).to eq(docs)
     expect(subject.data).to eq({ cost_breakdown: { "Rate" => "520.75" } })
+  end
+
+  describe "backwards compatibility for #number" do
+    subject do
+      described_class.new(
+        number: "1234",
+        total: nil,
+        bol_id: nil
+      ).number
+    end
+
+    it { is_expected.to eq("1234") }
   end
 end


### PR DESCRIPTION
This makes _setting_ the `number` attribute backwards compatible after the attribute was renamed to `pro_number` in [this PR](https://github.com/friendlycart/friendly_shipping/pull/196).