### PR TITLE
Add TForce endpoint to create access token

### DIFF
--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "dry-monads", "~> 1.0"
+  spec.add_runtime_dependency "jwt", "~> 2.7"
   spec.add_runtime_dependency "money", "~> 6.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.6"
   spec.add_runtime_dependency "physical", "~> 0.5", ">= 0.5.1"

--- a/lib/friendly_shipping/services/tforce_freight.rb
+++ b/lib/friendly_shipping/services/tforce_freight.rb
@@ -106,6 +106,8 @@ module FriendlyShipping
         end
       end
 
+      alias_method :rate_estimates, :rates
+
       private
 
       def build_request(action, payload, debug)

--- a/lib/friendly_shipping/services/tforce_freight.rb
+++ b/lib/friendly_shipping/services/tforce_freight.rb
@@ -2,6 +2,7 @@
 
 require 'dry/monads'
 require 'friendly_shipping/http_client'
+require 'friendly_shipping/services/tforce_freight/access_token'
 require 'friendly_shipping/services/tforce_freight/shipping_methods'
 require 'friendly_shipping/services/tforce_freight/rates_options'
 require 'friendly_shipping/services/tforce_freight/rates_package_options'
@@ -30,6 +31,9 @@ module FriendlyShipping
         rates: '/rating/getRate',
       }.freeze
 
+      # @param access_token [AccessToken] the access token
+      # @param test [Boolean] whether to use the test API version
+      # @param client [HttpClient] optional HTTP client to use for requests
       def initialize(access_token:, test: true, client: nil)
         @access_token = access_token
         @test = test
@@ -40,6 +44,52 @@ module FriendlyShipping
 
       def carriers
         Success([CARRIER])
+      end
+
+      # Creates an access token that can be used for future API requests.
+      # @see https://developer.tforcefreight.com/resources/integration-end-user End User Integration Guide
+      #
+      # @param token_endpoint [String] the Token Endpoint from the Application Integration section of your OAuth Client dialog
+      # @param client_id [String] the Client ID of your application from the OAuth Client dialog
+      # @param client_secret [String] the secret you created in the OAuth Client Secrets section of the OAuth Client dialog
+      # @param scope [String] the Scope value from the Application Integration section your OAuth Client dialog
+      # @param grant_type [String] defaults to "client_credentials" to indicate you wish to obtain a token representing your confidential client application
+      # @param debug [Boolean] whether to append debug information to the API result
+      # @return [ApiResult<AccessToken>] the access token
+      def create_access_token(
+        token_endpoint:,
+        client_id:,
+        client_secret:,
+        scope:,
+        grant_type: "client_credentials",
+        debug: false
+      )
+        request = FriendlyShipping::Request.new(
+          url: token_endpoint,
+          http_method: "POST",
+          body: "client_id=#{client_id}&" \
+                "client_secret=#{client_secret}&" \
+                "grant_type=#{grant_type}&" \
+                "scope=#{scope}",
+          headers: {
+            Content_Type: "application/x-www-form-urlencoded",
+            Accept: "application/json"
+          },
+          debug: debug
+        )
+        client.post(request).fmap do |response|
+          hash = JSON.parse(response.body)
+          FriendlyShipping::ApiResult.new(
+            AccessToken.new(
+              token_type: hash['token_type'],
+              expires_in: hash['expires_in'],
+              ext_expires_in: hash['ext_expires_in'],
+              raw_token: hash['access_token']
+            ),
+            original_request: request,
+            original_response: response
+          )
+        end
       end
 
       # Get rates for a shipment
@@ -67,7 +117,7 @@ module FriendlyShipping
           headers: {
             Content_Type: "application/json",
             Accept: "application/json",
-            Authorization: "Bearer #{access_token}"
+            Authorization: "Bearer #{access_token.raw_token}"
           },
           debug: debug
         )

--- a/lib/friendly_shipping/services/tforce_freight/access_token.rb
+++ b/lib/friendly_shipping/services/tforce_freight/access_token.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'jwt'
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      # Represents an access token returned by TForce Freight. The access token can be
+      # used to make API requests. Once it expires, a new token must be created.
+      class AccessToken
+        # @return [String] the token's type
+        attr_reader :token_type
+
+        # @return [Integer] the token's expiration
+        attr_reader :expires_in
+
+        # @return [Integer] the token's extended expiration
+        attr_reader :ext_expires_in
+
+        # @return [String] the raw JWT token
+        attr_reader :raw_token
+
+        # @param token_type [String] the token's type (typically "Bearer")
+        # @param expires_in [Integer] the token's expiration
+        # @param ext_expires_in [Integer] the token's extended expiration (only applicable during a service outage)
+        # @see https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/675 Service Outage Resiliency Support
+        # @param raw_token [String] the raw JWT token
+        def initialize(token_type:, expires_in:, ext_expires_in:, raw_token:)
+          @token_type = token_type
+          @expires_in = expires_in
+          @ext_expires_in = ext_expires_in
+          @raw_token = raw_token
+        end
+
+        # Decodes and returns the raw JWT token.
+        # @return [Array<Hash>] the decoded token
+        def decoded_token
+          @_decoded_token = JWT.decode(raw_token, nil, false)
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/generate_commodity_information.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_commodity_information.rb
@@ -28,7 +28,7 @@ module FriendlyShipping
                   length: item.length.convert_to(:inches).value.to_f.round(2),
                   width: item.width.convert_to(:inches).value.to_f.round(2),
                   height: item.height.convert_to(:inches).value.to_f.round(2),
