### PR TITLE
Add YARD docs for R+L, ShipEngine, and TForce

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ inherit_from:
 Metrics/BlockLength:
   Enabled: false
 
+Style/AccessorGrouping:
+  Enabled: false
+
 Style/HashEachMethods:
   Enabled: true
 

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,6 @@
+--protected
+--no-private
+--readme README.md
+--markup markdown
+--exclude friendly_shipping/types
+'lib/**/*.rb' - '*.md'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
   gem "dotenv", "~> 3.0"
   gem "factory_bot", "~> 6.2"
   gem "pry", "~> 0.12"
+  gem "rack"
   gem "rake", ">= 12.3.3"
   gem "rspec", "~> 3.0"
   gem "rspec_junit_formatter", "~> 0.4"
@@ -19,4 +20,6 @@ group :development do
   gem "simplecov", "~> 0.17"
   gem "vcr", "~> 6.0"
   gem "webmock", "~> 3.6"
+  gem "webrick"
+  gem "yard"
 end

--- a/lib/friendly_shipping/api_error.rb
+++ b/lib/friendly_shipping/api_error.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Raised when an API error is returned. Parent of carrier-specific API error classes.
   class ApiError < StandardError
+    # @return [RestClient::Exception] the cause of the error
     attr_reader :cause
 
-    # @param [RestClient::Exception] cause
-    # @param [String] message
+    # @param cause [RestClient::Exception] the cause of the error
+    # @param message [String] optional descriptive message
     def initialize(cause, message = nil)
       @cause = cause
       super(message || cause.message)

--- a/lib/friendly_shipping/api_error_handler.rb
+++ b/lib/friendly_shipping/api_error_handler.rb
@@ -4,7 +4,7 @@ require 'friendly_shipping/api_error'
 
 module FriendlyShipping
   class ApiErrorHandler
-    include Dry::Monads[:result]
+    include Dry::Monads::Result::Mixin
 
     attr_reader :api_error_class
 

--- a/lib/friendly_shipping/api_error_handler.rb
+++ b/lib/friendly_shipping/api_error_handler.rb
@@ -3,20 +3,24 @@
 require 'friendly_shipping/api_error'
 
 module FriendlyShipping
+  # Handles API errors by wrapping them in an API error class ({ApiError} by default) which
+  # is then wrapped in an {ApiFailure} (along with the original API request and response).
+  # Finally, the {ApiFailure} is then wrapped in a `Dry::Monads::Failure`.
   class ApiErrorHandler
     include Dry::Monads::Result::Mixin
 
+    # @return [Class] the class used to wrap the API error
     attr_reader :api_error_class
 
-    # @param [Class] api_error_class
+    # @param api_error_class [Class] the class used to wrap the API error
     def initialize(api_error_class: FriendlyShipping::ApiError)
       @api_error_class = api_error_class
     end
 
