### PR TITLE
Fix options to allow option class args to actually override the default

### DIFF
--- a/lib/friendly_shipping/services/rl/bol_options.rb
+++ b/lib/friendly_shipping/services/rl/bol_options.rb
@@ -46,7 +46,7 @@ module FriendlyShipping
           @packages_serializer = packages_serializer
           @generate_universal_pro = generate_universal_pro
           validate_additional_service_codes!
-          super(**kwargs.merge(package_options_class: PackageOptions))
+          super(**kwargs.reverse_merge(package_options_class: PackageOptions))
         end
 
         ADDITIONAL_SERVICE_CODES = %w[

--- a/lib/friendly_shipping/services/rl/item_options.rb
+++ b/lib/friendly_shipping/services/rl/item_options.rb
@@ -15,7 +15,7 @@ module FriendlyShipping
         # @param [String] nmfc_sub_code
         # @param [Array<Object>] **kwargs
         def initialize(
-          freight_class:,
+          freight_class: nil,
           nmfc_primary_code: nil,
           nmfc_sub_code: nil,
           **kwargs

--- a/lib/friendly_shipping/services/rl/package_options.rb
+++ b/lib/friendly_shipping/services/rl/package_options.rb
@@ -8,7 +8,7 @@ module FriendlyShipping
       class PackageOptions < FriendlyShipping::PackageOptions
         # @param [Array<Object>] **kwargs
         def initialize(**kwargs)
-          super(**kwargs.merge(item_options_class: ItemOptions))
+          super(**kwargs.reverse_merge(item_options_class: ItemOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/rl/rate_quote_options.rb
+++ b/lib/friendly_shipping/services/rl/rate_quote_options.rb
@@ -30,7 +30,7 @@ module FriendlyShipping
           @additional_service_codes = additional_service_codes
           @packages_serializer = packages_serializer
           validate_additional_service_codes!
-          super(**kwargs.merge(package_options_class: PackageOptions))
+          super(**kwargs.reverse_merge(package_options_class: PackageOptions))
         end
 
         ADDITIONAL_SERVICE_CODES = %w[

--- a/lib/friendly_shipping/services/ship_engine/label_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_options.rb
@@ -34,7 +34,7 @@ module FriendlyShipping
           @label_format = label_format
           @label_image_id = label_image_id
           @customs_options = customs_options
-          super(**kwargs.merge(package_options_class: LabelPackageOptions))
+          super(**kwargs.reverse_merge(package_options_class: LabelPackageOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/ship_engine/label_package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_package_options.rb
@@ -21,7 +21,7 @@ module FriendlyShipping
         def initialize(package_code: nil, messages: [], **kwargs)
           @package_code = package_code
           @messages = messages
-          super(**kwargs.merge(item_options_class: LabelItemOptions))
+          super(**kwargs.reverse_merge(item_options_class: LabelItemOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/ship_engine/rates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_options.rb
@@ -15,7 +15,7 @@ module FriendlyShipping
         def initialize(carriers:, service_code:, **kwargs)
           @carriers = carriers
           @service_code = service_code
-          super(**kwargs.merge(package_options_class: RatesPackageOptions))
+          super(**kwargs.reverse_merge(package_options_class: RatesPackageOptions))
         end
 
         def carrier_ids

--- a/lib/friendly_shipping/services/ship_engine/rates_package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_package_options.rb
@@ -10,7 +10,7 @@ module FriendlyShipping
       # @attribute [RatesItemOptions] item_options Options for each of the items in the package
       class RatesPackageOptions < FriendlyShipping::PackageOptions
         def initialize(**kwargs)
-          super(**kwargs.merge(item_options_class: RatesItemOptions))
+          super(**kwargs.reverse_merge(item_options_class: RatesItemOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/ship_engine_ltl/package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/package_options.rb
@@ -7,7 +7,7 @@ module FriendlyShipping
     class ShipEngineLTL
       class PackageOptions < FriendlyShipping::PackageOptions
         def initialize(**kwargs)
-          super(**kwargs.merge(item_options_class: ItemOptions))
+          super(**kwargs.reverse_merge(item_options_class: ItemOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/ship_engine_ltl/quote_options.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/quote_options.rb
@@ -26,7 +26,7 @@ module FriendlyShipping
           @pickup_date = pickup_date
           @accessorial_service_codes = accessorial_service_codes
           @packages_serializer_class = packages_serializer_class
-          super(**kwargs.merge(package_options_class: PackageOptions))
+          super(**kwargs.reverse_merge(package_options_class: PackageOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/tforce_freight/rates_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_options.rb
@@ -99,7 +99,7 @@ module FriendlyShipping
           validate_pickup_options!
           validate_delivery_options!
 
-          super(**kwargs.merge(package_options_class: RatesPackageOptions))
+          super(**kwargs.reverse_merge(package_options_class: RatesPackageOptions))
         end
 
         private

--- a/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
@@ -8,7 +8,7 @@ module FriendlyShipping
       # Options for packages/pallets within a TForce Freight shipment
       class RatesPackageOptions < FriendlyShipping::PackageOptions
         def initialize(**kwargs)
-          super(**kwargs.merge(item_options_class: RatesItemOptions))
+          super(**kwargs.reverse_merge(item_options_class: RatesItemOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/ups/label_options.rb
+++ b/lib/friendly_shipping/services/ups/label_options.rb
@@ -151,7 +151,7 @@ module FriendlyShipping
           @reason_for_export = reason_for_export
           @invoice_date = invoice_date
           @declaration_statement = declaration_statement
-          super(**kwargs.merge(package_options_class: package_options_class))
+          super(**kwargs.reverse_merge(package_options_class: package_options_class))
         end
 
         def delivery_confirmation_code

--- a/lib/friendly_shipping/services/ups/label_package_options.rb
+++ b/lib/friendly_shipping/services/ups/label_package_options.rb
@@ -35,7 +35,7 @@ module FriendlyShipping
           @delivery_confirmation = delivery_confirmation
           @shipper_release = shipper_release
           @declared_value = declared_value
-          super(**kwargs.merge(item_options_class: LabelItemOptions))
+          super(**kwargs.reverse_merge(item_options_class: LabelItemOptions))
         end
 
         def delivery_confirmation_code

--- a/lib/friendly_shipping/services/ups/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/ups/rate_estimate_options.rb
@@ -97,7 +97,7 @@ module FriendlyShipping
           @shipping_method = shipping_method
           @sub_version = sub_version
           @with_time_in_transit = with_time_in_transit
-          super(**kwargs.merge(package_options_class: package_options_class))
+          super(**kwargs.reverse_merge(package_options_class: package_options_class))
         end
 
         def pickup_type_code

--- a/lib/friendly_shipping/services/ups_freight/rates_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_options.rb
@@ -51,7 +51,7 @@ module FriendlyShipping
           @customer_context = customer_context
           @pickup_request_options = pickup_request_options
           @commodity_information_generator = commodity_information_generator
-          super(**kwargs.merge(package_options_class: RatesPackageOptions))
+          super(**kwargs.reverse_merge(package_options_class: RatesPackageOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/ups_freight/rates_package_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_package_options.rb
@@ -30,7 +30,7 @@ module FriendlyShipping
           @handling_unit_code = HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:code)
           @handling_unit_description = HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:description)
           @handling_unit_tag = "HandlingUnit#{HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:handling_unit_tag)}"
-          super(**kwargs.merge(item_options_class: RatesItemOptions))
+          super(**kwargs.reverse_merge(item_options_class: RatesItemOptions))
         end
       end
     end

--- a/lib/friendly_shipping/services/usps/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_options.rb
@@ -20,7 +20,7 @@ module FriendlyShipping
           package_options_class: FriendlyShipping::Services::Usps::RateEstimatePackageOptions,
           **kwargs
         )
-          super(**kwargs.merge(package_options_class: package_options_class))
+          super(**kwargs.reverse_merge(package_options_class: package_options_class))
         end
       end
     end

--- a/lib/friendly_shipping/services/usps_international/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/usps_international/rate_estimate_options.rb
@@ -20,7 +20,7 @@ module FriendlyShipping
           package_options_class: FriendlyShipping::Services::UspsInternational::RateEstimatePackageOptions,
           **kwargs
         )
-          super(**kwargs.merge(package_options_class: package_options_class))
+          super(**kwargs.reverse_merge(package_options_class: package_options_class))
         end
       end
     end

--- a/spec/friendly_shipping/services/rl/bol_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/bol_options_spec.rb
@@ -12,14 +12,40 @@ RSpec.describe FriendlyShipping::Services::RL::BOLOptions do
 
   let(:additional_service_codes) { %w[OriginLiftgate] }
 
-  it { is_expected.to respond_to(:pickup_time_window) }
-  it { is_expected.to respond_to(:pickup_instructions) }
-  it { is_expected.to respond_to(:declared_value) }
-  it { is_expected.to respond_to(:special_instructions) }
-  it { is_expected.to respond_to(:reference_numbers) }
-  it { is_expected.to respond_to(:additional_service_codes) }
-  it { is_expected.to respond_to(:generate_universal_pro) }
-  it { is_expected.to respond_to(:packages_serializer) }
+  [
+    :pickup_time_window,
+    :pickup_instructions,
+    :declared_value,
+    :special_instructions,
+    :reference_numbers,
+    :additional_service_codes,
+    :generate_universal_pro,
+    :packages_serializer
+  ].each do |attr|
+    it { is_expected.to respond_to(attr) }
+  end
+
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::RL::PackageOptions }
+    let(:required_attrs) { { pickup_time_window: 1.hour.ago..1.hour.from_now } }
+  end
+
+  describe "package options class" do
+    subject { options.send :package_options_class }
+
+    it { is_expected.to eq(FriendlyShipping::Services::RL::PackageOptions) }
+
+    context "when a custom class is passed" do
+      let(:options) do
+        described_class.new(
+          pickup_time_window: 1.hour.ago..1.hour.from_now,
+          package_options_class: Object
+        )
+      end
+
+      it { is_expected.to eq(Object) }
+    end
+  end
 
   describe "#packages_serializer" do
     subject { options.packages_serializer }

--- a/spec/friendly_shipping/services/rl/item_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/item_options_spec.rb
@@ -3,12 +3,13 @@
 require 'spec_helper'
 
 RSpec.describe FriendlyShipping::Services::RL::ItemOptions do
-  subject(:options) do
-    described_class.new(
-      item_id: "123",
-      freight_class: "92.5"
-    )
-  end
+  subject(:options) { described_class.new(item_id: "123") }
 
-  it { is_expected.to respond_to(:freight_class) }
+  [
+    :freight_class,
+    :nmfc_primary_code,
+    :nmfc_sub_code
+  ].each do |attr|
+    it { is_expected.to respond_to(attr) }
+  end
 end

--- a/spec/friendly_shipping/services/rl/package_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/package_options_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/rl/package_options'
+
+RSpec.describe FriendlyShipping::Services::RL::PackageOptions do
+  subject(:options) { described_class.new(package_id: "package") }
+
+  it_behaves_like "overrideable item options class" do
+    let(:default_class) { FriendlyShipping::Services::RL::ItemOptions }
+  end
+end

--- a/spec/friendly_shipping/services/rl/rate_quote_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/rate_quote_options_spec.rb
@@ -12,10 +12,19 @@ RSpec.describe FriendlyShipping::Services::RL::RateQuoteOptions do
 
   let(:additional_service_codes) { %w[Hazmat] }
 
-  it { is_expected.to respond_to(:pickup_date) }
-  it { is_expected.to respond_to(:declared_value) }
-  it { is_expected.to respond_to(:additional_service_codes) }
-  it { is_expected.to respond_to(:packages_serializer) }
+  [
+    :pickup_date,
+    :declared_value,
+    :additional_service_codes,
+    :packages_serializer
+  ].each do |attr|
+    it { is_expected.to respond_to(attr) }
+  end
+
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::RL::PackageOptions }
+    let(:required_attrs) { { pickup_date: Time.now } }
+  end
 
   describe "#packages_serializer" do
     subject { options.packages_serializer }

--- a/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::LabelOptions do
     it { is_expected.to respond_to(message) }
   end
 
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::ShipEngine::LabelPackageOptions }
+    let(:required_attrs) { { shipping_method: double } }
+  end
+
   context "customs_options" do
     subject(:customs_options) { options.customs_options }
     it { is_expected.to be_a(FriendlyShipping::Services::ShipEngine::LabelCustomsOptions) }

--- a/spec/friendly_shipping/services/ship_engine/label_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_package_options_spec.rb
@@ -4,12 +4,16 @@ require 'spec_helper'
 require 'friendly_shipping/services/ship_engine/label_package_options'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::LabelPackageOptions do
-  subject(:options) { described_class.new(package_id: "123") }
+  subject(:options) { described_class.new(package_id: "package") }
 
   [
     :package_code,
     :messages
   ].each do |message|
     it { is_expected.to respond_to(message) }
+  end
+
+  it_behaves_like "overrideable item options class" do
+    let(:default_class) { FriendlyShipping::Services::ShipEngine::LabelItemOptions }
   end
 end

--- a/spec/friendly_shipping/services/ship_engine/rate_estimates_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/rate_estimates_options_spec.rb
@@ -3,8 +3,13 @@
 require 'spec_helper'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::RateEstimatesOptions do
-  subject { described_class.new(carriers: [double(id: 'se-12345')]) }
+  subject(:options) { described_class.new(carriers: [double(id: 'se-12345')]) }
 
   it { is_expected.to respond_to(:carriers) }
   it { is_expected.to be_a(FriendlyShipping::ShipmentOptions) }
+
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::PackageOptions }
+    let(:required_attrs) { { carriers: [] } }
+  end
 end

--- a/spec/friendly_shipping/services/ship_engine/rates_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/rates_package_options_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'friendly_shipping/services/ship_engine/label_package_options'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::RatesPackageOptions do
+  subject(:options) { described_class.new(package_id: "package") }
+
+  it_behaves_like "overrideable item options class" do
+    let(:default_class) { FriendlyShipping::Services::ShipEngine::RatesItemOptions }
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine_ltl/quote_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine_ltl/quote_options_spec.rb
@@ -14,4 +14,9 @@ RSpec.describe FriendlyShipping::Services::ShipEngineLTL::QuoteOptions do
   ].each do |message|
     it { is_expected.to respond_to(message) }
   end
+
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::ShipEngineLTL::PackageOptions }
+    let(:required_attrs) { {} }
+  end
 end

--- a/spec/friendly_shipping/services/ship_engine_ltl/rates_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine_ltl/rates_package_options_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-RSpec.describe FriendlyShipping::Services::TForceFreight::RatesPackageOptions do
+RSpec.describe FriendlyShipping::Services::ShipEngineLTL::PackageOptions do
   subject(:options) { described_class.new(package_id: "package") }
 
   it_behaves_like "overrideable item options class" do
-    let(:default_class) { FriendlyShipping::Services::TForceFreight::RatesItemOptions }
+    let(:default_class) { FriendlyShipping::Services::ShipEngineLTL::ItemOptions }
   end
 end

--- a/spec/friendly_shipping/services/tforce_freight/rates_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/rates_options_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'friendly_shipping/services/tforce_freight/rates_options'
 
 RSpec.describe FriendlyShipping::Services::TForceFreight::RatesOptions do
-  subject(:rates_options) do
+  subject(:options) do
     described_class.new(
       pickup_date: Date.parse("2023-05-18"),
       billing_address: billing_location,
@@ -52,25 +52,30 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::RatesOptions do
     it { is_expected.to respond_to(option) }
   end
 
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::TForceFreight::RatesPackageOptions }
+    let(:required_attrs) { { billing_address: billing_location, shipping_method: shipping_method } }
+  end
+
   it "has the right attributes" do
-    expect(rates_options.pickup_date).to eq(Date.parse("2023-05-18"))
-    expect(rates_options.billing_address).to eq(billing_location)
-    expect(rates_options.billing_code).to eq("10")
-    expect(rates_options.shipping_method).to eq(shipping_method)
-    expect(rates_options.type_code).to eq("L")
-    expect(rates_options.density_eligible).to be(true)
-    expect(rates_options.accessorial_rate).to be(true)
-    expect(rates_options.time_in_transit).to be(false)
-    expect(rates_options.quote_number).to be(true)
-    expect(rates_options.pickup_options).to eq(%w[LIFO])
-    expect(rates_options.delivery_options).to eq(%w[LIFD])
-    expect(rates_options.customer_context).to eq("order-12345")
-    expect(rates_options.commodity_information_generator).
+    expect(options.pickup_date).to eq(Date.parse("2023-05-18"))
+    expect(options.billing_address).to eq(billing_location)
+    expect(options.billing_code).to eq("10")
+    expect(options.shipping_method).to eq(shipping_method)
+    expect(options.type_code).to eq("L")
+    expect(options.density_eligible).to be(true)
+    expect(options.accessorial_rate).to be(true)
+    expect(options.time_in_transit).to be(false)
+    expect(options.quote_number).to be(true)
+    expect(options.pickup_options).to eq(%w[LIFO])
+    expect(options.delivery_options).to eq(%w[LIFD])
+    expect(options.customer_context).to eq("order-12345")
+    expect(options.commodity_information_generator).
       to eq(FriendlyShipping::Services::TForceFreight::GenerateCommodityInformation)
   end
 
   describe "package options" do
-    subject(:package_options) { rates_options.options_for_package(package) }
+    subject(:package_options) { options.options_for_package(package) }
 
     let(:package) { double(package_id: nil) }
 
@@ -78,7 +83,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::RatesOptions do
   end
 
   describe "pickup option validation" do
-    subject(:rates_options) do
+    subject(:options) do
       described_class.new(
         billing_address: billing_location,
         shipping_method: shipping_method,
@@ -87,12 +92,12 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::RatesOptions do
     end
 
     it do
-      expect { rates_options }.to raise_error(ArgumentError, "Invalid pickup option(s): bogus, invalid")
+      expect { options }.to raise_error(ArgumentError, "Invalid pickup option(s): bogus, invalid")
     end
   end
 
   describe "delivery option validation" do
-    subject(:rates_options) do
+    subject(:options) do
       described_class.new(
         billing_address: billing_location,
         shipping_method: shipping_method,
@@ -101,7 +106,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::RatesOptions do
     end
 
     it do
-      expect { rates_options }.to raise_error(ArgumentError, "Invalid delivery option(s): bogus, invalid")
+      expect { options }.to raise_error(ArgumentError, "Invalid delivery option(s): bogus, invalid")
     end
   end
 end

--- a/spec/friendly_shipping/services/ups/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_options_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe FriendlyShipping::Services::Ups::LabelOptions do
     it { is_expected.to respond_to(message) }
   end
 
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::Ups::LabelPackageOptions }
+    let(:required_attrs) { { shipping_method: double, shipper_number: double } }
+  end
+
   describe 'sub-version validation' do
     subject(:options) { described_class.new(sub_version: 'bogus', shipping_method: double, shipper_number: double) }
 

--- a/spec/friendly_shipping/services/ups/label_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_package_options_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'friendly_shipping/services/ups/label_package_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::LabelPackageOptions do
-  subject(:options) { described_class.new(package_id: 'my_package_id') }
+  subject(:options) { described_class.new(package_id: 'package') }
 
   [
     :delivery_confirmation_code,
@@ -13,6 +13,10 @@ RSpec.describe FriendlyShipping::Services::Ups::LabelPackageOptions do
     :declared_value
   ].each do |message|
     it { is_expected.to respond_to(message) }
+  end
+
+  it_behaves_like "overrideable item options class" do
+    let(:default_class) { FriendlyShipping::Services::Ups::LabelItemOptions }
   end
 
   describe 'delivery_confirmation_code' do

--- a/spec/friendly_shipping/services/ups/rate_estimate_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/rate_estimate_options_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe FriendlyShipping::Services::Ups::RateEstimateOptions do
     it { is_expected.to respond_to(message) }
   end
 
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::Ups::RateEstimatePackageOptions }
+    let(:required_attrs) { { shipper_number: 'SECRET' } }
+  end
+
   describe 'sub-version validation' do
     subject(:options) { described_class.new(sub_version: 'bogus', shipper_number: 'SECRET') }
 

--- a/spec/friendly_shipping/services/ups_freight/rates_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/rates_options_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'friendly_shipping/services/ups_freight/rates_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::RatesOptions do
-  subject(:rates_options) do
+  subject(:options) do
     described_class.new(
       shipper_number: 'my_shipper_number',
       billing_address: double,
@@ -25,10 +25,21 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::RatesOptions do
     it { is_expected.to respond_to(option) }
   end
 
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::UpsFreight::RatesPackageOptions }
+    let(:required_attrs) do
+      {
+        shipper_number: 'my_shipper_number',
+        billing_address: double,
+        shipping_method: double
+      }
+    end
+  end
+
   describe 'package options' do
     let(:package) { double(package_id: nil) }
 
-    subject { rates_options.options_for_package(package) }
+    subject { options.options_for_package(package) }
 
     it { is_expected.to be_a(FriendlyShipping::Services::UpsFreight::RatesPackageOptions) }
   end

--- a/spec/friendly_shipping/services/ups_freight/rates_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/rates_package_options_spec.rb
@@ -4,12 +4,16 @@ require 'spec_helper'
 require 'friendly_shipping/services/ups_freight/rates_package_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::RatesPackageOptions do
-  subject(:rates_package_options) { described_class.new(package_id: nil) }
+  subject(:options) { described_class.new(package_id: "package") }
 
   it 'has the right attributes' do
     expect(subject.handling_unit_code).to eq('PLT')
     expect(subject.handling_unit_description).to eq('Pallet')
     expect(subject.handling_unit_tag).to eq('HandlingUnitOne')
+  end
+
+  it_behaves_like "overrideable item options class" do
+    let(:default_class) { FriendlyShipping::Services::UpsFreight::RatesItemOptions }
   end
 
   context 'with loose packaging' do
@@ -20,13 +24,5 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::RatesPackageOptions do
       expect(subject.handling_unit_description).to eq('Loose')
       expect(subject.handling_unit_tag).to eq('HandlingUnitTwo')
     end
-  end
-
-  describe 'item options' do
-    let(:item) { double(item_id: nil) }
-
-    subject { rates_package_options.options_for_item(item) }
-
-    it { is_expected.to be_a(FriendlyShipping::Services::UpsFreight::RatesItemOptions) }
   end
 end

--- a/spec/friendly_shipping/services/usps/rate_estimates_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimates_options_spec.rb
@@ -5,9 +5,9 @@ require 'friendly_shipping/services/usps/rate_estimate_options'
 
 RSpec.describe FriendlyShipping::Services::Usps::RateEstimateOptions do
   let(:options) { described_class.new }
-  describe '#options_for_package' do
-    subject { options.options_for_package(double(package_id: 'my_package_id')) }
 
-    it { is_expected.to be_a(FriendlyShipping::Services::Usps::RateEstimatePackageOptions) }
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::Usps::RateEstimatePackageOptions }
+    let(:required_attrs) { {} }
   end
 end

--- a/spec/friendly_shipping/services/usps_international/rate_estimates_options_spec.rb
+++ b/spec/friendly_shipping/services/usps_international/rate_estimates_options_spec.rb
@@ -5,9 +5,9 @@ require 'friendly_shipping/services/usps/rate_estimate_options'
 
 RSpec.describe FriendlyShipping::Services::UspsInternational::RateEstimateOptions do
   let(:options) { described_class.new }
-  describe '#options_for_package' do
-    subject { options.options_for_package(double(package_id: 'my_package_id')) }
 
-    it { is_expected.to be_a(FriendlyShipping::Services::UspsInternational::RateEstimatePackageOptions) }
+  it_behaves_like "overrideable package options class" do
+    let(:default_class) { FriendlyShipping::Services::UspsInternational::RateEstimatePackageOptions }
+    let(:required_attrs) { {} }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,9 @@ VCR.configure do |c|
   end
 end
 
+require "support/shared_examples/overrideable_item_options_class"
+require "support/shared_examples/overrideable_package_options_class"
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/support/shared_examples/overrideable_item_options_class.rb
+++ b/spec/support/shared_examples/overrideable_item_options_class.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "overrideable item options class" do
+  describe "item options class" do
+    subject { options.options_for_item(double(item_id: "item")) }
+
+    it { is_expected.to be_a(default_class) }
+
+    context "when a custom class is passed" do
+      let(:options) do
+        described_class.new(
+          package_id: "package",
+          item_options_class: FriendlyShipping::ItemOptions
+        )
+      end
+
+      it { is_expected.to be_a(FriendlyShipping::ItemOptions) }
+    end
+  end
+end

--- a/spec/support/shared_examples/overrideable_package_options_class.rb
+++ b/spec/support/shared_examples/overrideable_package_options_class.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "overrideable package options class" do
+  describe "package options class" do
+    subject { options.options_for_package(double(package_id: "package")) }
+
+    it { is_expected.to be_a(default_class) }
+
+    context "when a custom class is passed" do
+      let(:options) do
+        described_class.new(
+          **required_attrs.merge(package_options_class: FriendlyShipping::PackageOptions)
+        )
+      end
+
+      it { is_expected.to be_a(FriendlyShipping::PackageOptions) }
+    end
+  end
+end


### PR DESCRIPTION
We should be able to override option classes when constructing new option instances by passing the proper keyword arg. Previously, these args were being merged into the other keyword args which prevents callers from passing in a custom option class.

Switching from merging to reverse merging ensures that the class only gets set if one wasn't provided by the caller. If one was provided by the caller, that class will get used instead of the default.