-                  unit: "inches"
+                  unit: "IN"
                 }
               }
             end

--- a/lib/friendly_shipping/services/tforce_freight/generate_location_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_location_hash.rb
@@ -12,7 +12,7 @@ module FriendlyShipping
                 stateProvinceCode: location.region&.code,
                 postalCode: location.zip,
                 country: location.country&.code
-              }
+              }.compact
             }
           end
         end

--- a/lib/friendly_shipping/services/tforce_freight/generate_rates_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_rates_request_hash.rb
@@ -34,7 +34,7 @@ module FriendlyShipping
               timeInTransit: options.time_in_transit,
               quoteNumber: options.quote_number,
               customerContext: options.customer_context
-            }
+            }.compact
           end
 
           def payment(options)

--- a/spec/friendly_shipping/services/tforce_freight/access_token_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/access_token_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::AccessToken do
+  subject(:access_token) do
+    described_class.new(
+      token_type: "Bearer",
+      expires_in: 3599,
+      ext_expires_in: 3599,
+      raw_token: "XYADfw4Hz2KdN_sd8N4TzMo9"
+    )
+  end
+
+  it { is_expected.to respond_to(:token_type) }
+  it { is_expected.to respond_to(:expires_in) }
+  it { is_expected.to respond_to(:ext_expires_in) }
+  it { is_expected.to respond_to(:raw_token) }
+
+  describe "#decoded_token" do
+    subject(:decoded_token) { access_token.decoded_token }
+
+    before do
+      expect(JWT).to receive(:decode).with("XYADfw4Hz2KdN_sd8N4TzMo9", nil, false).and_return("result")
+    end
+
+    it { is_expected.to eq("result") }
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/generate_commodity_information_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_commodity_information_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCommodityInfor
               length: 1.87,
               width: 3.91,
               height: 5.81,
-              unit: "inches"
+              unit: "IN"
             },
             nmfc: {
               prime: "87700",
@@ -111,7 +111,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCommodityInfor
               length: 1.34,
               width: 3.29,
               height: 5.91,
-              unit: "inches"
+              unit: "IN"
             },
             nmfc: {
               prime: "87700",

--- a/spec/friendly_shipping/services/tforce_freight/generate_location_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_location_hash_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateLocationHash d
       )
     end
 
-    it "has all the right things" do
+    it do
       is_expected.to eq(
         address: {
           city: "Richmond",
@@ -25,6 +25,27 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateLocationHash d
           country: "US"
         }
       )
+    end
+
+    context "with missing values" do
+      let(:location) do
+        Physical::Location.new(
+          city: nil,
+          zip: "23224",
+          region: "VA",
+          country: "US"
+        )
+      end
+
+      it do
+        is_expected.to eq(
+          address: {
+            stateProvinceCode: "VA",
+            postalCode: "23224",
+            country: "US"
+          }
+        )
+      end
     end
   end
 end

--- a/spec/friendly_shipping/services/tforce_freight/generate_rates_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_rates_request_hash_spec.rb
@@ -130,6 +130,31 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateRatesRequestHa
           customerContext: "order-12345"
         )
       end
+
+      context "when values are missing" do
+        let(:options) do
+          FriendlyShipping::Services::TForceFreight::RatesOptions.new(
+            billing_address: billing_location,
+            shipping_method: FriendlyShipping::ShippingMethod.new(service_code: "308")
+          )
+        end
+
+        it do
+          is_expected.to eq(
+            {
+              serviceCode: "308",
+              pickupDate: "2024-01-05",
+              type: "L",
+              densityEligible: false,
+              gfpOptions: {
+                accessorialRate: false
+              },
+              timeInTransit: true,
+              quoteNumber: false
+            }
+          )
+        end
+      end
     end
 
     describe "shipFrom" do


### PR DESCRIPTION
This endpoint is used to create a new JWT access token. Once created, the token can be used to make additional API calls.

Tokens have a default life span of 60 mins. Once expired, a new token must be created to continue making API calls.

See https://developer.tforcefreight.com/resources/integration-end-user