### PR TITLE
Adjust TForce error parser for API errors

### DIFF
--- a/lib/friendly_shipping/services/tforce_freight/api_error.rb
+++ b/lib/friendly_shipping/services/tforce_freight/api_error.rb
@@ -19,8 +19,13 @@ module FriendlyShipping
           return error.message unless error.response
 
           parsed_json = JSON.parse(error.response.body)
-          status = parsed_json['statusCode']
-          message = parsed_json['message']
+          if parsed_json['summary'].present?
+            status = parsed_json.dig("summary", "responseStatus", "code")
+            message = parsed_json.dig("summary", "responseStatus", "message")
+          else
+            status = parsed_json['statusCode']
+            message = parsed_json['message']
+          end
           [status, message].compact.join(": ")
         rescue JSON::ParserError, KeyError => _e
           nil

--- a/spec/fixtures/tforce_freight/failure_with_api_error.json
+++ b/spec/fixtures/tforce_freight/failure_with_api_error.json
@@ -1,0 +1,12 @@
+{
+  "summary": {
+    "responseStatus": {
+      "code": "502",
+      "message": "Rate requires assistance from Customer Service (800-333-7400)"
+    },
+    "transactionReference": {
+      "transactionId": "eb3912fc-797c-430b-b17a-59a4448d7749"
+    }
+  },
+  "detail": null
+}

--- a/spec/friendly_shipping/services/tforce_freight/api_error_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/api_error_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::ApiError do
     let(:body) { File.read(File.join(gem_root, 'spec', 'fixtures', 'tforce_freight', fixture)) }
     let(:error) { RestClient::Exception.new(double(body: body)) }
 
+    context "with API error response" do
+      let(:fixture) { "failure_with_api_error.json" }
+      it { is_expected.to eq("502: Rate requires assistance from Customer Service (800-333-7400)") }
+    end
+
     context "with HTTP error response" do
       let(:fixture) { "failure_with_http_error.json" }
 

--- a/spec/friendly_shipping/services/tforce_freight/generate_rates_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_rates_request_hash_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateRatesRequestHa
       context "when values are missing" do
         let(:options) do
           FriendlyShipping::Services::TForceFreight::RatesOptions.new(
+            pickup_date: Date.parse("2024-01-05"),
             billing_address: billing_location,
             shipping_method: FriendlyShipping::ShippingMethod.new(service_code: "308")
           )


### PR DESCRIPTION
As it turns out, TForce returns errors in 2 different formats. We were already parsing HTTP error responses correctly, but errors coming from the API itself have a different format. This commit updates the `ApiError` class to parse these errors correctly.