-    # @param [StandardError] error
-    # @param [FriendlyShipping::Request] original_request
-    # @param [RestClient::Response] original_response
-    # @return [Dry::Monads::Failure<FriendlyShipping::ApiFailure>]
+    # @param error [StandardError] the error to handle
+    # @param original_request [Request] the API request which triggered the error
+    # @param original_response [RestClient::Response] the API response containing the error
+    # @return [Failure<ApiFailure>]
     def call(error, original_request: nil, original_response: nil)
       Failure(
         ApiFailure.new(

--- a/lib/friendly_shipping/api_failure.rb
+++ b/lib/friendly_shipping/api_failure.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Wraps an API result from a request that failed.
   class ApiFailure < ApiResult
+    # @!attribute [r] data
+    #   The API failure (typically an exception)
     alias_method :failure, :data
 
+    # @return [#to_s] a string representation of the failure
     def to_s
       failure.to_s
     end

--- a/lib/friendly_shipping/api_result.rb
+++ b/lib/friendly_shipping/api_result.rb
@@ -1,12 +1,24 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Wraps an API result (a response body, for example) along with the
+  # original request and response objects.
   class ApiResult
-    attr_reader :data, :original_request, :original_response
+    # @return [Object] the API result (typically the response body)
+    attr_reader :data
 
-    # @param [Object] data The API result
-    # @param [FriendlyShipping::Request] original_request The HTTP request
-    # @param [FriendlyShipping::Response] original_response The HTTP response
+    # @return [Request] the original API request (if debugging is enabled)
+    attr_reader :original_request
+
+    # @return [Response] the original API response (if debugging is enabled)
+    attr_reader :original_response
+
+    # Returns a new instance of `ApiResult`. The original request and response are only attached
+    # to this object if debugging is enabled. See {FriendlyShipping::Request#debug}
+    #
+    # @param data [Object] the API result (typically the response body)
+    # @param original_request [Request] the original API request
+    # @param original_response [Response] the original API response
     def initialize(data, original_request: nil, original_response: nil)
       @data = data
 

--- a/lib/friendly_shipping/carrier.rb
+++ b/lib/friendly_shipping/carrier.rb
@@ -1,15 +1,32 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Represents a carrier (UPS, FedEx, etc.) and its {ShippingMethod} objects.
   class Carrier
-    attr_reader :id, :name, :code, :shipping_methods, :balance, :data
+    # @return [String] a unique identifier for this carrier
+    attr_reader :id
 
-    # @param [Integer, String] id The carrier's ID
-    # @param [String] name The carrier's name
-    # @param [String] code The carrier's unique code
-    # @param [Array] shipping_methods The shipping methods available on this carrier
-    # @param [Float] balance The remaining balance for this carrier
-    # @param [Hash] data Additional data related to this carrier
+    # @return [String] the carrier's name
+    attr_reader :name
+
+    # @return [String] the carrier's unique code
+    attr_reader :code
+
+    # @return [Array<ShippingMethod>] the shipping methods available on this carrier
+    attr_reader :shipping_methods
+
+    # @return [Float] the remaining balance for this carrier
+    attr_reader :balance
+
+    # @return [Hash] additional data related to this carrier
+    attr_reader :data
+
+    # @param id [Integer, String] a unique identifier for this carrier
+    # @param name [String] the carrier's name
+    # @param code [String] the carrier's unique code
+    # @param shipping_methods [Array<ShippingMethod>] the shipping methods available on this carrier
+    # @param balance [Float] the remaining balance for this carrier
+    # @param data [Hash] additional data related to this carrier
     def initialize(id: nil, name: nil, code: nil, shipping_methods: [], balance: nil, data: {})
       @id = id
       @name = name
@@ -19,6 +36,9 @@ module FriendlyShipping
       @data = data
     end
 
+    # Returns true if the given object shares the same ID with this carrier.
+    # @param [Object] other
+    # @return [Boolean]
     def ==(other)
       id == other.id
     end

--- a/lib/friendly_shipping/http_client.rb
+++ b/lib/friendly_shipping/http_client.rb
@@ -8,7 +8,7 @@ require 'friendly_shipping/api_error_handler'
 
 module FriendlyShipping
   class HttpClient
-    include Dry::Monads[:result]
+    include Dry::Monads::Result::Mixin
 
     attr_reader :error_handler
 

--- a/lib/friendly_shipping/http_client.rb
+++ b/lib/friendly_shipping/http_client.rb
@@ -7,16 +7,22 @@ require 'friendly_shipping/api_failure'
 require 'friendly_shipping/api_error_handler'
 
 module FriendlyShipping
+  # A façade for `RestClient` which constructs requests, wraps responses in `Dry::Monad`
+  # results, and calls the API error handler with failures.
   class HttpClient
     include Dry::Monads::Result::Mixin
 
+    # @return [.call] the API error handler
     attr_reader :error_handler
 
-    # @param [Proc, #call] error_handler Called to handle an error if one occurs
+    # @param error_handler [.call] called if an API error occurs
     def initialize(error_handler: FriendlyShipping::ApiErrorHandler.new)
       @error_handler = error_handler
     end
 
+    # Makes a GET request and handles the response.
+    # @param request [Request] the request to GET
+    # @return [Success<Response>, Failure<ApiFailure>]
     def get(request)
       http_response = ::RestClient.get(
         request.url, request.headers
@@ -27,6 +33,9 @@ module FriendlyShipping
       error_handler.call(e, original_request: request, original_response: e.response)
     end
 
+    # Makes a DELETE request and handles the response.
+    # @param request [Request] the request to DELETE
+    # @return [Success<Response>, Failure<ApiFailure>]
     def delete(request)
       http_response = ::RestClient.delete(request.url, request.headers)
 
@@ -35,6 +44,9 @@ module FriendlyShipping
       error_handler.call(e, original_request: request, original_response: e.response)
     end
 
+    # Makes a POST request and handles the response.
+    # @param request [Request] the request to POST
+    # @return [Success<Response>, Failure<ApiFailure>]
     def post(request)
       http_response = ::RestClient.post(
         request.url,
@@ -47,6 +59,9 @@ module FriendlyShipping
       error_handler.call(e, original_request: request, original_response: e.response)
     end
 
+    # Makes a PUT request and handles the response.
+    # @param request [Request] the request to PUT
+    # @return [Success<Response>, Failure<ApiFailure>]
     def put(request)
       http_response = ::RestClient.put(
         request.url,

--- a/lib/friendly_shipping/item_options.rb
+++ b/lib/friendly_shipping/item_options.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Base class for item options. Used when serializing API requests.
   class ItemOptions
+    # @return [String] the ID for the item that belongs to these options
     attr_reader :item_id
 
+    # @param item_id [String] the ID for the item that belongs to these options
     def initialize(item_id:)
       @item_id = item_id
     end

--- a/lib/friendly_shipping/label.rb
+++ b/lib/friendly_shipping/label.rb
@@ -3,27 +3,48 @@
 require 'friendly_shipping/types'
 
 module FriendlyShipping
+  # Base class for a shipping label returned by a carrier API.
   class Label
-    attr_reader :id,
-                :shipment_id,
-                :tracking_number,
-                :service_code,
-                :label_href,
-                :data,
-                :label_format,
-                :cost,
-                :shipment_cost,
-                :label_data
+    # @return [String] the label's unique ID
+    attr_reader :id
 
-    # @param [String] id The label's ID
-    # @param [String] shipment_id The label's shipment ID
-    # @param [String] tracking_number The label's tracking number
-    # @param [String] service_code The label's service code
-    # @param [String] label_href The URL for the label
-    # @param [String] label_format The label's format
-    # @param [String] label_data The raw label data
-    # @param [Money] shipment_cost The cost of the shipment
-    # @param [Hash] data Additional data related to the label
+    # @return [String] the label's shipment ID
+    attr_reader :shipment_id
+
+    # @return [String] the label's tracking number
+    attr_reader :tracking_number
+
+    # @return [String] the label's service code
+    attr_reader :service_code
+
+    # @return [String] the URL for the label
+    attr_reader :label_href
+
+    # @return [String] the label's format
+    attr_reader :label_format
+
+    # @return [String] the raw label data
+    attr_reader :label_data
+
+    # @return [Money] the label's cost
+    attr_reader :cost
+
+    # @return [Money] the overall cost of the shipment
+    attr_reader :shipment_cost
+
+    # @return [Hash] additional data related to the label
+    attr_reader :data
+
+    # @param id [String] the label's unique ID
+    # @param shipment_id [String] the label's shipment ID
+    # @param tracking_number [String] the label's tracking number
+    # @param service_code [String] the label's service code
+    # @param label_href [String] the URL for the label
+    # @param label_format [String] the label's format
+    # @param label_data [String] the raw label data
+    # @param cost [Money] the label's cost
+    # @param shipment_cost [Money] the overall cost of the shipment
+    # @param data [Hash] additional data related to the label
     def initialize(
       id: nil,
       shipment_id: nil,

--- a/lib/friendly_shipping/package_options.rb
+++ b/lib/friendly_shipping/package_options.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Base class for package options. Used when serializing API requests.
   class PackageOptions
+    # @return [String] the ID for the package that belongs to these options
     attr_reader :package_id
 
+    # @param package_id [String] the ID for the package  that belongs to these options
+    # @param item_options [Array<ItemOptions>] the options for items in this package
+    # @param item_options_class [Class] the class to use for item options when none are provided
     def initialize(
       package_id:,
       item_options: Set.new,
@@ -14,6 +19,11 @@ module FriendlyShipping
       @item_options_class = item_options_class
     end
 
+    # Finds and returns item options for the given item. If options cannot be
+    # found, the `item_options_class` is used to construct new options.
+    #
+    # @param item [#id] the item for which to get options
+    # @return [ItemOptions]
     def options_for_item(item)
       item_options.detect do |item_option|
         item_option.item_id == item.id
@@ -22,9 +32,18 @@ module FriendlyShipping
 
     private
 
-    attr_reader :item_options,
-                :item_options_class
+    # @return [Array<ItemOptions>]
+    attr_reader :item_options
 
+    # @return [Class]
+    attr_reader :item_options_class
+
+    # Attempts to find a hash value for the given key. If no value is found, the
+    # default value is returned.
+    #
+    # @param key [Symbol] the key to use
+    # @param default [Object] the default value
+    # @param kwargs [Hash] the hash to search
     def value_or_default(key, default, kwargs)
       kwargs.key?(key) ? kwargs.delete(key) : default
     end

--- a/lib/friendly_shipping/rate.rb
+++ b/lib/friendly_shipping/rate.rb
@@ -1,27 +1,47 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Base class for a shipping rate returned by a carrier API.
   class Rate
+    # Indicates a shipping rate has no amounts.
     class NoAmountsGiven < StandardError; end
-    attr_reader :shipping_method,
-                :amounts,
-                :remote_service_id,
-                :pickup_date,
-                :delivery_date,
-                :guaranteed,
-                :warnings,
-                :errors,
-                :data
 
-    # @param [FriendlyShipping::ShippingMethod] shipping_method The rate's shipping method
-    # @param [Hash] amounts The amounts (as Money objects) that make up the rate
-    # @param [Integer] remote_service_id The remote service ID for the rate
-    # @param [Time] pickup_date The pickup date for the rate
-    # @param [Time] delivery_date The delivery date for the rate
-    # @param [Boolean] guaranteed Whether the delivery date is guaranteed
-    # @param [Array] warnings Any warnings that were generated
-    # @param [Array] errors Any errors that were generated
-    # @param [Hash] data Additional data related to the rate
+    # @return [ShippingMethod] the rate's shipping method
+    attr_reader :shipping_method
+
+    # @return [Hash{String,Symbol=>Money}] the amounts that make up the rate
+    attr_reader :amounts
+
+    # @return [Integer] the remote service ID for the rate
+    attr_reader :remote_service_id
+
+    # @return [Time] the pickup date for the rate
+    attr_reader :pickup_date
+
+    # @return [Time] the delivery date for the rate
+    attr_reader :delivery_date
+
+    # @return [Boolean] whether the delivery date is guaranteed
+    attr_reader :guaranteed
+
+    # @return [Array] any warnings that were generated while getting this rate
+    attr_reader :warnings
+
+    # @return [Array] any errors that were generated while getting this rate
+    attr_reader :errors
+
+    # @return [Hash] additional data related to the rate
+    attr_reader :data
+
+    # @param shipping_method [ShippingMethod] the rate's shipping method
+    # @param amounts [Hash{String,Symbol=>Money}] the amounts that make up the rate
+    # @param remote_service_id [Integer] the remote service ID for the rate
+    # @param pickup_date [Time] the pickup date for the rate
+    # @param delivery_date [Time] the delivery date for the rate
+    # @param guaranteed [Boolean] whether the delivery date is guaranteed
+    # @param warnings [Array] any warnings that were generated while getting this rate
+    # @param errors [Array] any errors that were generated while getting this rate
+    # @param data [Hash] additional data related to the rate
     def initialize(
       shipping_method:,
       amounts:,
@@ -44,9 +64,13 @@ module FriendlyShipping
       @data = data
     end
 
+    # Make this class interchangeable with FriendlyShipping::Timing
     alias_method :pickup, :pickup_date
     alias_method :delivery, :delivery_date
 
+    # Sums all the amounts in the rate, returning the total amount.
+    # @return [Money]
+    # @raise [NoAmountsGiven] if the rate has no amounts
     def total_amount
       raise NoAmountsGiven if amounts.empty?
 

--- a/lib/friendly_shipping/request.rb
+++ b/lib/friendly_shipping/request.rb
@@ -1,15 +1,29 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Represents an HTTP request sent to a carrier API.
   class Request
-    attr_reader :url, :http_method, :body, :headers, :debug
+    # @return [String] the HTTP request URL
+    attr_reader :url
 
-    # @param [String] url The HTTP request URL
-    # @param [String] http_method The HTTP request method
-    # @param [String] body The HTTP request body
-    # @param [String] readable_body Human-readable HTTP request body
-    # @param [Hash] headers The HTTP request headers
-    # @param [Boolean] debug Whether to debug the request
+    # @return [String] the HTTP request method
+    attr_reader :http_method
+
+    # @return [String] the HTTP request body
+    attr_reader :body
+
+    # @return [String] human-readable HTTP request body
+    attr_reader :headers
+
+    # @return [Boolean] whether to attach debugging information to the response
+    attr_reader :debug
+
+    # @param url [String] the HTTP request URL
+    # @param http_method [String] the HTTP request method
+    # @param body [String] the HTTP request body
+    # @param readable_body [String] human-readable HTTP request body
+    # @param headers [Hash] the HTTP request headers
+    # @param debug [Boolean] whether to attach debugging information to the response
     def initialize(url:, http_method: nil, body: nil, readable_body: nil, headers: {}, debug: false)
       @url = url
       @http_method = http_method
@@ -19,6 +33,8 @@ module FriendlyShipping
       @debug = debug
     end
 
+    # Returns the HTTP request body.
+    # @return [String] human-readable HTTP request body
     def readable_body
       @readable_body.presence || @body
     end

--- a/lib/friendly_shipping/response.rb
+++ b/lib/friendly_shipping/response.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Represents an HTTP response received from a carrier API.
   class Response
-    attr_reader :status, :body, :headers
+    # @return [Integer] the HTTP response status code
+    attr_reader :status
 
-    # @param [Integer] status The HTTP response status code
-    # @param [String] body The HTTP response body
-    # @param [Hash] headers The HTTP response headers
+    # @return [String] the HTTP response body
+    attr_reader :body
+
+    # @return [Hash] the HTTP response headers
+    attr_reader :headers
+
+    # @param status [Integer] the HTTP response status code
+    # @param body [String] the HTTP response body
+    # @param headers [Hash] the HTTP response headers
     def initialize(status:, body:, headers:)
       @status = status
       @body = body
@@ -15,13 +23,16 @@ module FriendlyShipping
 
     alias_method :code, :status
 
-    # @param [RestClient::Response] response
-    # @return [FriendlyShipping::Response]
+    # Constructs a new {Response} from a `RestClient::Response` object.
+    # @param response [RestClient::Response] the response to use
+    # @return [Response]
     def self.new_from_rest_client_response(response)
       new(status: response&.code, body: response&.body, headers: response&.headers)
     end
 
+    # Returns true if the given object shares the same class and attributes with this response.
     # @param [Object] other
+    # @return [Boolean]
     def ==(other)
       other.class == self.class &&
         other.attributes == attributes
@@ -29,12 +40,16 @@ module FriendlyShipping
 
     alias_method :eql?, :==
 
+    # Returns this response's attributes as a hash.
+    # @return [Hash]
     def hash
       attributes.hash
     end
 
     protected
 
+    # Returns the status, body, and headers from this response.
+    # @return [Array]
     def attributes
       [status, body, headers]
     end

--- a/lib/friendly_shipping/services/rl/api_error.rb
+++ b/lib/friendly_shipping/services/rl/api_error.rb
@@ -5,16 +5,19 @@ require 'friendly_shipping/api_error'
 module FriendlyShipping
   module Services
     class RL
+      # Raised when an R+L API error is returned.
       class ApiError < FriendlyShipping::ApiError
-        # @param [RestClient::Exception] cause
+        # @param cause [RestClient::Exception] the cause of the error
         def initialize(cause)
           super(cause, parse_message(cause))
         end
 
         private
 
-        # @param [RestClient::Exception] error
-        # @return [String, nil]
+        # Parses the message from the error response.
+        #
+        # @param error [RestClient::Exception] the cause of the error
+        # @return [String, nil] the message or nil if it couldn't be parsed
         def parse_message(error)
           return error.message unless error.response && error.http_code == 400
 

--- a/lib/friendly_shipping/services/rl/bol_options.rb
+++ b/lib/friendly_shipping/services/rl/bol_options.rb
@@ -6,26 +6,44 @@ require 'friendly_shipping/services/rl/bol_packages_serializer'
 module FriendlyShipping
   module Services
     class RL
+      # Bill of Lading (BOL) options class. Used when serializing R+L API requests.
       class BOLOptions < ShipmentOptions
-        attr_reader :pickup_time_window,
-                    :pickup_instructions,
-                    :declared_value,
-                    :special_instructions,
-                    :reference_numbers,
-                    :additional_service_codes,
-                    :generate_universal_pro,
-                    :packages_serializer
+        # @return [Range] the pickup time window
+        attr_reader :pickup_time_window
 
-        # @param [Range] pickup_time_window
-        # @param [String] pickup_instructions
-        # @param [Numeric] declared_value
-        # @param [String] special_instructions
-        # @param [Hash] reference_numbers
-        # @param [Array<String>] additional_service_codes
-        # @param [Boolean] generate_universal_pro
-        # @param [Callable] packages_serializer A callable that takes packages
+        # @return [String] the pickup instructions
+        attr_reader :pickup_instructions
+
+        # @return [Numeric] the declared value of this shipment
+        attr_reader :declared_value
+
+        # @return [String] any special instructions
+        attr_reader :special_instructions
+
+        # @return [Hash] reference numbers for the shipment
+        attr_reader :reference_numbers
+
+        # @return [Array<String>] additional service codes
+        attr_reader :additional_service_codes
+
+        # @return [Boolean] whether to generate universal PRO number
+        attr_reader :generate_universal_pro
+
+        # @return [Callable] the packages serializer
+        attr_reader :packages_serializer
+
+        # @param pickup_time_window [Range]
+        # @param pickup_instructions [String]
+        # @param declared_value [Numeric]
+        # @param special_instructions [String]
+        # @param reference_numbers [Hash]
+        # @param additional_service_codes [Array<String>]
+        # @param generate_universal_pro [Boolean]
+        # @param packages_serializer [Callable] a callable that takes packages
         #   and an options object to create an Array of item hashes per the R+L Carriers docs
-        # @param [Hash] kwargs
+        # @param kwargs [Hash]
+        # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           pickup_time_window:,
           pickup_instructions: nil,
@@ -49,6 +67,7 @@ module FriendlyShipping
           super(**kwargs.reverse_merge(package_options_class: PackageOptions))
         end
 
+        # Optional service codes that can be used for R+L shipments.
         ADDITIONAL_SERVICE_CODES = %w[
           OriginLiftgate
           DestinationLiftgate
@@ -62,6 +81,9 @@ module FriendlyShipping
 
         private
 
+        # Raises an exception if the additional service codes passed into the initializer
+        # don't correspond to valid codes from {ADDITIONAL_SERVICE_CODES}.
+        #
         # @raise [ArgumentError] invalid additional service codes
         # @return [nil]
         def validate_additional_service_codes!

--- a/lib/friendly_shipping/services/rl/bol_options.rb
+++ b/lib/friendly_shipping/services/rl/bol_options.rb
@@ -25,7 +25,7 @@ module FriendlyShipping
         # @param [Boolean] generate_universal_pro
         # @param [Callable] packages_serializer A callable that takes packages
         #   and an options object to create an Array of item hashes per the R+L Carriers docs
-        # @param [Array<Object>] **kwargs
+        # @param [Hash] kwargs
         def initialize(
           pickup_time_window:,
           pickup_instructions: nil,

--- a/lib/friendly_shipping/services/rl/bol_packages_serializer.rb
+++ b/lib/friendly_shipping/services/rl/bol_packages_serializer.rb
@@ -3,10 +3,11 @@
 module FriendlyShipping
   module Services
     class RL
+      # Serializes packages for R+L BOL API requests.
       class BOLPackagesSerializer
-        # @param [Array<Physical::Package>] packages
-        # @param [FriendlyShipping::Services::RL::BOLOptions] options
-        # @return [Array<Hash>]
+        # @param packages [Array<Physical::Package>] packages to serialize
+        # @param options [BOLOptions] options for these packages
+        # @return [Array<Hash>] serialized packages
         def self.call(packages:, options:)
           packages.flat_map do |package|
             package_options = options.options_for_package(package)

--- a/lib/friendly_shipping/services/rl/item_options.rb
+++ b/lib/friendly_shipping/services/rl/item_options.rb
@@ -13,7 +13,7 @@ module FriendlyShipping
         # @param [String] freight_class
         # @param [String] nmfc_primary_code
         # @param [String] nmfc_sub_code
-        # @param [Array<Object>] **kwargs
+        # @param [Hash] kwargs
         def initialize(
           freight_class: nil,
           nmfc_primary_code: nil,

--- a/lib/friendly_shipping/services/rl/item_options.rb
+++ b/lib/friendly_shipping/services/rl/item_options.rb
@@ -5,15 +5,22 @@ require 'friendly_shipping/item_options'
 module FriendlyShipping
   module Services
     class RL
+      # Serializes items for R+L API requests.
       class ItemOptions < FriendlyShipping::ItemOptions
-        attr_reader :freight_class,
-                    :nmfc_primary_code,
-                    :nmfc_sub_code
+        # @return [String] the freight class
+        attr_reader :freight_class
 
-        # @param [String] freight_class
-        # @param [String] nmfc_primary_code
-        # @param [String] nmfc_sub_code
-        # @param [Hash] kwargs
+        # @return [String] the NMFC primary code
+        attr_reader :nmfc_primary_code
+
+        # @return [String] the NMFC sub code
+        attr_reader :nmfc_sub_code
+
+        # @param freight_class [String] the freight class
+        # @param nmfc_primary_code [String] the NMFC primary code
+        # @param nmfc_sub_code [String] the NMFC sub code
+        # @param kwargs [Hash]
+        # @option kwargs [String] :item_id the ID for the item that belongs to these options
         def initialize(
           freight_class: nil,
           nmfc_primary_code: nil,

--- a/lib/friendly_shipping/services/rl/package_options.rb
+++ b/lib/friendly_shipping/services/rl/package_options.rb
@@ -5,8 +5,12 @@ require 'friendly_shipping/package_options'
 module FriendlyShipping
   module Services
     class RL
+      # Serializes packages for R+L API requests.
       class PackageOptions < FriendlyShipping::PackageOptions
-        # @param [Hash] kwargs
+        # @param kwargs [Hash]
+        # @option kwargs [String] :package_id the ID for the package that belongs to these options
+        # @option kwargs [Array<ItemOptions>] :item_options the options for items in this package
+        # @option kwargs [Class] :item_options_class the class to use for item options when none are provided
         def initialize(**kwargs)
           super(**kwargs.reverse_merge(item_options_class: ItemOptions))
         end

--- a/lib/friendly_shipping/services/rl/package_options.rb
+++ b/lib/friendly_shipping/services/rl/package_options.rb
@@ -6,7 +6,7 @@ module FriendlyShipping
   module Services
     class RL
       class PackageOptions < FriendlyShipping::PackageOptions
-        # @param [Array<Object>] **kwargs
+        # @param [Hash] kwargs
         def initialize(**kwargs)
           super(**kwargs.reverse_merge(item_options_class: ItemOptions))
         end

--- a/lib/friendly_shipping/services/rl/parse_create_bol_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_create_bol_response.rb
@@ -6,13 +6,14 @@ require 'friendly_shipping/services/rl/shipment_information'
 module FriendlyShipping
   module Services
     class RL
+      # Parses the response from the R+L API when creating a Bill of Lading (BOL).
       class ParseCreateBOLResponse
         extend Dry::Monads::Result::Mixin
 
         class << self
-          # @param [FriendlyShipping::Request] request
-          # @param [FriendlyShipping::Response] response
-          # @return [Dry::Monads::Result<ApiResult<ShipmentInformation>>]
+          # @param request [Request] the request to attach to the API result
+          # @param response [Response] the response to parse
+          # @return [Result<ApiResult<ShipmentInformation>>] shipment info with the BOL document attached
           def call(request:, response:)
             parsed_json = JSON.parse(response.body)
             shipment_info = ShipmentInformation.new(

--- a/lib/friendly_shipping/services/rl/parse_invoice_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_invoice_response.rb
@@ -12,7 +12,7 @@ module FriendlyShipping
         class << self
           # @param [FriendlyShipping::Request] request
           # @param [FriendlyShipping::Response] response
-          # @return [Dry::Monads::Result<ApiResult<ShipmentDocument>>]
+          # @return [Result<ApiResult<ShipmentDocument>>]
           def call(request:, response:)
             parsed_json = JSON.parse(response.body)
             data = (parsed_json['Documents'].find { _1["Type"] == "Invoice" } || {})["Data"]

--- a/lib/friendly_shipping/services/rl/parse_print_bol_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_print_bol_response.rb
@@ -6,13 +6,14 @@ require 'friendly_shipping/services/rl/shipment_document'
 module FriendlyShipping
   module Services
     class RL
+      # Parses the response from the R+L API when printing a Bill of Lading (BOL).
       class ParsePrintBOLResponse
         extend Dry::Monads::Result::Mixin
 
         class << self
-          # @param [FriendlyShipping::Request] request
-          # @param [FriendlyShipping::Response] response
-          # @return [Dry::Monads::Result<ApiResult<ShipmentDocument>>]
+          # @param request [Request] the request to attach to the API result
+          # @param response [Response] the response to parse
+          # @return [Result<ApiResult<ShipmentDocument>>] shipment document containing the BOL
           def call(request:, response:)
             parsed_json = JSON.parse(response.body)
             bol_document = ShipmentDocument.new(

--- a/lib/friendly_shipping/services/rl/parse_print_shipping_labels_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_print_shipping_labels_response.rb
@@ -6,13 +6,14 @@ require 'friendly_shipping/services/rl/shipment_document'
 module FriendlyShipping
   module Services
     class RL
+      # Parses the response from the R+L API when printing shipping labels.
       class ParsePrintShippingLabelsResponse
         extend Dry::Monads::Result::Mixin
 
         class << self
-          # @param [FriendlyShipping::Request] request
-          # @param [FriendlyShipping::Response] response
-          # @return [Dry::Monads::Result<ApiResult<ShipmentDocument>>]
+          # @param request [Request] the request to attach to the API result
+          # @param response [Response] the response to parse
+          # @return [Result<ApiResult<ShipmentDocument>>] shipping document containing the labels
           def call(request:, response:)
             parsed_json = JSON.parse(response.body)
             label_doc = ShipmentDocument.new(

--- a/lib/friendly_shipping/services/rl/parse_rate_quote_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_rate_quote_response.rb
@@ -6,16 +6,14 @@ require 'friendly_shipping/services/rl/shipping_methods'
 module FriendlyShipping
   module Services
     class RL
+      # Parses the response from the R+L API when getting rate quotes.
       class ParseRateQuoteResponse
         extend Dry::Monads::Result::Mixin
 
         class << self
-          # @param [FriendlyShipping::Request] request
-          # @param [FriendlyShipping::Response] response
-          # @return [
-          #   Dry::Monads::Success<FriendlyShipping::ApiResult>,
-          #   Dry::Monads::Failure<FriendlyShipping::ApiResult>
-          # ]
+          # @param request [Request] the request to attach to the API result
+          # @param response [Response] the response to parse
+          # @return [Success<ApiResult>, Failure<ApiResult>] the parsed rates
           def call(request:, response:)
             parsed_json = JSON.parse(response.body)
             rates = build_rates(parsed_json)
@@ -41,10 +39,13 @@ module FriendlyShipping
 
           private
 
+          # The currency to use when parsing the rate quotes.
           CURRENCY = Money::Currency.new('USD').freeze
 
-          # @param [String] parsed_json
-          # @return [Array<FriendlyShipping::Rate>]
+          # Builds {Rate} instances from the parsed JSON.
+          #
+          # @param parsed_json [String] the parsed JSON
+          # @return [Array<Rate>] the parsed rates
           def build_rates(parsed_json)
             service_levels = parsed_json.dig('RateQuote', 'ServiceLevels')
             return [] unless service_levels

--- a/lib/friendly_shipping/services/rl/parse_transit_times_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_transit_times_response.rb
@@ -6,16 +6,14 @@ require 'friendly_shipping/services/rl/shipping_methods'
 module FriendlyShipping
   module Services
     class RL
+      # Parses the response from the R+L API when getting transit times.
       class ParseTransitTimesResponse
         extend Dry::Monads::Result::Mixin
 
         class << self
-          # @param [FriendlyShipping::Request] request
-          # @param [FriendlyShipping::Response] response
-          # @return [
-          #   Dry::Monads::Success<FriendlyShipping::ApiResult>,
-          #   Dry::Monads::Failure<FriendlyShipping::ApiResult>
-          # ]
+          # @param request [Request] the request to attach to the API result
+          # @param response [Response] the response to parse
+          # @return [Success<ApiResult>, Failure<ApiResult>] the parsed timings
           def call(request:, response:)
             parsed_json = JSON.parse(response.body)
             timings = build_timings(parsed_json)
@@ -41,8 +39,10 @@ module FriendlyShipping
 
           private
 
-          # @param [String] parsed_json
-          # @return [Array<FriendlyShipping::Timing>]
+          # Builds {Timing} instances from the parsed JSON.
+          #
+          # @param parsed_json [String] the parsed JSON
+          # @return [Array<Timing>] the parsed timings
           def build_timings(parsed_json)
             destinations = parsed_json['Destinations']
             return [] unless destinations

--- a/lib/friendly_shipping/services/rl/rate_quote_options.rb
+++ b/lib/friendly_shipping/services/rl/rate_quote_options.rb
@@ -6,18 +6,27 @@ require 'friendly_shipping/services/rl/rate_quote_packages_serializer'
 module FriendlyShipping
   module Services
     class RL
+      # Rate quote options for serializing R+L API requests.
       class RateQuoteOptions < ShipmentOptions
-        attr_reader :pickup_date,
-                    :declared_value,
-                    :additional_service_codes,
-                    :packages_serializer
+        # @return [Time] the pickup date
+        attr_reader :pickup_date
 
-        # @param [Time] pickup_date
-        # @param [Numeric] declared_value
-        # @param [Array<String>] additional_service_codes
-        # @param [Callable] packages_serializer A callable that takes packages
-        #   and an options object to create an Array of item hashes per the R+L Carriers docs
-        # @param [Hash] kwargs
+        # @return [Numeric] the declared value of this shipment
+        attr_reader :declared_value
+
+        # @return [Array<String>] additional service codes
+        attr_reader :additional_service_codes
+
+        # @return [Callable] the serializer for this shipment's packages
+        attr_reader :packages_serializer
+
+        # @param pickup_date [Time] the pickup date
+        # @param declared_value [Numeric] the declared value of this shipment
+        # @param additional_service_codes [Array<String>] additional service codes
+        # @param packages_serializer [Callable] the serializer for this shipment's packages
+        # @param kwargs [Hash]
+        # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           pickup_date:,
           declared_value: nil,
@@ -33,6 +42,7 @@ module FriendlyShipping
           super(**kwargs.reverse_merge(package_options_class: PackageOptions))
         end
 
+        # Optional service codes that can be used for R+L shipments.
         ADDITIONAL_SERVICE_CODES = %w[
           InsideDelivery
           LimitedAccessPickup
@@ -49,6 +59,9 @@ module FriendlyShipping
 
         private
 
+        # Raises an exception if the additional service codes passed into the initializer
+        # don't correspond to valid codes from {ADDITIONAL_SERVICE_CODES}.
+        #
         # @raise [ArgumentError] invalid additional service codes
         # @return [nil]
         def validate_additional_service_codes!

--- a/lib/friendly_shipping/services/rl/rate_quote_options.rb
+++ b/lib/friendly_shipping/services/rl/rate_quote_options.rb
@@ -17,7 +17,7 @@ module FriendlyShipping
         # @param [Array<String>] additional_service_codes
         # @param [Callable] packages_serializer A callable that takes packages
         #   and an options object to create an Array of item hashes per the R+L Carriers docs
-        # @param [Array<Object>] **kwargs
+        # @param [Hash] kwargs
         def initialize(
           pickup_date:,
           declared_value: nil,

--- a/lib/friendly_shipping/services/rl/rate_quote_packages_serializer.rb
+++ b/lib/friendly_shipping/services/rl/rate_quote_packages_serializer.rb
@@ -3,11 +3,12 @@
 module FriendlyShipping
   module Services
     class RL
+      # Serializes packages for R+L rate quote API requests.
       class RateQuotePackagesSerializer
         class << self
-          # @param [Array<Physical::Package>] packages
-          # @param [FriendlyShipping::Services::RL::RateQuoteOptions] options
-          # @return [Array<Hash>]
+          # @param packages [Array<Physical::Package>] packages to serialize
+          # @param options [RateQuoteOptions] options for this request
+          # @return [Array<Hash>] serialized packages
           def call(packages:, options:)
             item_hashes = packages.flat_map do |package|
               package_options = options.options_for_package(package)
@@ -30,8 +31,8 @@ module FriendlyShipping
           # Group items by freight class. The R+L Carriers API has a limit on the number of items
           # we can submit to the API, so this helps reduce the number of items.
           #
-          # @param [Array<Hash>] item_hashes
-          # @return [Array<Hash>]
+          # @param item_hashes [Array<Hash>] the item hashes to group
+          # @return [Array<Hash>] item hashes grouped by freight class
           def group_items(item_hashes)
             item_hashes.group_by do |item_hash|
               item_hash[:Class]

--- a/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
+++ b/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
@@ -3,11 +3,12 @@
 module FriendlyShipping
   module Services
     class RL
+      # Serializes an R+L API request to create a Bill of Lading (BOL).
       class SerializeCreateBOLRequest
         class << self
-          # @param [Physical::Shipment] shipment
-          # @param [FriendlyShipping::Services::RL::BOLOptions] options
-          # @return [Hash]
+          # @param shipment [Physical::Shipment] the shipment for the request
+          # @param options [BOLOptions] options for the request
+          # @return [Hash] the serialized request
           def call(shipment:, options:)
             {
               BillOfLading: {
@@ -28,8 +29,8 @@ module FriendlyShipping
 
           private
 
-          # @param [Numeric] declared_value
-          # @return [Hash, nil]
+          # @param declared_value [Numeric] the declared value to serialize
+          # @return [Hash, nil] the serialized declared value or nil if the value is blank
           def serialize_declared_value(declared_value)
             return if declared_value.blank?
 
@@ -39,8 +40,8 @@ module FriendlyShipping
             }
           end
 
-          # @param [Hash] reference_numbers
-          # @return [Hash, nil]
+          # @param reference_numbers [Hash] the reference numbers to serialize
+          # @return [Hash, nil] the serialized reference numbers or nil if the reference numbers are blank
           def serialize_reference_numbers(reference_numbers)
             return if reference_numbers.blank?
 
@@ -51,8 +52,8 @@ module FriendlyShipping
             }.compact
           end
 
-          # @param [FriendlyShipping::Services::RL::BOLOptions] options
-          # @return [Hash, nil]
+          # @param options [BOLOptions] the options containing pickup information
+          # @return [Hash, nil] the serialized pickup request
           def serialize_pickup_request(options)
             pickup_time_window = options.pickup_time_window
             return if pickup_time_window.nil?

--- a/lib/friendly_shipping/services/rl/serialize_location.rb
+++ b/lib/friendly_shipping/services/rl/serialize_location.rb
@@ -24,7 +24,7 @@ module FriendlyShipping
 
           private
 
-          # RL does not support leading country codes in phone numbers.
+          # R+L does not support leading country codes in phone numbers.
           #
           # @param [String] phone
           # @return [String]

--- a/lib/friendly_shipping/services/rl/serialize_rate_quote_request.rb
+++ b/lib/friendly_shipping/services/rl/serialize_rate_quote_request.rb
@@ -3,11 +3,12 @@
 module FriendlyShipping
   module Services
     class RL
+      # Serializes an R+L API request to get a shipping rate quote.
       class SerializeRateQuoteRequest
         class << self
-          # @param [Physical::Shipment] shipment
-          # @param [FriendlyShipping::Services::RL::QuoteOptions] options
-          # @return [Hash]
+          # @param shipment [Physical::Shipment] the shipment for the request
+          # @param options [RateQuoteOptions] options for the request
+          # @return [Hash] the serialized request
           def call(shipment:, options:)
             {
               RateQuote: {
@@ -24,8 +25,8 @@ module FriendlyShipping
 
           private
 
-          # @param [Physical::Location] location
-          # @return [Hash]
+          # @param location [Physical::Location] the location to serialize
+          # @return [Hash] the serialized location
           def serialize_location(location)
             {
               City: location.city,
@@ -35,9 +36,9 @@ module FriendlyShipping
             }.compact
           end
 
-          # @param [Array<Physical::Package>] packages
-          # @param [FriendlyShipping::Services::RL::QuoteOptions] options
-          # @return [Array<Hash>]
+          # @param packages [Array<Physical::Package>] the items (as packages) to serialize
+          # @param options [RateQuoteOptions] options for the items
+          # @return [Array<Hash>] the serialized items
           def serialize_items(packages, options)
             item_hashes = packages.flat_map do |package|
               package_options = options.options_for_package(package)
@@ -52,8 +53,8 @@ module FriendlyShipping
             group_items(item_hashes)
           end
 
-          # @param [Array<Physical::Pallet>] pallets
-          # @return [Array<Hash>]
+          # @param pallets [Array<Physical::Pallet>] the pallets to serialize
+          # @return [Array<Hash>] the serialized pallets
           def serialize_pallets(pallets)
             pallets.group_by do |pallet|
               pallet.weight.convert_to(:pounds).value.ceil

--- a/lib/friendly_shipping/services/rl/serialize_transit_times_request.rb
+++ b/lib/friendly_shipping/services/rl/serialize_transit_times_request.rb
@@ -3,11 +3,12 @@
 module FriendlyShipping
   module Services
     class RL
+      # Serializes an R+L API request to get a shipment transit timing estimate.
       class SerializeTransitTimesRequest
         class << self
-          # @param [Physical::Shipment] shipment
-          # @param [FriendlyShipping::Services::RL::QuoteOptions] options
-          # @return [Hash]
+          # @param shipment [Physical::Shipment] the shipment for the request
+          # @param options [RateQuoteOptions] options for the request
+          # @return [Hash] the serialized request
           def call(shipment:, options:)
             {
               PickupDate: options.pickup_date.strftime('%m/%d/%Y'),
@@ -20,8 +21,8 @@ module FriendlyShipping
 
           private
 
-          # @param [Physical::Location] location
-          # @return [Hash]
+          # @param location [Physical::Location] the location to serialize
+          # @return [Hash] the serialized location
           def serialize_location(location)
             {
               City: location.city,

--- a/lib/friendly_shipping/services/rl/shipment_document.rb
+++ b/lib/friendly_shipping/services/rl/shipment_document.rb
@@ -3,12 +3,20 @@
 module FriendlyShipping
   module Services
     class RL
+      # Represents an R+L shipment document such as a BOL or shipping label.
       class ShipmentDocument
-        attr_reader :format, :document_type, :binary
+        # @return [String] the format of the document's binary data
+        attr_reader :format
 
-        # @param [String] format The format of the binary data
-        # @param [String] document_type The type of document
-        # @param [String] binary The binary data
+        # @return [String] the type of document
+        attr_reader :document_type
+
+        # @return [String] the document's binary data
+        attr_reader :binary
+
+        # @param format [String] the format of the document's binary data
+        # @param document_type [String] the type of document
+        # @param binary [String] the document's binary data
         def initialize(
           format:,
           document_type:,
@@ -19,6 +27,9 @@ module FriendlyShipping
           @binary = binary
         end
 
+        # Returns true if format, document type, and binary data are all present.
+        # Returns false if any of these values are missing.
+        #
         # @return [Boolean]
         def valid?
           format.present? && document_type.present? && binary.present?

--- a/lib/friendly_shipping/services/rl/shipment_information.rb
+++ b/lib/friendly_shipping/services/rl/shipment_information.rb
@@ -3,11 +3,21 @@
 module FriendlyShipping
   module Services
     class RL
+      # Represents information for a specific shipment. This includes one or more
+      # documents, a PRO number, and a pickup request number.
       class ShipmentInformation
-        attr_reader :documents,
-                    :pro_number,
-                    :pickup_request_number
+        # @return [String] the shipment's PRO number
+        attr_reader :pro_number
 
+        # @return [String] the shipment's pickup request number
+        attr_reader :pickup_request_number
+
+        # @return [Array<ShipmentDocument>] the shipment's documents
+        attr_reader :documents
+
+        # @param pro_number [String] the shipment's PRO number
+        # @param pickup_request_number [String] the shipment's pickup request number
+        # @param documents [Array<ShipmentDocument>] the shipment's documents (BOL, labels, etc)
         def initialize(
           pro_number:,
           pickup_request_number: nil,
@@ -18,6 +28,9 @@ module FriendlyShipping
           @documents = documents
         end
 
+        # Returns true if PRO number and pickup request number are present.
+        # Returns false if either of these values are missing.
+        #
         # @return [Boolean]
         def valid?
           pro_number.present? && pickup_request_number.present?

--- a/lib/friendly_shipping/services/rl/shipping_methods.rb
+++ b/lib/friendly_shipping/services/rl/shipping_methods.rb
@@ -3,10 +3,12 @@
 module FriendlyShipping
   module Services
     class RL
+      # Available origin countries for R+L shipments.
       ORIGIN_COUNTRIES = %w[
         AG BB CA DO GU GY JM PR VC TT US VG VI
       ].map { |country_code| Carmen::Country.coded(country_code) }.freeze
 
+      # Available R+L shipping methods.
       SHIPPING_METHODS = [
         ["STD", "Standard Service"],
         ["GSDS", "Guaranteed Service"],

--- a/lib/friendly_shipping/services/ship_engine.rb
+++ b/lib/friendly_shipping/services/ship_engine.rb
@@ -56,7 +56,7 @@ module FriendlyShipping
       # Get rates from ShipEngine
       #
       # @param [Physical::Shipment] shipment The shipment object we're trying to get results for
-      # @options [FriendlyShipping::Services::ShipEngine::RatesOptions] The options relevant to rates. See object description.
+      # @param [FriendlyShipping::Services::ShipEngine::RatesOptions] options The options relevant to rates. See object description.
       #
       # @return [Result<ApiResult<Array<FriendlyShipping::Rate>>>] When successfully parsing, an array of rates in a Success Monad.
       #   When the parsing is not successful or ShipEngine can't give us rates, a Failure monad containing something that
@@ -77,8 +77,7 @@ module FriendlyShipping
       # Get rate estimates from ShipEngine
       #
       # @param [Physical::Shipment] shipment The shipment object we're trying to get results for
-      #
-      # @options [FriendlyShipping::Services::ShipEngine::RateEstimatesOptions] The options relevant to estimating rates. See object description.
+      # @param [FriendlyShipping::Services::ShipEngine::RateEstimatesOptions] options The options relevant to estimating rates. See object description.
       #
       # @return [Result<ApiResult<Array<FriendlyShipping::Rate>>>] When successfully parsing, an array of rates in a Success Monad.
       #   When the parsing is not successful or ShipEngine can't give us rates, a Failure monad containing something that

--- a/lib/friendly_shipping/services/ship_engine/api_error.rb
+++ b/lib/friendly_shipping/services/ship_engine/api_error.rb
@@ -5,16 +5,19 @@ require 'friendly_shipping/api_error'
 module FriendlyShipping
   module Services
     class ShipEngine
+      # Raised when an API error is returned.
       class ApiError < FriendlyShipping::ApiError
-        # @param [RestClient::Exception] cause
+        # @param cause [RestClient::Exception] the cause of the error
         def initialize(cause)
           super(cause, parse_message(cause))
         end
 
         private
 
-        # @param [RestClient::Exception] error
-        # @return [String, nil]
+        # Parses the message from the error response.
+        #
+        # @param error [RestClient::Exception] the cause of the error
+        # @return [String, nil] the message or nil if it couldn't be parsed
         def parse_message(error)
           return error.message unless error.response && error.http_code == 400
 

--- a/lib/friendly_shipping/services/ship_engine/customs_items_serializer.rb
+++ b/lib/friendly_shipping/services/ship_engine/customs_items_serializer.rb
@@ -3,8 +3,12 @@
 module FriendlyShipping
   module Services
     class ShipEngine
+      # Serializes customs items for international labels.
       class CustomsItemsSerializer
         class << self
+          # @param packages [Array<Physical::Package>] the packages to serialize
+          # @param options [LabelOptions] options for the packages
+          # @return [Array<Hash>] the serialized customs items
           def call(packages, options)
             packages.map do |package|
               package.items.group_by(&:sku).map do |sku, items|

--- a/lib/friendly_shipping/services/ship_engine/label_customs_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_customs_options.rb
@@ -3,15 +3,18 @@
 module FriendlyShipping
   module Services
     class ShipEngine
-      # Represents customs options for obtaining international shipment labels.
-      # @option contents [String] The contents of the shipment.
-      #  Valid values are: gift, merchandise, returned_goods, documents, sample
-      # @option non_delivery [String] Indicates what should be done if the shipment cannot be delivered.
-      #  Valid values are: treat_as_abandoned, return_to_sender
+      # Options for obtaining international shipment labels with customs.
       class LabelCustomsOptions
-        attr_reader :contents,
-                    :non_delivery
+        # @return [String] the contents of the shipment
+        attr_reader :contents
 
+        # @return [String] indicates what should be done if the shipment cannot be delivered
+        attr_reader :non_delivery
+
+        # @param contents [String] the contents of the shipment. Valid values are: gift, merchandise,
+        #   returned_goods, documents, sample
+        # @param non_delivery [String] indicates what should be done if the shipment cannot be delivered.
+        #   Valid values are: treat_as_abandoned, return_to_sender
         def initialize(
           contents: "merchandise",
           non_delivery: "return_to_sender"

--- a/lib/friendly_shipping/services/ship_engine/label_item_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_item_options.rb
@@ -5,13 +5,18 @@ require 'friendly_shipping/item_options'
 module FriendlyShipping
   module Services
     class ShipEngine
-      # Represents item options for obtaining shipment labels.
-      # @option commodity_code [String] This item's HS or NMFC code for international shipments.
-      # @option country_of_origin [String] This item's country of origin for international shipments.
+      # Item options for generating shipping labels.
       class LabelItemOptions < FriendlyShipping::ItemOptions
-        attr_reader :commodity_code,
-                    :country_of_origin
+        # @return [String] the HS or NMFC code for international shipments
+        attr_reader :commodity_code
 
+        # @return [String] the country of origin for international shipments
+        attr_reader :country_of_origin
+
+        # @param commodity_code [String] the HS or NMFC code for international shipments
+        # @param country_of_origin [String] the country of origin for international shipments
+        # @param kwargs [Hash]
+        # @option kwargs [String] :item_id the ID for the item that belongs to these options
         def initialize(
           commodity_code: nil,
           country_of_origin: nil,

--- a/lib/friendly_shipping/services/ship_engine/label_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_options.rb
@@ -7,24 +7,35 @@ require 'friendly_shipping/services/ship_engine/customs_items_serializer'
 module FriendlyShipping
   module Services
     class ShipEngine
-      # Options for generating ShipEngine labels
-      #
-      # @attribute label_format [Symbol] The format for the label. Possible Values: :png, :zpl and :pdf. Default :pdf
-      # @attribute label_download_type [Symbol] Whether to download directly (`:inline`) or
-      #   obtain a URL to the label (`:url`). Default :url
-      # @attribute label_image_id [String] Identifier for image uploaded to ShipEngine. Default: nil
-      # @attribute package_options [Enumberable<LabelPackageOptions>] Package options for the packages in the shipment
-      # @param [Callable] customs_items_serializer A callable that takes packages and an options object
-      #   to create the customs items array for the shipment
-      #
+      # Options for generating shipping labels.
       class LabelOptions < FriendlyShipping::ShipmentOptions
-        attr_reader :shipping_method,
-                    :label_download_type,
-                    :label_format,
-                    :label_image_id,
-                    :customs_options,
-                    :customs_items_serializer
+        # @return [ShippingMethod] the label's shipping method
+        attr_reader :shipping_method
 
+        # @return [Symbol] whether to download directly or obtain a URL to the label
+        attr_reader :label_download_type
+
+        # @return [Symbol] the format for the label
+        attr_reader :label_format
+
+        # @return [String] identifier for image uploaded to ShipEngine
+        attr_reader :label_image_id
+
+        # @return [LabelCustomsOptions] customs options for international shipment labels
+        attr_reader :customs_options
+
+        # @return [Proc, #call] a callable that takes packages and an options object to create the customs items array for the shipment
+        attr_reader :customs_items_serializer
+
+        # @param shipping_method [ShippingMethod] the label's shipping method
+        # @param label_download_type [Symbol] whether to download directly (`:inline`) or obtain a URL to the label (`:url`). Default :url
+        # @param label_format [Symbol] the format for the label. Possible Values: :png, :zpl and :pdf. Default :pdf
+        # @param label_image_id [String] identifier for image uploaded to ShipEngine. Default: nil
+        # @param customs_options [LabelCustomsOptions] customs options for obtaining international shipment labels
+        # @param customs_items_serializer [Proc, #call] a callable that takes packages and an options object to create the customs items array for the shipment
+        # @param kwargs [Hash]
+        # @option kwargs [Array<LabelPackageOptions>] :package_options package options for the packages in the shipment
+        # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           shipping_method:,
           label_download_type: :url,

--- a/lib/friendly_shipping/services/ship_engine/label_package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_package_options.rb
@@ -6,18 +6,25 @@ require 'friendly_shipping/services/ship_engine/label_item_options'
 module FriendlyShipping
   module Services
     class ShipEngine
-      # Options relating to packages in the ShipEngine labels call
-      #
-      # @attribute :package_code [Symbol] The type of package. Possible types can be gotten
-      #    via the ShipEngine API: https://www.shipengine.com/docs/reference/list-carrier-packages/
-      #    If a package type is given, no dimensions will be added to the call (as we can assume the
-      #    carrier knows the dimensions of their packaging types).
-      # @attribute messages [Array<String>] A list of messages to add to the label. No carrier accepts
-      #    more than three messages, and some have restrictions on how many characters are possible.
-      #    We're not validating here though.
+      # Package options for generating shipping labels.
       class LabelPackageOptions < FriendlyShipping::PackageOptions
-        attr_reader :package_code, :messages
+        # @return [Symbol] the type of package
+        attr_reader :package_code
 
+        # @return [Array<String>] a list of messages to add to the label
+        attr_reader :messages
+
+        # @param package_code [Symbol] The type of package. Possible types can be gotten
+        #    via the ShipEngine API: https://www.shipengine.com/docs/reference/list-carrier-packages/
+        #    If a package type is given, no dimensions will be added to the call (as we can assume the
+        #    carrier knows the dimensions of their packaging types).
+        # @param messages [Array<String>] A list of messages to add to the label. No carrier accepts
+        #    more than three messages, and some have restrictions on how many characters are possible.
+        #    We're not validating here though.
+        # @param kwargs [Hash]
+        # @option kwargs [String] :package_id the ID for the package that belongs to these options
+        # @option kwargs [Array<ItemOptions>] :item_options the options for items in this package
+        # @option kwargs [Class] :item_options_class the class to use for item options when none are provided
         def initialize(package_code: nil, messages: [], **kwargs)
           @package_code = package_code
           @messages = messages

--- a/lib/friendly_shipping/services/ship_engine/parse_carrier_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_carrier_response.rb
@@ -5,8 +5,12 @@ require 'json'
 module FriendlyShipping
   module Services
     class ShipEngine
+      # Parses the carriers API response.
       class ParseCarrierResponse
         class << self
+          # @param request [Request] the request to attach to the API result
+          # @param response [Response] the response to parse
+          # @return [ApiResult<Array<Carrier>] the parsed carriers
           def call(request:, response:)
             parsed_json = JSON.parse(response.body)
             carriers = parsed_json['carriers'].map do |carrier_data|
@@ -35,6 +39,11 @@ module FriendlyShipping
 
           private
 
+          # Parses and returns a ShipEngine shipping method from the carriers API response.
+          #
+          # @param carrier [Carrier] the carrier for the shipping method
+          # @param shipping_method_data [Hash] the data for the shipping method
+          # @return [ShippingMethod] the parsed shipping method
           def parse_shipping_method(carrier, shipping_method_data)
             FriendlyShipping::ShippingMethod.new(
               carrier: carrier,

--- a/lib/friendly_shipping/services/ship_engine/parse_label_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_label_response.rb
@@ -5,7 +5,11 @@ require 'json'
 module FriendlyShipping
   module Services
     class ShipEngine
+      # Parses the labels API response.
       class ParseLabelResponse
+        # @param request [Request] the request to attach to the API result
+        # @param response [Response] the response to parse
+        # @return [ApiResult<Array<Label>] the parsed labels (ShipEngine only returns one label at a time)
         def self.call(request:, response:)
           parsed_json = JSON.parse(response.body)
 

--- a/lib/friendly_shipping/services/ship_engine/parse_void_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_void_response.rb
@@ -3,9 +3,13 @@
 module FriendlyShipping
   module Services
     class ShipEngine
+      # Parses the API response for voiding a label.
       class ParseVoidResponse
         extend Dry::Monads::Result::Mixin
 
+        # @param request [Request] the request to attach to the API result
+        # @param response [Response] the response to parse
+        # @return [Success<ApiResult<String>>, Failure<ApiFailure<String>>] the success or failure message
         def self.call(request:, response:)
           parsed_json = JSON.parse(response.body)
           approved, message = parsed_json["approved"], parsed_json["message"]

--- a/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
@@ -5,18 +5,18 @@ require 'friendly_shipping/shipment_options'
 module FriendlyShipping
   module Services
     class ShipEngine
-      # Options for generating rate estimates for a shipment.
+      # Options for the rate estimates API call.
       class RateEstimatesOptions < ShipmentOptions
-        # @return [Array<Carrier>]
+        # @return [Array<Carrier>] the carriers for these rate estimates
         attr_reader :carriers
 
         # @return [#strftime]
         attr_reader :ship_date
 
-        # @param carriers [Array<Carrier>] the carriers for which we want to get rate estimates
+        # @param carriers [Array<Carrier] the carriers for these rate estimates
         # @param ship_date [#strftime] the date we want to ship on
         # @param kwargs [Hash]
-        # @option kwargs [Enumerable<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this shipment
         # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           carriers:,
@@ -28,7 +28,7 @@ module FriendlyShipping
           super(**kwargs)
         end
 
-        # @return [Array<String>]
+        # @return [Array<String>] the carrier IDs for these rate estimates
         def carrier_ids
           carriers.map(&:id)
         end

--- a/lib/friendly_shipping/services/ship_engine/rates_item_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_item_options.rb
@@ -5,12 +5,18 @@ require 'friendly_shipping/item_options'
 module FriendlyShipping
   module Services
     class ShipEngine
-      # Represents item options for determining rates.
-      # @option commodity_code [String] This item's HS or NMFC code for international shipments.
-      # @option country_of_origin [String] This item's country of origin for international shipments.
+      # Options for each item passed in the rates API call.
       class RatesItemOptions < FriendlyShipping::ItemOptions
-        attr_reader :commodity_code, :country_of_origin
+        # @return [String] the HS or NMFC code for international shipments
+        attr_reader :commodity_code
 
+        # @return [String] the country of origin for international shipments
+        attr_reader :country_of_origin
+
+        # @param commodity_code [String] the HS or NMFC code for international shipments
+        # @param country_of_origin [String] the country of origin for international shipments
+        # @param kwargs [Hash]
+        # @option kwargs [String] :item_id the ID for the item that belongs to these options
         def initialize(commodity_code: nil, country_of_origin: nil, **kwargs)
           @commodity_code = commodity_code
           @country_of_origin = country_of_origin

--- a/lib/friendly_shipping/services/ship_engine/rates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_options.rb
@@ -5,12 +5,12 @@ require 'friendly_shipping/shipment_options'
 module FriendlyShipping
   module Services
     class ShipEngine
-      # Options for generating rates for a shipment.
+      # Options for the rates API call.
       class RatesOptions < FriendlyShipping::ShipmentOptions
-        # @return [Array<Carrier>]
+        # @return [Array<Carrier>] the carriers from which to get rates
         attr_reader :carriers
 
-        # @return [String]
+        # @return [String] the service code for which to get rates
         attr_reader :service_code
 
         # @return [#strftime]
@@ -19,12 +19,12 @@ module FriendlyShipping
         # @return [String]
         attr_reader :comparison_rate_type
 
-        # @param carriers [Array<Carrier>] the carriers for which we want to get rates
-        # @param service_code [String] the service code for which we want to get rates
+        # @param carriers [Array<Carrier>] the carriers for these rates
+        # @param service_code [String] the service code to use when getting rates
         # @param ship_date [#strftime] the date we want to ship on
         # @param comparison_rate_type [String] set to "retail" for retail rates (UPS/USPS only)
         # @param kwargs [Hash]
-        # @option kwargs [Enumerable<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this shipment
         # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           carriers:,
@@ -41,7 +41,7 @@ module FriendlyShipping
           super(**kwargs.reverse_merge(package_options_class: RatesPackageOptions))
         end
 
-        # @return [Array<String>]
+        # @return [Array<String>] the carrier IDs for these rates
         def carrier_ids
           carriers.map(&:id)
         end

--- a/lib/friendly_shipping/services/ship_engine/rates_package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_package_options.rb
@@ -5,10 +5,12 @@ require 'friendly_shipping/services/ups_freight/rates_item_options'
 module FriendlyShipping
   module Services
     class ShipEngine
-      # Options for packages within a ShipEngine shipment
-      #
-      # @attribute [RatesItemOptions] item_options Options for each of the items in the package
+      # Options for each package passed in the rates API call.
       class RatesPackageOptions < FriendlyShipping::PackageOptions
+        # @param kwargs [Hash]
+        # @option kwargs [String] :package_id the ID for the package  that belongs to these options
+        # @option kwargs [Array<ItemOptions>] :item_options the options for items in this package
+        # @option kwargs [Class] :item_options_class the class to use for item options when none are provided
         def initialize(**kwargs)
           super(**kwargs.reverse_merge(item_options_class: RatesItemOptions))
         end

--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -3,8 +3,13 @@
 module FriendlyShipping
   module Services
     class ShipEngine
+      # Serializes a shipment and options for the label API request.
       class SerializeLabelShipment
         class << self
+          # @param shipment [Physical::Shipment] the shipment to serialize
+          # @param options [LabelOptions] the options to serialize
+          # @param test [Boolean] whether to use the test API
+          # @return [Hash] the serialized request
           def call(shipment:, options:, test:)
             shipment_hash = {
               label_format: options.label_format,
@@ -39,6 +44,8 @@ module FriendlyShipping
 
           private
 
+          # @param address [Physical::Location]
+          # @return [Hash]
           def serialize_address(address)
             {
               name: address.name,
@@ -53,6 +60,9 @@ module FriendlyShipping
             }.merge(SerializeAddressResidentialIndicator.call(address))
           end
 
+          # @param packages [Array<Physical::Package>]
+          # @param options [LabelOptions]
+          # @return [Array<Hash>]
           def serialize_packages(packages, options)
             packages.map do |package|
               package_options = options.options_for_package(package)
@@ -72,6 +82,8 @@ module FriendlyShipping
             end
           end
 
+          # @param packages [Array<Physical::Package>]
+          # @param options [LabelOptions]
           def serialize_customs(packages, options)
             {
               contents: options.customs_options.contents,
@@ -80,6 +92,8 @@ module FriendlyShipping
             }
           end
 
+          # @param weight [Measured::Weight]
+          # @return [Hash]
           def serialize_weight(weight)
             ounces = weight.convert_to(:ounce).value.to_f.round(2)
             {
@@ -91,6 +105,8 @@ module FriendlyShipping
             }
           end
 
+          # @param shipment [Physical::Shipment]
+          # @return [Boolean]
           def international?(shipment)
             shipment.origin.country != shipment.destination.country
           end

--- a/lib/friendly_shipping/services/ship_engine/serialize_rate_estimate_request.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_rate_estimate_request.rb
@@ -3,8 +3,12 @@
 module FriendlyShipping
   module Services
     class ShipEngine
+      # Serializes a shipment and options for the rate estimates API request.
       class SerializeRateEstimateRequest
         class << self
+          # @param shipment [Physical::Shipment] the shipment to serialize
+          # @param options [LabelOptions] the options to serialize
+          # @return [Hash] the serialized request
           def call(shipment:, options:)
             {
               carrier_ids: options.carrier_ids,
@@ -26,6 +30,8 @@ module FriendlyShipping
 
           private
 
+          # @param packages [Array<Physical::Package>]
+          # @return [Hash]
           def dimensions(packages)
             length = packages.map { |p| p.length.convert_to(:inch).value.to_f }.sum.round(2)
             width = packages.map { |p| p.width.convert_to(:inch).value.to_f }.sum.round(2)

--- a/lib/friendly_shipping/services/ship_engine/serialize_rates_request.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_rates_request.rb
@@ -3,8 +3,12 @@
 module FriendlyShipping
   module Services
     class ShipEngine
+      # Serializes a shipment and options for the rates API request.
       class SerializeRatesRequest
         class << self
+          # @param shipment [Physical::Shipment] the shipment to serialize
+          # @param options [LabelOptions] the options to serialize
+          # @return [Hash] the serialized request
           def call(shipment:, options:)
             rates_hash = {
               shipment: {
@@ -36,6 +40,8 @@ module FriendlyShipping
 
           private
 
+          # @param package [Physical::Package]
+          # @return [Array<Hash>]
           def serialize_items(package)
             return [] unless package&.items.present?
 
@@ -49,6 +55,8 @@ module FriendlyShipping
             end
           end
 
+          # @param address [Physical::Location]
+          # @return [Hash]
           def serialize_address(address)
             {
               name: address.name,
@@ -63,6 +71,9 @@ module FriendlyShipping
             }.merge(SerializeAddressResidentialIndicator.call(address))
           end
 
+          # @param shipment [Physical::Shipment]
+          # @param options [LabelOptions]
+          # @return [Array<Hash>]
           def serialize_packages(shipment, options)
             shipment.packages.map do |package|
               {
@@ -81,6 +92,9 @@ module FriendlyShipping
             end
           end
 
+          # @param package [Physical::Package]
+          # @param options [LabelOptions]
+          # @return [Array<Hash>]
           def serialize_products(package, options)
             package.items.group_by(&:sku).map do |sku, items|
               reference_item = items.first
@@ -100,6 +114,8 @@ module FriendlyShipping
             end
           end
 
+          # @param shipment [Physical::Shipment]
+          # @return [Boolean]
           def international?(shipment)
             shipment.origin.country != shipment.destination.country
           end

--- a/lib/friendly_shipping/services/ship_engine_ltl/api_error.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/api_error.rb
@@ -5,6 +5,7 @@ require 'friendly_shipping/services/ship_engine/api_error'
 module FriendlyShipping
   module Services
     class ShipEngineLTL
+      # Raised when an API error is returned.
       class ApiError < FriendlyShipping::Services::ShipEngine::ApiError
         # not implemented
       end

--- a/lib/friendly_shipping/services/ship_engine_ltl/item_options.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/item_options.rb
@@ -3,13 +3,30 @@
 module FriendlyShipping
   module Services
     class ShipEngineLTL
+      # Item options for rate quotes.
       class ItemOptions < FriendlyShipping::ItemOptions
-        attr_reader :packaging_code,
-                    :freight_class,
-                    :nmfc_code,
-                    :stackable,
-                    :hazardous_materials
+        # @return [String] the packaging code
+        attr_reader :packaging_code
 
+        # @return [String] the freight class
+        attr_reader :freight_class
+
+        # @return [String] the NMFC code
+        attr_reader :nmfc_code
+
+        # @return [Boolean] whether the item is stackable
+        attr_reader :stackable
+
+        # @return [Boolean] whether the item contains hazardous materials
+        attr_reader :hazardous_materials
+
+        # @param packaging_code [String] the packaging code
+        # @param freight_class [String] the freight class
+        # @param nmfc_code [String] the NMFC code
+        # @param stackable [Boolean] whether the item is stackable
+        # @param hazardous_materials [Boolean] whether the item contains hazardous materials
+        # @param kwargs [Hash]
+        # @option kwargs [String] :item_id the ID for the item that belongs to these options
         def initialize(
           packaging_code: nil,
           freight_class: nil,

--- a/lib/friendly_shipping/services/ship_engine_ltl/package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/package_options.rb
@@ -5,7 +5,12 @@ require 'friendly_shipping/services/ups/label_item_options'
 module FriendlyShipping
   module Services
     class ShipEngineLTL
+      # Package options for rate quotes.
       class PackageOptions < FriendlyShipping::PackageOptions
+        # @param kwargs [Hash]
+        # @option kwargs [String] :package_id the ID for the package  that belongs to these options
+        # @option kwargs [Array<ItemOptions>] :item_options the options for items in this package
+        # @option kwargs [Class] :item_options_class the class to use for item options when none are provided
         def initialize(**kwargs)
           super(**kwargs.reverse_merge(item_options_class: ItemOptions))
         end

--- a/lib/friendly_shipping/services/ship_engine_ltl/parse_carrier_response.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/parse_carrier_response.rb
@@ -5,10 +5,14 @@ require 'json'
 module FriendlyShipping
   module Services
     class ShipEngineLTL
+      # Parses the carriers API response.
       class ParseCarrierResponse
         extend Dry::Monads::Result::Mixin
 
         class << self
+          # @param request [Request] the request to attach to the API result
+          # @param response [Response] the response to parse
+          # @return [Success<ApiResult<Array<Carrier>>>, Failure<ApiFailure<Array<String>>>] the parsed carriers or errors
           def call(request:, response:)
             parsed_json = JSON.parse(response.body)
             carriers = parsed_json.fetch('carriers', []).map do |carrier_data|

--- a/lib/friendly_shipping/services/ship_engine_ltl/parse_quote_response.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/parse_quote_response.rb
@@ -5,10 +5,14 @@ require 'json'
 module FriendlyShipping
   module Services
     class ShipEngineLTL
+      # Parses the rate quotes API response.
       class ParseQuoteResponse
         extend Dry::Monads::Result::Mixin
 
         class << self
+          # @param request [Request] the request to attach to the API result
+          # @param response [Response] the response to parse
+          # @return [Success<ApiResult<Array<Rate>>>, Failure<ApiFailure<Array<String>>>] the parsed rates or errors
           def call(request:, response:)
             parsed_json = JSON.parse(response.body)
             rates = build_rates(parsed_json)
@@ -34,6 +38,8 @@ module FriendlyShipping
 
           private
 
+          # @param parsed_json [Hash] the parsed JSON
+          # @return [Array<Rate>] the parsed rates
           def build_rates(parsed_json)
             total = build_total(parsed_json)
             return [] unless total.positive?
@@ -46,6 +52,8 @@ module FriendlyShipping
             ]
           end
 
+          # @param parsed_json [Hash] the parsed JSON
+          # @return [ShippingMethod] the parsed shipping method
           def build_shipping_method(parsed_json)
             description = parsed_json.dig("service", "carrier_description")
             code = parsed_json.dig("service", "code")
@@ -57,6 +65,8 @@ module FriendlyShipping
             )
           end
 
+          # @param parsed_json [Hash] the parsed JSON
+          # @return [Money] the parsed total charges
           def build_total(parsed_json)
             total_charges = parsed_json.fetch("charges", []).detect { |e| e['type'] == "total" }
             return 0 unless total_charges

--- a/lib/friendly_shipping/services/ship_engine_ltl/quote_options.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/quote_options.rb
@@ -5,16 +5,27 @@ require 'friendly_shipping/shipment_options'
 module FriendlyShipping
   module Services
     class ShipEngineLTL
+      # Options for rate quote requests.
       class QuoteOptions < ShipmentOptions
-        attr_reader :service_code,
-                    :pickup_date,
-                    :accessorial_service_codes,
-                    :packages_serializer_class
+        # @return [String] the service code to use when getting rates
+        attr_reader :service_code
 
-        # @param [String] service_code
-        # @param [Time] pickup_date
-        # @param [Array<String>] accessorial_service_codes
-        # @param [Class] packages_serializer_class
+        # @return [Time] the pickup date
+        attr_reader :pickup_date
+
+        # @return [Array<String>] the accessorial service codes
+        attr_reader :accessorial_service_codes
+
+        # @return [Class] the class to use for serializing packages
+        attr_reader :packages_serializer_class
+
+        # @param service_code [String] the service code to use when getting rates
+        # @param pickup_date [Time] the pickup date
+        # @param accessorial_service_codes [Array<String>] the accessorial service codes (if any)
+        # @param packages_serializer_class [Class] the class to use for serializing packages
+        # @param kwargs [Hash]
+        # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           service_code: nil,
           pickup_date: nil,

--- a/lib/friendly_shipping/services/ship_engine_ltl/serialize_packages.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/serialize_packages.rb
@@ -3,10 +3,12 @@
 module FriendlyShipping
   module Services
     class ShipEngineLTL
+      # Serializes packages for the rate quote API request.
       class SerializePackages
         class << self
-          # @param [Array<Physical::Package>] packages
-          # @param [FriendlyShipping::Services::ShipEngineLTL::QuoteOptions] options
+          # @param packages [Array<Physical::Package>]
+          # @param options [QuoteOptions]
+          # @return [Array<Hash>]
           def call(packages:, options:)
             packages.flat_map do |package|
               package_options = options.options_for_package(package)

--- a/lib/friendly_shipping/services/ship_engine_ltl/serialize_quote_request.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/serialize_quote_request.rb
@@ -3,10 +3,12 @@
 module FriendlyShipping
   module Services
     class ShipEngineLTL
+      # Serializes a shipment and options for the rate quote API request.
       class SerializeQuoteRequest
         class << self
-          # @param [Physical::Shipment] shipment
-          # @param [FriendlyShipping::Services::ShipEngineLTL::QuoteOptions] options
+          # @param shipment [Physical::Shipment] the shipment to serialize
+          # @param options [QuoteOptions] the options to serialize
+          # @return [Hash] the serialized request
           def call(shipment:, options:)
             {
               shipment: {
@@ -25,14 +27,16 @@ module FriendlyShipping
 
           private
 
-          # @param [FriendlyShipping::Services::ShipEngineLTL::QuoteOptions] options
+          # @param options [QuoteOptions]
+          # @return [Array<Hash>]
           def serialize_options(options)
             options.accessorial_service_codes.map do |code|
               { code: code }
             end
           end
 
-          # @param [Physical::Location] location
+          # @param location [Physical::Location]
+          # @return [Hash]
           def serialize_ship_address(location)
             {
               account: location.properties.with_indifferent_access['account_number'],
@@ -41,7 +45,8 @@ module FriendlyShipping
             }.compact
           end
 
-          # @param [Physical::Location] location
+          # @param location [Physical::Location]
+          # @return [Hash]
           def serialize_bill_address(location)
             {
               type: "shipper",
@@ -52,7 +57,8 @@ module FriendlyShipping
             }.compact
           end
 
-          # @param [Physical::Location] location
+          # @param location [Physical::Location]
+          # @return [Hash]
           def serialize_address(location)
             {
               company_name: location.company_name,
@@ -64,7 +70,8 @@ module FriendlyShipping
             }.compact
           end
 
-          # @param [Physical::Location] location
+          # @param location [Physical::Location]
+          # @return [Hash]
           def serialize_contact(location)
             {
               name: location.name,
@@ -73,7 +80,8 @@ module FriendlyShipping
             }.compact
           end
 
-          # @param [Physical::Location] location
+          # @param location [Physical::Location]
+          # @return [Hash]
           def serialize_requested_by(location)
             {
               company_name: location.company_name,
@@ -81,7 +89,8 @@ module FriendlyShipping
             }.compact
           end
 
-          # @param [Array<Physical::Package>] packages
+          # @param packages [Array<Physical::Package>]
+          # @return [Hash]
           def serialize_shipment_measurements(packages)
             {
               total_linear_length: {

--- a/lib/friendly_shipping/services/tforce_freight.rb
+++ b/lib/friendly_shipping/services/tforce_freight.rb
@@ -27,7 +27,7 @@ require 'friendly_shipping/services/tforce_freight/api_error'
 module FriendlyShipping
   module Services
     class TForceFreight
-      include Dry::Monads[:result]
+      include Dry::Monads::Result::Mixin
 
       # @return [AccessToken] the access token
       attr_reader :access_token

--- a/lib/friendly_shipping/services/tforce_freight/api_error.rb
+++ b/lib/friendly_shipping/services/tforce_freight/api_error.rb
@@ -5,15 +5,16 @@ require 'friendly_shipping/api_error'
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Raised when an API error is returned.
       class ApiError < FriendlyShipping::ApiError
-        # @param [RestClient::Exception] cause
+        # @param cause [RestClient::Exception]
         def initialize(cause)
           super(cause, parse_message(cause))
         end
 
         private
 
-        # @param [RestClient::Exception] error
+        # @param error [RestClient::Exception]
         # @return [String]
         def parse_message(error)
           return error.message unless error.response

--- a/lib/friendly_shipping/services/tforce_freight/bol_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/bol_options.rb
@@ -3,14 +3,16 @@
 module FriendlyShipping
   module Services
     class TForceFreight
-      # Options for creating a TForce Freight BOL
+      # Options for creating a Bill of Lading (BOL).
       class BOLOptions < FriendlyShipping::ShipmentOptions
+        # Maps friendly names to billing codes.
         BILLING_CODES = {
           prepaid: "10",
           third_party: "30",
           freight_collect: "40"
         }.freeze
 
+        # Maps friendly names to reference number codes.
         REFERENCE_NUMBER_CODES = {
           bill_of_lading_number: "BL",
           purchase_order_number: "PO",
@@ -25,6 +27,7 @@ module FriendlyShipping
           other: "OTHER"
         }.freeze
 
+        # Maps friendly names to pickup options.
         PICKUP_OPTIONS = {
           inside: "INPU",
           liftgate: "LIFO",
@@ -35,6 +38,7 @@ module FriendlyShipping
           residential: "RESP"
         }.freeze
 
+        # Maps friendly names to delivery options.
         DELIVERY_OPTIONS = {
           inside: "INDE",
           liftgate: "LIFD",
@@ -103,7 +107,7 @@ module FriendlyShipping
         # @param document_options [Array<DocumentOptions>] options for documents
         # @param commodity_information_generator [Proc, #call] the callable used generate commodity information
         # @param kwargs [Hash]
-        # @option kwargs [Enumerable<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this shipment
         # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           service_code: FriendlyShipping::Services::TForceFreight::SHIPPING_METHODS.first.service_code,

--- a/lib/friendly_shipping/services/tforce_freight/document_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/document_options.rb
@@ -3,6 +3,7 @@
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Options for getting documents (BOLs, labels, etc.) from the API.
       class DocumentOptions
         # @return [Symbol] the document type (see {DOCUMENT_TYPES})
         attr_reader :type
@@ -19,16 +20,19 @@ module FriendlyShipping
         # @return [Integer] the number of stickers
         attr_reader :number_of_stickers
 
+        # Maps friendly names to document types.
         DOCUMENT_TYPES = {
           label: "30",
           tforce_bol: "20",
           vics_bol: "21"
         }.freeze
 
+        # Maps friendly names to document formats.
         DOCUMENT_FORMATS = {
           pdf: "01"
         }.freeze
 
+        # Maps booleans to thermal codes.
         THERMAL_CODE = {
           false => "01",
           true => "02"

--- a/lib/friendly_shipping/services/tforce_freight/generate_commodity_information.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_commodity_information.rb
@@ -3,9 +3,11 @@
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Generates a commodity information hash for JSON serialization.
       class GenerateCommodityInformation
-        # @param [Physical::Shipment] shipment
-        # @param [FriendlyShipping::Services::TForceFreight::RatesOptions] options
+        # @param shipment [Physical::Shipment] the shipment with commodities to serialize
+        # @param options [RatesOptions] the options to serialize
+        # @return [Array<Hash>] commodities hash suitable for JSON request
         def self.call(shipment:, options:)
           shipment.packages.flat_map do |package|
             package_options = options.options_for_package(package)

--- a/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
@@ -5,12 +5,12 @@ require 'friendly_shipping/services/tforce_freight/generate_location_hash'
 module FriendlyShipping
   module Services
     class TForceFreight
-      # Generate a TForceFreight BOL request hash for JSON serialization.
+      # Generates a Bill of Lading (BOL) request hash for JSON serialization.
       class GenerateCreateBOLRequestHash
         class << self
           # @param shipment [Physical::Shipment] the shipment for which we want to create a BOL
           # @param options [BOLOptions] options for the BOL
-          # @return [Hash]
+          # @return [Hash] BOL request hash
           def call(shipment:, options:)
             {
               requestOptions: request_options(options),
@@ -82,6 +82,7 @@ module FriendlyShipping
           end
 
           # @param location [Physical::Location]
+          # @return [String, nil]
           def address_line(location)
             [
               location.address1,

--- a/lib/friendly_shipping/services/tforce_freight/generate_document_options_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_document_options_hash.rb
@@ -3,9 +3,10 @@
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Generates a document options hash for JSON serialization.
       class GenerateDocumentOptionsHash
-        # @param document_options [DocumentOptions]
-        # @return [Hash]
+        # @param document_options [DocumentOptions] the document options
+        # @return [Hash] document options hash suitable for JSON request
         def self.call(document_options:)
           {
             type: document_options.document_type_code,

--- a/lib/friendly_shipping/services/tforce_freight/generate_handling_units_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_handling_units_hash.rb
@@ -3,11 +3,12 @@
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Generates a handling units hash for JSON serialization.
       class GenerateHandlingUnitsHash
         class << self
           # @param shipment [Physical::Shipment]
           # @param options [FriendlyShipping::ShipmentOptions]
-          # @return [Hash]
+          # @return [Hash] handling units hash suitable for JSON request
           def call(shipment:, options:)
             handling_units(shipment, options).reduce(&:merge)
           end

--- a/lib/friendly_shipping/services/tforce_freight/generate_location_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_location_hash.rb
@@ -3,8 +3,11 @@
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Generates a location hash for JSON serialization.
       class GenerateLocationHash
         class << self
+          # @param location [Physical::Location] the location
+          # @return [Hash] location hash suitable for JSON request
           def call(location:)
             {
               address: {

--- a/lib/friendly_shipping/services/tforce_freight/generate_pickup_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_pickup_request_hash.rb
@@ -5,12 +5,12 @@ require 'friendly_shipping/services/tforce_freight/generate_location_hash'
 module FriendlyShipping
   module Services
     class TForceFreight
-      # Generate a TForceFreight pickup request hash for JSON serialization.
+      # Generates a pickup request hash for JSON serialization.
       class GeneratePickupRequestHash
         class << self
           # @param shipment [Physical::Shipment] the shipment for which we want to create a pickup request
           # @param options [PickupOptions] options for the pickup request
-          # @return [Hash]
+          # @return [Hash] pickup request hash
           def call(shipment:, options:)
             {
               pickup: pickup(options),

--- a/lib/friendly_shipping/services/tforce_freight/generate_rates_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_rates_request_hash.rb
@@ -5,10 +5,12 @@ require 'friendly_shipping/services/tforce_freight/generate_location_hash'
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Generates a rates request hash for JSON serialization.
       class GenerateRatesRequestHash
         class << self
-          # @param [Physical::Shipment] shipment The shipment for which we want to get rates
-          # @param [FriendlyShipping::Services::TForceFreight::RatesOptions] options Options for obtaining rates for this shipment
+          # @param shipment [Physical::Shipment] the shipment for which we want to get rates
+          # @param options [RatesOptions] options for obtaining rates for this shipment
+          # @return [Hash] rates request hash
           def call(shipment:, options:)
             {
               requestOptions: request_options(options),
@@ -22,6 +24,8 @@ module FriendlyShipping
 
           private
 
+          # @param options [RatesOptions]
+          # @return [Hash]
           def request_options(options)
             {
               serviceCode: options.shipping_method.service_code,
@@ -37,6 +41,8 @@ module FriendlyShipping
             }.compact
           end
 
+          # @param options [RatesOptions]
+          # @return [Hash]
           def payment(options)
             {
               payer: GenerateLocationHash.call(location: options.billing_address),
@@ -44,6 +50,8 @@ module FriendlyShipping
             }
           end
 
+          # @param options [RatesOptions]
+          # @return [Hash]
           def service_options(options)
             {
               pickup: options.pickup_options,

--- a/lib/friendly_shipping/services/tforce_freight/generate_reference_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_reference_hash.rb
@@ -3,6 +3,7 @@
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Generates a reference hash for JSON serialization.
       class GenerateReferenceHash
         class << self
           # @param reference_numbers [Array] reference numbers for the Bill of Lading

--- a/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
@@ -7,12 +7,12 @@ require 'friendly_shipping/services/tforce_freight/shipping_methods'
 module FriendlyShipping
   module Services
     class TForceFreight
-      # Parse a TForce Freight BOL response JSON into an ApiResult.
+      # Parses a Bill of Lading (BOL) response into an `ApiResult`.
       class ParseCreateBOLResponse
         class << self
           # @param request [Request] the original request
           # @param response [RestClient::Response] the response to parse
-          # @return [ApiResult<Hash>] the parsed result
+          # @return [ApiResult<ShipmentInformation>] the parsed result
           def call(request:, response:)
             json = JSON.parse(response.body)
 
@@ -74,6 +74,8 @@ module FriendlyShipping
 
           private
 
+          # @param rate_detail [Hash]
+          # @return [Hash]
           def build_cost_breakdown(rate_detail)
             {
               "Rates" => rate_detail["rate"].each_with_object({}) do |rate, hash|

--- a/lib/friendly_shipping/services/tforce_freight/parse_pickup_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_pickup_response.rb
@@ -7,7 +7,7 @@ require 'friendly_shipping/services/tforce_freight/shipping_methods'
 module FriendlyShipping
   module Services
     class TForceFreight
-      # Parse a TForce Freight pickup response JSON into an ApiResult.
+      # Parses a pickup response into an `ApiResult`.
       class ParsePickupResponse
         class << self
           # @param request [Request] the original request

--- a/lib/friendly_shipping/services/tforce_freight/parse_rates_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_rates_response.rb
@@ -7,8 +7,12 @@ require 'friendly_shipping/services/tforce_freight/shipping_methods'
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Parses a rates response into an `ApiResult`.
       class ParseRatesResponse
         class << self
+          # @param request [Request] the original request
+          # @param response [RestClient::Response] the response to parse
+          # @return [ApiResult<Array<Rate>>] the parsed result
           def call(request:, response:)
             json = JSON.parse(response.body)
             transaction_id = json.dig("summary", "transactionReference", "transactionId")

--- a/lib/friendly_shipping/services/tforce_freight/parse_shipment_document.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_shipment_document.rb
@@ -5,9 +5,13 @@ require 'friendly_shipping/services/ups_freight/shipment_document'
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Parses shipment document JSON into a `ShipmentDocument`.
       class ParseShipmentDocument
+        # Maps document types to friendly names.
         REVERSE_DOCUMENT_TYPES = DocumentOptions::DOCUMENT_TYPES.map(&:reverse_each).to_h(&:to_a)
 
+        # @param image_data [Hash] the shipping document JSON
+        # @return [ShipmentDocument] the parsed shipment document
         def self.call(image_data:)
           type_code = image_data["type"]
           format = image_data["format"]

--- a/lib/friendly_shipping/services/tforce_freight/pickup_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/pickup_options.rb
@@ -3,9 +3,9 @@
 module FriendlyShipping
   module Services
     class TForceFreight
-      # Options for creating a TForce Freight pickup request
+      # Options for creating a pickup.
       class PickupOptions < FriendlyShipping::ShipmentOptions
-        # Service options for pickups
+        # Maps friendly names to service options.
         SERVICE_OPTIONS = {
           inside: "INPU",
           liftgate: "LIFO",
@@ -21,7 +21,7 @@ module FriendlyShipping
         # @return [Range] time window for pickup
         attr_reader :pickup_time_window
 
-        # @return [Array<String>] shipment pickup service options
+        # @return [Array<String>] shipment pickup service options (see {SERVICE_OPTIONS})
         attr_reader :service_options
 
         # @return [String] instructions for pickup
@@ -35,12 +35,12 @@ module FriendlyShipping
 
         # @param pickup_at [Time] date/time of pickup (defaults to now)
         # @param pickup_time_window [Range] time window for pickup (defaults to start/end of today)
-        # @param service_options [Array<String>] shipment pickup service options
+        # @param service_options [Array<String>] shipment pickup service options (see {SERVICE_OPTIONS})
         # @param pickup_instructions [String] instructions for pickup
         # @param handling_instructions [String] instructions for handling
         # @param delivery_instructions [String] instructions for delivery
         # @param kwargs [Hash]
-        # @option kwargs [Enumerable<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this shipment
         # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           pickup_at: Time.now,

--- a/lib/friendly_shipping/services/tforce_freight/rates_item_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_item_options.rb
@@ -3,14 +3,9 @@
 module FriendlyShipping
   module Services
     class TForceFreight
-      # Options for Items in a TForce Freight shipment
-      #
-      # @attribute [Symbol] packaging
-      # @attribute [String] freight_class
-      # @attribute [String] nmfc_primary_code
-      # @attribute [String] nmfc_sub_code
-      # @attribute [Boolean] hazardous
+      # Options for items in a shipment.
       class RatesItemOptions < FriendlyShipping::ItemOptions
+        # Maps friendly names to packaging types.
         PACKAGING_TYPES = {
           bag: { code: "BAG", description: "Bag" },
           bale: { code: "BAL", description: "Bale" },
@@ -51,13 +46,25 @@ module FriendlyShipping
           wrapped: { code: "WRP", description: "Wrapped" }
         }.freeze
 
-        attr_reader :packaging_code,
-                    :packaging_description,
-                    :freight_class,
-                    :nmfc_primary_code,
-                    :nmfc_sub_code,
-                    :hazardous
+        attr_reader :packaging_code
 
+        attr_reader :packaging_description
+
+        attr_reader :freight_class
+
+        attr_reader :nmfc_primary_code
+
+        attr_reader :nmfc_sub_code
+
+        attr_reader :hazardous
+
+        # @param packaging [Symbol] this item's packaging
+        # @param freight_class [String] the freight class
+        # @param nmfc_primary_code [String] the NMFC primary code
+        # @param nmfc_sub_code [String] the NMFC sub code
+        # @param hazardous [Boolean] whether or not the item is hazardous
+        # @param kwargs [Hash]
+        # @option kwargs [String] :item_id the ID for the item that belongs to these options
         def initialize(
           packaging: :carton,
           freight_class: nil,

--- a/lib/friendly_shipping/services/tforce_freight/rates_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_options.rb
@@ -6,37 +6,23 @@ require 'friendly_shipping/services/tforce_freight/generate_commodity_informatio
 module FriendlyShipping
   module Services
     class TForceFreight
-      # Options for generating TForce Freight rates for a shipment
-      #
-      # @attribute [Physical::Location] billing_address The billing address
-      # @attribute [FriendlyShipping::ShippingMethod] shipping_method The shipping method to use
-      # @attribute [Date] pickup_date Date of the Pickup. Defaults to today.
-      # @attribute [Symbol] billing One of the keys in the `BILLING_CODES` constant. How the shipment
-      #     would be billed.
-      # @attribute [String] type Rating call type. Possible values are L, F, or B. Defaults to L.
-      # @attribute [Boolean] density_eligible Indicates that the rate request is density based. Defaults to `false`
-      # @attribute [Boolean] accessorial_rate Indicates that the rate is accessorial. Defaults to `false`
-      # @attribute [Boolean] time_in_transit Requests transit timing information be included in the response. Defaults to `true`
-      # @attribute [Boolean] quote_number Requests a quote number be included in the response. Defaults to `false`
-      # @attribute [String] customer_context A reference to match this request with an order or shipment. Defaults to `nil`
-      # @attribute [Array<String>] pickup_options Shipment pick up service options
-      # @attribute [Array<String] delivery_options Shipment delivery service options
-      # @attribute [Callable] commodity_information_generator A callable that takes a shipment
-      #     and an options object to create an Array of commodity fields as per the UPS docs.
-      # @attribute [RatesPackageOptions] package_options Options for each of the packages/pallets in this shipment
+      # Options for getting rates for a shipment.
       class RatesOptions < FriendlyShipping::ShipmentOptions
+        # Maps friendly names to billing codes.
         BILLING_CODES = {
           prepaid: "10",
           third_party: "30",
           freight_collect: "40"
         }.freeze
 
+        # Maps friendly names to type codes.
         TYPE_CODES = {
           l: "L", # LTL (Less Than Truckload) only
           f: "F", # GFP (Ground w/Freight Pricing) only
           b: "B"  # Both (LTL and GFP)
         }.freeze
 
+        # Maps friendly names to pickup options.
         PICKUP_OPTIONS = {
           inside: "INPU",
           liftgate: "LIFO",
@@ -47,6 +33,7 @@ module FriendlyShipping
           residential: "RESP"
         }.freeze
 
+        # Maps friendly names to delivery options.
         DELIVERY_OPTIONS = {
           inside: "INDE",
           liftgate: "LIFD",
@@ -58,20 +45,62 @@ module FriendlyShipping
           residential: "RESD"
         }.freeze
 
-        attr_reader :billing_address,
-                    :shipping_method,
-                    :pickup_date,
-                    :billing_code,
-                    :type_code,
-                    :density_eligible,
-                    :accessorial_rate,
-                    :time_in_transit,
-                    :quote_number,
-                    :pickup_options,
-                    :delivery_options,
-                    :customer_context,
-                    :commodity_information_generator
+        # @return [Physical::Location] the billing address
+        attr_reader :billing_address
 
+        # @return [ShippingMethod] the shipping method
+        attr_reader :shipping_method
+
+        # @return [Date] date of the pickup
+        attr_reader :pickup_date
+
+        # @return [Symbol] how the shipment is billed (see {BILLING_CODES})
+        attr_reader :billing_code
+
+        # @return [String] rating call type (see {TYPE_CODES})
+        attr_reader :type_code
+
+        # @return [Boolean] indicates that the rate request is density based
+        attr_reader :density_eligible
+
+        # @return [Boolean] indicates that the rate is accessorial
+        attr_reader :accessorial_rate
+
+        # @return [Boolean] requests transit timing information be included in the response
+        attr_reader :time_in_transit
+
+        # @return [Boolean] requests a quote number be included in the response
+        attr_reader :quote_number
+
+        # @return [Array<String>] shipment pick up service options (see {PICKUP_OPTIONS})
+        attr_reader :pickup_options
+
+        # @return [Array<String] shipment delivery service options (see {DELIVERY_OPTIONS})
+        attr_reader :delivery_options
+
+        # @return [String] customer context
+        attr_reader :customer_context
+
+        # @return [Callable] a callable that takes a shipment
+        attr_reader :commodity_information_generator
+
+        # @param billing_address [Physical::Location] the billing address
+        # @param shipping_method [ShippingMethod] the shipping method to use
+        # @param pickup_date [Date] date of the pickup (defaults to today)
+        # @param billing [Symbol] how the shipment is billed (see {BILLING_CODES})
+        # @param type [String] rating call type (defaults to L, see {TYPE_CODES})
+        # @param density_eligible [Boolean] indicates that the rate request is density based (defaults to `false`)
+        # @param accessorial_rate [Boolean] indicates that the rate is accessorial (defaults to `false`)
+        # @param time_in_transit [Boolean] requests transit timing information be included in the response (defaults to `true`)
+        # @param quote_number [Boolean] requests a quote number be included in the response (defaults to `false`)
+        # @param pickup_options [Array<String>] shipment pick up service options (see {PICKUP_OPTIONS})
+        # @param delivery_options [Array<String] shipment delivery service options (see {DELIVERY_OPTIONS})
+        # @param customer_context [String] a reference to match this request with an order or shipment (defaults to `nil`)
+        # @param commodity_information_generator [Callable] a callable that takes a shipment
+        #     and an options object to create an `Array` of commodity fields as per the UPS docs
+        # @param kwargs [Hash]
+        # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           billing_address:,
           shipping_method:,
@@ -110,6 +139,8 @@ module FriendlyShipping
 
         private
 
+        # @raise [ArgumentError] invalid pickup options
+        # @return [nil]
         def validate_pickup_options!
           invalid_options = (pickup_options - PICKUP_OPTIONS.values)
           return unless invalid_options.any?
@@ -117,6 +148,8 @@ module FriendlyShipping
           raise ArgumentError, "Invalid pickup option(s): #{invalid_options.join(', ')}"
         end
 
+        # @raise [ArgumentError] invalid delivery options
+        # @return [nil]
         def validate_delivery_options!
           invalid_options = (delivery_options - DELIVERY_OPTIONS.values)
           return unless invalid_options.any?

--- a/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
@@ -5,8 +5,9 @@ require 'friendly_shipping/services/tforce_freight/rates_item_options'
 module FriendlyShipping
   module Services
     class TForceFreight
-      # Options for packages/pallets within a TForce Freight shipment
+      # Options for packages/pallets in a shipment.
       class RatesPackageOptions < FriendlyShipping::PackageOptions
+        # Maps friendly names to handling unit types.
         HANDLING_UNIT_TYPES = {
           pallet: { code: "PLT", description: "Pallet", handling_unit_tag: 'One' },
           skid: { code: "SKD", description: "Skid", handling_unit_tag: 'One' },
@@ -16,10 +17,20 @@ module FriendlyShipping
           loose: { code: "LOO", description: "Loose", handling_unit_tag: 'Two' }
         }.freeze
 
-        attr_reader :handling_unit_description,
-                    :handling_unit_tag,
-                    :handling_unit_code
+        # @return [String] the handling unit description
+        attr_reader :handling_unit_description
 
+        # @return [String] the handling unit tag
+        attr_reader :handling_unit_tag
+
+        # @return [String] the handling unit code
+        attr_reader :handling_unit_code
+
+        # @param handling_unit [Symbol] the handling unit for this package/pallet
+        # @param kwargs [Hash]
+        # @option kwargs [String] :package_id the ID for the package  that belongs to these options
+        # @option kwargs [Array<ItemOptions>] :item_options the options for items in this package
+        # @option kwargs [Class] :item_options_class the class to use for item options when none are provided
         def initialize(
           handling_unit: :pallet,
           **kwargs

--- a/lib/friendly_shipping/services/tforce_freight/shipment_document.rb
+++ b/lib/friendly_shipping/services/tforce_freight/shipment_document.rb
@@ -3,9 +3,24 @@
 module FriendlyShipping
   module Services
     class TForceFreight
+      # A shipping document (BOL, label, etc.) returned by the API.
       class ShipmentDocument
-        attr_reader :document_type, :document_format, :binary, :status
+        # @return [String] the type of document
+        attr_reader :document_type
 
+        # @return [String] the format of the document
+        attr_reader :document_format
+
+        # @return [String] the document's binary data
+        attr_reader :binary
+
+        # @return [String] the status of the document
+        attr_reader :status
+
+        # @param document_type [String] the type of document
+        # @param document_format [String] the format of the document
+        # @param binary [String] the document's binary data
+        # @param status [String] the status of the document (defaults to `nil`)
         def initialize(
           document_type:,
           document_format:,

--- a/lib/friendly_shipping/services/tforce_freight/shipment_information.rb
+++ b/lib/friendly_shipping/services/tforce_freight/shipment_information.rb
@@ -3,22 +3,64 @@
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Information for a specific shipment returned by the API.
       class ShipmentInformation
-        attr_reader :documents,
-                    :bol_id,
-                    :pro_number,
-                    :origin_service_center,
-                    :email_sent,
-                    :origin_is_rural,
-                    :destination_is_rural,
-                    :rates,
-                    :total_charges,
-                    :billable_weight,
-                    :days_in_transit,
-                    :shipping_method,
-                    :warnings,
-                    :data
+        # @return [String] the shipment's BOL ID number
+        attr_reader :bol_id
 
+        # @return [String] the shipment's PRO number
+        attr_reader :pro_number
+
+        # @return [String] the origin service center
+        attr_reader :origin_service_center
+
+        # @return [Boolean] whether or not the email was sent
+        attr_reader :email_sent
+
+        # @return [Boolean] whether or not the origin is rural
+        attr_reader :origin_is_rural
+
+        # @return [Boolean] whether or not the destination is rural
+        attr_reader :destination_is_rural
+
+        # @return [Array<Hash>] the rates
+        attr_reader :rates
+
+        # @return [Money] the total charges for this shipment
+        attr_reader :total_charges
+
+        # @return [Measured::Weight] the billable weight for this shipment
+        attr_reader :billable_weight
+
+        # @return [Integer] the number of days in transit
+        attr_reader :days_in_transit
+
+        # @return [Array<ShipmentDocument>] the shipment's documents (BOL, labels, etc)
+        attr_reader :documents
+
+        # @return [ShippingMethod] the shipping method
+        attr_reader :shipping_method
+
+        # @return [Array<String>] any warnings
+        attr_reader :warnings
+
+        # @return [Hash] any additional data
+        attr_reader :data
+
+        # @param bol_id [String] the shipment's BOL ID number
+        # @param pro_number [String] the shipment's PRO number
+        # @param origin_service_center [String] the origin service center
+        # @param email_sent [Boolean] whether or not the email was sent
+        # @param origin_is_rural [Boolean] whether or not the origin is rural
+        # @param destination_is_rural [Boolean] whether or not the destination is rural
+        # @param rates [Array<Hash>] the rates
+        # @param total_charges [Money] the total charges for this shipment
+        # @param billable_weight [Measured::Weight] the billable weight for this shipment
+        # @param days_in_transit [Integer] the number of days in transit
+        # @param documents [Array<ShipmentDocument>] the shipment's documents (BOL, labels, etc)
+        # @param shipping_method [ShippingMethod] the shipping method
+        # @param warnings [Array<String>] any warnings
+        # @param data [Hash] any additional data
         def initialize(
           bol_id:,
           pro_number: nil,

--- a/lib/friendly_shipping/services/ups.rb
+++ b/lib/friendly_shipping/services/ups.rb
@@ -27,7 +27,7 @@ require 'friendly_shipping/services/ups/timing_options'
 module FriendlyShipping
   module Services
     class Ups
-      include Dry::Monads[:result]
+      include Dry::Monads::Result::Mixin
 
       attr_reader :test, :key, :login, :password, :client
 

--- a/lib/friendly_shipping/services/ups/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_rate_response.rb
@@ -92,7 +92,7 @@ module FriendlyShipping
 
           # @param [Nokogiri::XML::NodeSet] node The RateModifier node set from the source XML
           # @param [String] currency_code The currency code for the modifier amounts (i.e. 'USD')
-          # @param [Array<Hash>]
+          # @return [Array<Hash>]
           def extract_modifiers(node, currency_code:)
             node.map do |element|
               ParseModifierElement.call(element, currency_code: currency_code)

--- a/lib/friendly_shipping/services/ups_freight.rb
+++ b/lib/friendly_shipping/services/ups_freight.rb
@@ -23,7 +23,7 @@ require 'friendly_shipping/services/ups_freight/api_error'
 module FriendlyShipping
   module Services
     class UpsFreight
-      include Dry::Monads[:result]
+      include Dry::Monads::Result::Mixin
 
       attr_reader :test, :key, :login, :password, :client
 

--- a/lib/friendly_shipping/services/usps.rb
+++ b/lib/friendly_shipping/services/usps.rb
@@ -16,7 +16,7 @@ require 'friendly_shipping/services/usps/rate_estimate_options'
 module FriendlyShipping
   module Services
     class Usps
-      include Dry::Monads[:result]
+      include Dry::Monads::Result::Mixin
 
       attr_reader :test, :login, :client
 

--- a/lib/friendly_shipping/services/usps/choose_package_rate.rb
+++ b/lib/friendly_shipping/services/usps/choose_package_rate.rb
@@ -12,8 +12,8 @@ module FriendlyShipping
         # Select the corresponding rate for a package from all the rates USPS returns to us
         #
         # @param [FriendlyShipping::ShippingMethod] shipping_method The shipping method we want to filter by
-        # @param [Physical::Package] package The package we want to match with a rate
-        # @param [Array<FriendlyShipping::Rate>] The rates we select from
+        # @param [Array<FriendlyShipping::Rate>] rates The rates we select from
+        # @param [FriendlyShipping::PackageOptions] package_options The package options we want to match with a rate
         #
         # @return [FriendlyShipping::Rate] The rate that most closely matches our package
         def self.call(shipping_method, rates, package_options)

--- a/lib/friendly_shipping/services/usps/machinable_package.rb
+++ b/lib/friendly_shipping/services/usps/machinable_package.rb
@@ -21,7 +21,7 @@ module FriendlyShipping
 
         MAX_WEIGHT = Measured::Weight(25, :pounds)
 
-        # @param [Physical::Package]
+        # @param [Physical::Package] package
         def initialize(package)
           @package = package
         end

--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -15,7 +15,7 @@ module FriendlyShipping
           # @param [String] login The USPS login code
           # @param [FriendlyShipping::Services::Usps::RateEstimateOptions] options The options
           #   object to use with this request.
-          # @return Array<[FriendlyShipping::Rate]> A set of Rates that this package may be sent with
+          # @return [Array<FriendlyShipping::Rate>] A set of Rates that this package may be sent with
           def call(shipment:, login:, options:)
             xml_builder = Nokogiri::XML::Builder.new do |xml|
               xml.RateV4Request('USERID' => login) do

--- a/lib/friendly_shipping/services/usps_international.rb
+++ b/lib/friendly_shipping/services/usps_international.rb
@@ -9,7 +9,7 @@ require 'friendly_shipping/services/usps_international/rate_estimate_options'
 module FriendlyShipping
   module Services
     class UspsInternational
-      include Dry::Monads[:result]
+      include Dry::Monads::Result::Mixin
 
       attr_reader :test, :login, :client
 

--- a/lib/friendly_shipping/services/usps_international/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps_international/serialize_rate_request.rb
@@ -13,7 +13,7 @@ module FriendlyShipping
           # @param [String] login The USPS login code
           # @param [FriendlyShipping::Services::UspsInternational::RateEstimateOptions] options The options
           #   object to use with this request.
-          # @return Array<[FriendlyShipping::Rate]> A set of Rates that this package may be sent with
+          # @return [Array<FriendlyShipping::Rate>] A set of Rates that this package may be sent with
           def call(shipment:, login:, options:)
             xml_builder = Nokogiri::XML::Builder.new do |xml|
               xml.IntlRateV2Request('USERID' => login) do

--- a/lib/friendly_shipping/shipment_options.rb
+++ b/lib/friendly_shipping/shipment_options.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Base class for shipment options. Used when serializing API requests.
   class ShipmentOptions
+    # @param package_options [Array<PackageOptions>] the options for packages in this shipment
+    # @param package_options_class [Class] the class to use for package options when none are provided
     def initialize(
       package_options: Set.new,
       package_options_class: PackageOptions
@@ -10,6 +13,11 @@ module FriendlyShipping
       @package_options_class = package_options_class
     end
 
+    # Finds and returns package options for the given item. If options cannot be
+    # found, the `package_options_class` is used to construct new options.
+    #
+    # @param package [#id] the package for which to get options
+    # @return [PackageOptions]
     def options_for_package(package)
       package_options.detect do |package_option|
         package_option.package_id == package.id
@@ -18,6 +26,10 @@ module FriendlyShipping
 
     private
 
-    attr_reader :package_options, :package_options_class
+    # @return [Array<PackageOptions>]
+    attr_reader :package_options
+
+    # @return [Class]
+    attr_reader :package_options_class
   end
 end

--- a/lib/friendly_shipping/shipping_method.rb
+++ b/lib/friendly_shipping/shipping_method.rb
@@ -1,17 +1,31 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Represents a shipping method (UPS Ground, USPS Priority, etc.) that belongs to a {Carrier}.
   class ShippingMethod
-    attr_reader :name, :service_code, :carrier, :origin_countries, :data
+    # @return [String] the shipping method's name
+    attr_reader :name
 
-    # @param [String] name The shipping method's name
-    # @param [String] service_code The shipping method's service code
-    # @param [Boolean] domestic Whether this is a domestic shipping method
-    # @param [Boolean] international Whether this is an international shipping method
-    # @param [Boolean] multi_package Whether this is a multi-package shipping method
-    # @param [FriendlyShipping::Carrier] carrier This shipping method's carrier
-    # @param [Array] origin_countries Countries this shipping method ships from
-    # @param [Hash] data Additional carrier-specific data for this shipping method
+    # @return [String] the shipping method's service code
+    attr_reader :service_code
+
+    # @return [Carrier] this shipping method's carrier
+    attr_reader :carrier
+
+    # @return [Array<String>] countries this shipping method ships from
+    attr_reader :origin_countries
+
+    # @return [Hash] additional carrier-specific data for this shipping method
+    attr_reader :data
+
+    # @param name [String] the shipping method's name
+    # @param service_code [String] the shipping method's service code
+    # @param domestic [Boolean] whether this is a domestic shipping method
+    # @param international [Boolean] whether this is an international shipping method
+    # @param multi_package [Boolean] whether this is a multi-package shipping method
+    # @param carrier [Carrier] this shipping method's carrier
+    # @param origin_countries [Array] countries this shipping method ships from
+    # @param data [Hash] additional carrier-specific data for this shipping method
     def initialize(
       name: nil,
       service_code: nil,
@@ -32,20 +46,33 @@ module FriendlyShipping
       @data = data
     end
 
+    # Returns true if this is a domestic shipping method.
+    # @return [Boolean]
     def domestic?
       !!domestic
     end
 
+    # Returns true if this is an international shipping method.
+    # @return [Boolean]
     def international?
       !!international
     end
 
+    # Returns true if this shipping method supports multiple packages.
+    # @return [Boolean]
     def multi_package?
       !!multi_package
     end
 
     private
 
-    attr_reader :domestic, :international, :multi_package
+    # @return [Boolean]
+    attr_reader :domestic
+
+    # @return [Boolean]
+    attr_reader :international
+
+    # @return [Boolean]
+    attr_reader :multi_package
   end
 end

--- a/lib/friendly_shipping/timing.rb
+++ b/lib/friendly_shipping/timing.rb
@@ -1,24 +1,40 @@
 # frozen_string_literal: true
 
 module FriendlyShipping
+  # Base class for a transit timing estimate returned by a carrier API.
   class Timing
-    attr_reader :shipping_method,
-                :pickup,
-                :delivery,
-                :guaranteed,
-                :warnings,
-                :errors,
-                :properties,
-                :data
+    # @return [ShippingMethod] this timing's shipping method
+    attr_reader :shipping_method
 
-    # @param [FriendlyShipping::ShippingMethod] shipping_method The timing's shipping method
-    # @param [Time] pickup The pickup date for the timing
-    # @param [Time] delivery The delivery date for the timing
-    # @param [Boolean] guaranteed Whether the delivery date is guaranteed
-    # @param [Array] warnings Any warnings that were generated
-    # @param [Array] errors Any errors that were generated
-    # @param [Hash] properties Additional properties related to the timing (DEPRECATED: use `data` instead)
-    # @param [Hash] data Additional data related to the timing
+    # @return [Time] the pickup estimate
+    attr_reader :pickup
+
+    # @return [Time] the delivery estimate
+    attr_reader :delivery
+
+    # @return [Boolean] whether the delivery estimate is guaranteed
+    attr_reader :guaranteed
+
+    # @return [Array] any warnings that were generated
+    attr_reader :warnings
+
+    # @return [Array] any errors that were generated
+    attr_reader :errors
+
+    # @return [Hash] additional data related to the timing (DEPRECATED: use `data` instead)
+    attr_reader :properties
+
+    # @return [Hash] additional data related to the timing
+    attr_reader :data
+
+    # @param shipping_method [ShippingMethod] this timing's shipping method
+    # @param pickup [Time] the pickup estimate
+    # @param delivery [Time] the delivery estimate
+    # @param guaranteed [Boolean] whether the delivery estimate is guaranteed
+    # @param warnings [Array] any warnings that were generated
+    # @param errors [Array] any errors that were generated
+    # @param properties [Hash] additional data related to the timing
+    # @param data [Hash] additional data related to the timing (DEPRECATED: use `data` instead)
     def initialize(
       shipping_method:,
       pickup:,
@@ -39,6 +55,8 @@ module FriendlyShipping
       warn "[DEPRECATION] `properties` is deprecated.  Please use `data` instead." if properties.present?
     end
 
+    # Calculates and returns the time between pickup and delivery.
+    # @return [Time]
     def time_in_transit
       delivery - pickup
     end


### PR DESCRIPTION
This creates a `.yardopts` file with sensible defaults and adds YARD docs to these classes:

- [x] Base classes
- [x] R+L Carriers
- [x] ShipEngine
- [x] ShipEngine LTL
- [x] TForce Freight