### PR TITLE
Consolidate customs items for ShipEngine

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/customs_items_serializer.rb
+++ b/lib/friendly_shipping/services/ship_engine/customs_items_serializer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class ShipEngine
+      class CustomsItemsSerializer
+        class << self
+          def call(packages, options)
+            packages.map do |package|
+              package.items.group_by(&:sku).map do |sku, items|
+                reference_item = items.first
+                package_options = options.options_for_package(package)
+                item_options = package_options.options_for_item(reference_item)
+                {
+                  sku: sku,
+                  description: reference_item.description,
+                  quantity: items.count,
+                  value: {
+                    amount: reference_item.cost.to_d,
+                    currency: reference_item.cost.currency.to_s
+                  },
+                  harmonized_tariff_code: item_options.commodity_code,
+                  country_of_origin: item_options.country_of_origin
+                }
+              end
+            end.flatten
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ship_engine/label_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_options.rb
@@ -2,6 +2,7 @@
 
 require 'friendly_shipping/shipment_options'
 require 'friendly_shipping/services/ship_engine/label_customs_options'
+require 'friendly_shipping/services/ship_engine/customs_items_serializer'
 
 module FriendlyShipping
   module Services
@@ -13,13 +14,16 @@ module FriendlyShipping
       #   obtain a URL to the label (`:url`). Default :url
       # @attribute label_image_id [String] Identifier for image uploaded to ShipEngine. Default: nil
       # @attribute package_options [Enumberable<LabelPackageOptions>] Package options for the packages in the shipment
+      # @param [Callable] customs_items_serializer A callable that takes packages and an options object
+      #   to create the customs items array for the shipment
       #
       class LabelOptions < FriendlyShipping::ShipmentOptions
         attr_reader :shipping_method,
                     :label_download_type,
                     :label_format,
                     :label_image_id,
-                    :customs_options
+                    :customs_options,
+                    :customs_items_serializer
 
         def initialize(
           shipping_method:,
@@ -27,6 +31,7 @@ module FriendlyShipping
           label_format: :pdf,
           label_image_id: nil,
           customs_options: LabelCustomsOptions.new,
+          customs_items_serializer: CustomsItemsSerializer,
           **kwargs
         )
           @shipping_method = shipping_method
@@ -34,6 +39,7 @@ module FriendlyShipping
           @label_format = label_format
           @label_image_id = label_image_id
           @customs_options = customs_options
+          @customs_items_serializer = customs_items_serializer
           super(**kwargs.reverse_merge(package_options_class: LabelPackageOptions))
         end
       end

--- a/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_label_shipment.rb
@@ -77,29 +77,8 @@ module FriendlyShipping
             {
               contents: options.customs_options.contents,
               non_delivery: options.customs_options.non_delivery,
-              customs_items: serialize_customs_items(packages, options)
+              customs_items: options.customs_items_serializer.call(packages, options)
             }
-          end
-
-          def serialize_customs_items(packages, options)
-            packages.map do |package|
-              package.items.group_by(&:sku).map do |sku, items|
-                reference_item = items.first
-                package_options = options.options_for_package(package)
-                item_options = package_options.options_for_item(reference_item)
-                {
-                  sku: sku,
-                  description: reference_item.description,
-                  quantity: items.count,
-                  value: {
-                    amount: reference_item.cost.to_d,
-                    currency: reference_item.cost.currency.to_s
-                  },
-                  harmonized_tariff_code: item_options.commodity_code,
-                  country_of_origin: item_options.country_of_origin
-                }
-              end
-            end.flatten
           end
 
           def serialize_weight(weight)

--- a/spec/friendly_shipping/services/ship_engine/customs_items_serializer_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/customs_items_serializer_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::ShipEngine::CustomsItemsSerializer do
+  subject { described_class.call([package], options) }
+
+  let(:package) { FactoryBot.build(:physical_package, items: [item], void_fill_density: Measured::Density(0, :g_ml)) }
+  let(:package_options) do
+    [
+      FriendlyShipping::Services::ShipEngine::LabelPackageOptions.new(
+        package_id: package.id,
+        package_code: :large_flat_rate_box,
+        item_options: item_options
+      )
+    ]
+  end
+  let(:item) { FactoryBot.build(:physical_item, sku: "20010", description: "Wicks", cost: Money.new(120, "CAD")) }
+  let(:item_options) do
+    [
+      FriendlyShipping::Services::ShipEngine::LabelItemOptions.new(
+        item_id: item.id,
+        commodity_code: "6116.10.0000",
+        country_of_origin: "US"
+      )
+    ]
+  end
+  let(:options) do
+    FriendlyShipping::Services::ShipEngine::LabelOptions.new(
+      shipping_method: nil,
+      label_format: :zpl,
+      package_options: package_options
+    )
+  end
+
+  it do
+    is_expected.to match(
+      [{
+        sku: "20010",
+        description: "Wicks",
+        quantity: 1,
+        value: {
+          amount: 1.20,
+          currency: "CAD"
+        },
+        harmonized_tariff_code: "6116.10.0000",
+        country_of_origin: "US"
+      }]
+    )
+  end
+end

--- a/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
@@ -26,4 +26,21 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::LabelOptions do
     subject(:customs_options) { options.customs_options }
     it { is_expected.to be_a(FriendlyShipping::Services::ShipEngine::LabelCustomsOptions) }
   end
+
+  context "customs_items_serializer" do
+    subject(:customs_items_serializer) { options.customs_items_serializer }
+
+    it { is_expected.to be(FriendlyShipping::Services::ShipEngine::CustomsItemsSerializer) }
+
+    context "can be overridden" do
+      subject(:options) do
+        described_class.new(shipping_method: double,
+                            customs_items_serializer: alternate_serializer).customs_items_serializer
+      end
+
+      let(:alternate_serializer) { Class }
+
+      it { is_expected.to eq(Class) }
+    end
+  end
 end

--- a/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_label_shipment_spec.rb
@@ -271,5 +271,22 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeLabelShipment do
         )
       )
     end
+
+    context "with a custom customs items serializer" do
+      let(:options) do
+        FriendlyShipping::Services::ShipEngine::LabelOptions.new(
+          shipping_method: shipping_method,
+          label_format: :zpl,
+          package_options: package_options,
+          customs_items_serializer: AnotherSerializer
+        )
+      end
+
+      it "calls the custom serializer" do
+        stub_const("AnotherSerializer", Class.new)
+        expect(AnotherSerializer).to receive(:call).once
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
APC has a hard limit of 35 line items per shipment. Since the most commonly ordered items are fragrance oils and they all (or mostly all) are identical for customs purposes, they can be consolidated so that the overall number of line items for the label are reduced.

This is more of a stopgap than a fix since it doesn't consider the 35 limit at all. This should catch at least 90% of the cases. This and the weight limit on the shipment combined should minimize the number of too many items failures.