### PR TITLE
Truncate zips to 5 digits for TForce

### DIFF
--- a/lib/friendly_shipping/services/tforce_freight/generate_location_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_location_hash.rb
@@ -10,7 +10,7 @@ module FriendlyShipping
               address: {
                 city: location.city,
                 stateProvinceCode: location.region&.code,
-                postalCode: location.zip,
+                postalCode: location.zip&.strip&.[](0..4),
                 country: location.country&.code
               }.compact
             }

--- a/spec/friendly_shipping/services/tforce_freight/generate_location_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_location_hash_spec.rb
@@ -47,5 +47,47 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateLocationHash d
         )
       end
     end
+
+    context "with 9 digit zip" do
+      let(:location) do
+        Physical::Location.new(
+          city: nil,
+          zip: "23224-1000",
+          region: "VA",
+          country: "US"
+        )
+      end
+
+      it do
+        is_expected.to eq(
+          address: {
+            stateProvinceCode: "VA",
+            postalCode: "23224",
+            country: "US"
+          }
+        )
+      end
+    end
+
+    context "with zip containing whitespace" do
+      let(:location) do
+        Physical::Location.new(
+          city: nil,
+          zip: "  23224  ",
+          region: "VA",
+          country: "US"
+        )
+      end
+
+      it do
+        is_expected.to eq(
+          address: {
+            stateProvinceCode: "VA",
+            postalCode: "23224",
+            country: "US"
+          }
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
TForce requires zips to be truncated to 5 digits. An API error is returned otherwise.