### PR TITLE
Add TForce create BOL service method

### DIFF
--- a/lib/friendly_shipping/services/tforce_freight/bol_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/bol_options.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      # Options for creating a TForce Freight BOL
+      class BOLOptions < FriendlyShipping::ShipmentOptions
+        BILLING_CODES = {
+          prepaid: "10",
+          third_party: "30",
+          freight_collect: "40"
+        }.freeze
+
+        REFERENCE_NUMBER_CODES = {
+          bill_of_lading_number: "BL",
+          purchase_order_number: "PO",
+          shipper_reference: "SH",
+          consignee_reference: "CO",
+          pm: "PM",
+          proj: "PROJ",
+          quote: "QUOTE",
+          sid: "SID",
+          task: "TASK",
+          vprc: "VPRC",
+          other: "OTHER"
+        }.freeze
+
+        PICKUP_OPTIONS = {
+          inside: "INPU",
+          liftgate: "LIFO",
+          limited_access: "LAPU",
+          holiday: "WHPU",
+          weekend: "WHPU",
+          tradeshow: "TRPU",
+          residential: "RESP"
+        }.freeze
+
+        DELIVERY_OPTIONS = {
+          inside: "INDE",
+          liftgate: "LIFD",
+          limited_access: "LADL",
+          holiday: "WHDL",
+          weekend: "WHDL",
+          call_consignee: "NTFN",
+          tradeshow: "TRDS",
+          residential: "RESD"
+        }.freeze
+
+        # @return [String] the service code to use
+        attr_reader :service_code
+
+        # @return [Time] date/time of pickup
+        attr_reader :pickup_at
+
+        # @return [Range] time window for pickup
+        attr_reader :pickup_time_window
+
+        # @return [Boolean] whether to preview rates in the response
+        attr_reader :preview_rate
+
+        # @return [Boolean] whether to include time in transit in the response
+        attr_reader :time_in_transit
+
+        # @return [String] code indicating how to bill this shipment (see {BILLING_CODES})
+        attr_reader :billing_code
+
+        # @return [Array<Hash>] reference numbers for this shipment (see {REFERENCE_NUMBER_CODES})
+        attr_reader :reference_numbers
+
+        # @return [String] instructions for pickup
+        attr_reader :pickup_instructions
+
+        # @return [String] instructions for handling
+        attr_reader :handling_instructions
+
+        # @return [String] instructions for delivery
+        attr_reader :delivery_instructions
+
+        # @return [Array<String>] options for pickup (see {PICKUP_OPTIONS})
+        attr_reader :pickup_options
+
+        # @return [Array<String>] options for delivery (see {DELIVERY_OPTIONS})
+        attr_reader :delivery_options
+
+        # @return [Array<DocumentOptions>] options for documents
+        attr_reader :document_options
+
+        # @return [Proc, #call] the callable used generate commodity information
+        attr_reader :commodity_information_generator
+
+        # @param service_code [String] the service code to use
+        # @param pickup_at [Time] date/time of pickup (defaults to now)
+        # @param pickup_time_window [Range] time window for pickup (defaults to start/end of today)
+        # @param preview_rate [Boolean] whether to preview rates in the response
+        # @param time_in_transit [Boolean] whether to include time in transit in the response
+        # @param billing [Symbol] how to bill this shipment (see {BILLING_CODES})
+        # @param reference_numbers [Array<Hash>] reference numbers for this shipment (see {REFERENCE_NUMBER_CODES})
+        # @param pickup_instructions [String] instructions for pickup
+        # @param handling_instructions [String] instructions for handling
+        # @param delivery_instructions [String] instructions for delivery
+        # @param pickup_options [Array<String>] options for pickup (see {PICKUP_OPTIONS})
+        # @param delivery_options [Array<String>] options for delivery (see {DELIVERY_OPTIONS})
+        # @param document_options [Array<DocumentOptions>] options for documents
+        # @param commodity_information_generator [Proc, #call] the callable used generate commodity information
+        # @param kwargs [Hash]
+        # @option kwargs [Enumerable<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
+        def initialize(
+          service_code: FriendlyShipping::Services::TForceFreight::SHIPPING_METHODS.first.service_code,
+          pickup_at: Time.now,
+          pickup_time_window: Time.now.beginning_of_day..Time.now.end_of_day,
+          preview_rate: false,
+          time_in_transit: false,
+          billing: :prepaid,
+          reference_numbers: [],
+          pickup_instructions: nil,
+          handling_instructions: nil,
+          delivery_instructions: nil,
+          pickup_options: [],
+          delivery_options: [],
+          document_options: [],
+          commodity_information_generator: GenerateCommodityInformation,
+          **kwargs
+        )
+          @service_code = service_code
+          @pickup_at = pickup_at
+          @pickup_time_window = pickup_time_window
+          @preview_rate = preview_rate
+          @time_in_transit = time_in_transit
+          @billing_code = BILLING_CODES.fetch(billing)
+          @reference_numbers = fill_codes(reference_numbers)
+          @pickup_instructions = pickup_instructions
+          @handling_instructions = handling_instructions
+          @delivery_instructions = delivery_instructions
+          @pickup_options = pickup_options
+          @delivery_options = delivery_options
+          @document_options = document_options
+          @commodity_information_generator = commodity_information_generator
+
+          validate_pickup_options!
+          validate_delivery_options!
+
+          super(**kwargs.reverse_merge(package_options_class: RatesPackageOptions))
+        end
+
+        private
+
+        # @param reference_numbers [Array<Hash>]
+        # @return [Array<Hash>]
+        def fill_codes(reference_numbers)
+          reference_numbers.each do |reference_number|
+            reference_number[:code] = REFERENCE_NUMBER_CODES.fetch(reference_number[:code])
+          end
+        end
+
+        # @raise [ArgumentError] invalid pickup options
+        # @return [nil]
+        def validate_pickup_options!
+          invalid_options = (pickup_options - PICKUP_OPTIONS.values)
+          return unless invalid_options.any?
+
+          raise ArgumentError, "Invalid pickup option(s): #{invalid_options.join(', ')}"
+        end
+
+        # @raise [ArgumentError] invalid delivery options
+        # @return [nil]
+        def validate_delivery_options!
+          invalid_options = (delivery_options - DELIVERY_OPTIONS.values)
+          return unless invalid_options.any?
+
+          raise ArgumentError, "Invalid delivery option(s): #{invalid_options.join(', ')}"
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/document_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/document_options.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      class DocumentOptions
+        # @return [Symbol] the document type (see {DOCUMENT_TYPES})
+        attr_reader :type
+
+        # @return [Symbol] the document format (see {DOCUMENT_FORMATS})
+        attr_reader :format
+
+        # @return [Boolean] whether or not the label is for thermal printers
+        attr_reader :thermal
+
+        # @return [Integer] the start position of the sticker
+        attr_reader :start_position
+
+        # @return [Integer] the number of stickers
+        attr_reader :number_of_stickers
+
+        DOCUMENT_TYPES = {
+          label: "30",
+          tforce_bol: "20",
+          vics_bol: "21"
+        }.freeze
+
+        DOCUMENT_FORMATS = {
+          pdf: "01"
+        }.freeze
+
+        THERMAL_CODE = {
+          false => "01",
+          true => "02"
+        }.freeze
+
+        # @param type [Symbol] the document type (see [DOCUMENT_TYPES])
+        # @param format [Symbol] the document format (see [DOCUMENT_FORMATS])
+        # @param thermal [Boolean] whether or not the label is for thermal printers
+        # @param start_position [Integer] the start position of the sticker
+        # @param number_of_stickers [Integer] the number of stickers
+        def initialize(
+          type: :label,
+          format: :pdf,
+          thermal: false,
+          start_position: 1,
+          number_of_stickers: 1
+        )
+          @type = type
+          @format = format
+          @thermal = thermal
+          @start_position = start_position
+          @number_of_stickers = number_of_stickers
+        end
+
+        # @return [String]
+        def format_code
+          DOCUMENT_FORMATS.fetch(format)
+        end
+
+        # @return [String]
+        def document_type_code
+          DOCUMENT_TYPES.fetch(type)
+        end
+
+        # @return [String]
+        def thermal_code
+          THERMAL_CODE.fetch(thermal)
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/generate_commodity_information.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_commodity_information.rb
@@ -12,25 +12,26 @@ module FriendlyShipping
             package.items.map do |item|
               item_options = package_options.options_for_item(item)
               {
+                description: item.description.presence || "Commodities",
                 class: item_options.freight_class,
                 nmfc: {
                   prime: item_options.nmfc_primary_code,
                   sub: item_options.nmfc_sub_code
-                },
+                }.compact.presence,
                 pieces: 1, # We don't support grouping yet
                 weight: {
                   weight: item.weight.convert_to(:pounds).value.to_f.round(2),
                   weightUnit: "LBS"
                 },
                 packagingType: item_options.packaging_code,
-                dangerousGoods: false,
+                dangerousGoods: item_options.hazardous,
                 dimensions: {
                   length: item.length.convert_to(:inches).value.to_f.round(2),
                   width: item.width.convert_to(:inches).value.to_f.round(2),
                   height: item.height.convert_to(:inches).value.to_f.round(2),
                   unit: "IN"
                 }
-              }
+              }.compact
             end
           end
         end

--- a/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/services/tforce_freight/generate_location_hash'
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      # Generate a TForceFreight BOL request hash for JSON serialization.
+      class GenerateCreateBOLRequestHash
+        class << self
+          # @param shipment [Physical::Shipment] the shipment for which we want to create a BOL
+          # @param options [BOLOptions] options for the BOL
+          # @return [Hash]
+          def call(shipment:, options:)
+            {
+              requestOptions: request_options(options),
+              shipFrom: location(shipment.origin),
+              shipTo: location(shipment.destination),
+              payment: payment(shipment.origin, options),
+              commodities: options.commodity_information_generator.call(shipment: shipment, options: options),
+              instructions: instructions(options),
+              serviceOptions: service_options(options),
+              pickupRequest: pickup_request(shipment.origin, options),
+              documents: { image: documents(options.document_options) }
+            }.compact.
+              merge(GenerateHandlingUnitsHash.call(shipment: shipment, options: options)).
+              merge(GenerateReferenceHash.call(reference_numbers: options.reference_numbers))
+          end
+
+          private
+
+          # @param options [BOLOptions]
+          # @return [Hash]
+          def request_options(options)
+            {
+              serviceCode: options.service_code,
+              pickupDate: options.pickup_at&.strftime("%Y-%m-%d"),
+              previewRate: options.preview_rate,
+              timeInTransit: options.time_in_transit
+            }.compact
+          end
+
+          # @param location [Physical::Location]
+          # @return [Hash]
+          def location(location)
+            {
+              name: location.company_name.presence || location.name,
+              contact: location.name,
+              email: location.email,
+              phone: { number: location.phone },
+              address: {
+                addressLine: address_line(location),
+                city: location.city,
+                stateProvinceCode: location.region&.code,
+                postalCode: location.zip,
+                country: location.country&.code
+              }.compact,
+              isResidential: location.residential?
+            }.compact
+          end
+
+          # @param location [Physical::Location]
+          # @param options [BOLOptions]
+          # @return [Hash]
+          def payment(location, options)
+            {
+              payer: {
+                name: location.company_name.presence || location.name,
+                contact: location.name,
+                email: location.email,
+                phone: { number: location.phone, },
+                address: {
+                  addressLine: address_line(location),
+                  city: location.city,
+                  stateProvinceCode: location.region&.code,
+                  postalCode: location.zip,
+                  country: location.country&.code
+                }
+              },
+              billingCode: options.billing_code
+            }
+          end
+
+          # @param location [Physical::Location]
+          def address_line(location)
+            [
+              location.address1,
+              location.address2,
+              location.address3
+            ].compact.reject(&:blank?).join(" ")
+          end
+
+          # @param options [BOLOptions]
+          # @return [Hash]
+          def instructions(options)
+            {
+              pickup: options.pickup_instructions,
+              handling: options.handling_instructions,
+              delivery: options.delivery_instructions
+            }.compact
+          end
+
+          # @param options [BOLOptions]
+          # @return [Hash]
+          def service_options(options)
+            {
+              pickup: options.pickup_options,
+              delivery: options.delivery_options
+            }
+          end
+
+          # @param location [Physical::Location]
+          # @param options [PickupOptions]
+          # @return [Hash]
+          def pickup_request(location, options)
+            {
+              pickup: pickup(options),
+              requester: requester(location),
+              pomIndicator: false # We don't support this yet
+            }
+          end
+
+          # @param options [PickupOptions]
+          # @return [Hash]
+          def pickup(options)
+            {
+              date: options.pickup_at&.strftime("%Y-%m-%d"),
+              time: options.pickup_at&.strftime("%H:%M:%S"),
+              openTime: options.pickup_time_window&.begin&.strftime("%H:%M:%S"),
+              closeTime: options.pickup_time_window&.end&.strftime("%H:%M:%S")
+            }.compact
+          end
+
+          # @param location [Physical::Location]
+          # @return [Hash]
+          def requester(location)
+            {
+              companyName: location.company_name.presence || location.name,
+              contactName: location.name,
+              email: location.email,
+              phone: { number: location.phone }.compact
+            }.compact
+          end
+
+          # @param document_options [Array<DocumentOptions>]
+          # @return [Array<Hash>]
+          def documents(document_options)
+            document_options.map { GenerateDocumentOptionsHash.call(document_options: _1) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/generate_document_options_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_document_options_hash.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      class GenerateDocumentOptionsHash
+        # @param document_options [DocumentOptions]
+        # @return [Hash]
+        def self.call(document_options:)
+          {
+            type: document_options.document_type_code,
+            format: document_options.format_code,
+            label: {
+              type: document_options.thermal_code,
+              startPosition: document_options.start_position,
+              numberOfStickers: document_options.number_of_stickers
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/generate_handling_units_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_handling_units_hash.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      class GenerateHandlingUnitsHash
+        class << self
+          # @param shipment [Physical::Shipment]
+          # @param options [FriendlyShipping::ShipmentOptions]
+          # @return [Hash]
+          def call(shipment:, options:)
+            handling_units(shipment, options).reduce(&:merge)
+          end
+
+          private
+
+          # @param shipment [Physical::Shipment]
+          # @param options [FriendlyShipping::ShipmentOptions]
+          # @return [Array<Hash>]
+          def handling_units(shipment, options)
+            all_package_options = shipment.packages.map { |package| options.options_for_package(package) }
+            all_package_options.group_by(&:handling_unit_code).map do |_handling_unit_code, options_group|
+              [options_group.first, options_group.length]
+            end.map { |package_options, quantity| handling_unit_hash(package_options, quantity) }
+          end
+
+          # @param package_options [FriendlyShipping::PackageOptions]
+          # @param quantity [Integer]
+          # @return [Hash]
+          def handling_unit_hash(package_options, quantity)
+            {
+              package_options.handling_unit_tag.to_sym => {
+                quantity: quantity,
+                typeCode: package_options.handling_unit_code
+              }
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/generate_reference_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_reference_hash.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      class GenerateReferenceHash
+        class << self
+          # @param reference_numbers [Array] reference numbers for the Bill of Lading
+          # @return [Hash] reference hash suitable for JSON request
+          def call(reference_numbers:)
+            return {} unless reference_numbers
+
+            references = reference_numbers.map do |reference_number|
+              {
+                number: reference_number[:value],
+                type: reference_number[:code],
+                quantity: reference_number[:quantity],
+                weight: reference_number[:weight]
+              }.compact
+            end
+            references.any? ? { references: references } : {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'friendly_shipping/rate'
+require 'friendly_shipping/api_result'
+require 'friendly_shipping/services/tforce_freight/shipping_methods'
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      # Parse a TForce Freight BOL response JSON into an ApiResult.
+      class ParseCreateBOLResponse
+        class << self
+          # @param request [Request] the original request
+          # @param response [RestClient::Response] the response to parse
+          # @return [ApiResult<Hash>] the parsed result
+          def call(request:, response:)
+            json = JSON.parse(response.body)
+
+            code = json.dig("summary", "code")
+            message = json.dig("summary", "message")
+            bol_id = json.dig("detail", "bolId")
+            pro_number = json.dig("detail", "pro")
+            documents = json.dig("detail", "documents", "image")&.map { _1.transform_keys(&:to_sym) }
+
+            FriendlyShipping::ApiResult.new(
+              {
+                code: code,
+                message: message,
+                bol_id: bol_id,
+                pro_number: pro_number,
+                documents: documents
+              },
+              original_request: request,
+              original_response: response
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/rates_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_options.rb
@@ -40,15 +40,22 @@ module FriendlyShipping
         PICKUP_OPTIONS = {
           inside: "INPU",
           liftgate: "LIFO",
-          residential: "RESP",
-          limited_access: "LAPU"
+          limited_access: "LAPU",
+          holiday: "WHPU",
+          weekend: "WHPU",
+          tradeshow: "TRPU",
+          residential: "RESP"
         }.freeze
 
         DELIVERY_OPTIONS = {
           inside: "INDE",
           liftgate: "LIFD",
-          residential: "RESD",
-          limited_access: "LADL"
+          limited_access: "LADL",
+          holiday: "WHDL",
+          weekend: "WHDL",
+          call_consignee: "NTFN",
+          tradeshow: "TRDS",
+          residential: "RESD"
         }.freeze
 
         attr_reader :billing_address,

--- a/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
@@ -7,7 +7,26 @@ module FriendlyShipping
     class TForceFreight
       # Options for packages/pallets within a TForce Freight shipment
       class RatesPackageOptions < FriendlyShipping::PackageOptions
-        def initialize(**kwargs)
+        HANDLING_UNIT_TYPES = {
+          pallet: { code: "PLT", description: "Pallet", handling_unit_tag: 'One' },
+          skid: { code: "SKD", description: "Skid", handling_unit_tag: 'One' },
+          carboy: { code: "CBY", description: "Carboy", handling_unit_tag: 'One' },
+          totes: { code: "TOT", description: "Totes", handling_unit_tag: 'One' },
+          other: { code: "OTH", description: "Other", handling_unit_tag: 'Two' },
+          loose: { code: "LOO", description: "Loose", handling_unit_tag: 'Two' }
+        }.freeze
+
+        attr_reader :handling_unit_description,
+                    :handling_unit_tag,
+                    :handling_unit_code
+
+        def initialize(
+          handling_unit: :pallet,
+          **kwargs
+        )
+          @handling_unit_code = HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:code)
+          @handling_unit_description = HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:description)
+          @handling_unit_tag = "handlingUnit#{HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:handling_unit_tag)}"
           super(**kwargs.reverse_merge(item_options_class: RatesItemOptions))
         end
       end

--- a/spec/cassettes/tforce_freight/create_bol/failure.yml
+++ b/spec/cassettes/tforce_freight/create_bol/failure.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.tforcefreight.com/shipping/bol/create?api-version=cie-v1
+    body:
+      encoding: UTF-8
+      string: '{"requestOptions":{"serviceCode":"308","pickupDate":"2024-01-22","previewRate":false,"timeInTransit":false},"shipFrom":{"name":"ACME
+        Inc","contact":"John Smith","email":"john@acme.com","phone":{"number":"123-123-1234"},"address":{"addressLine":"123
+        Maple St Suite 456","city":"Richmond","stateProvinceCode":"VA","postalCode":"23224","country":"US"},"isResidential":false},"shipTo":{"phone":{"number":null},"address":{"addressLine":""},"isResidential":false},"payment":{"payer":{"name":"ACME
+        Inc","contact":"John Smith","email":"john@acme.com","phone":{"number":"123-123-1234"},"address":{"addressLine":"123
+        Maple St Suite 456","city":"Richmond","stateProvinceCode":"VA","postalCode":"23224","country":"US"}},"billingCode":"10"},"commodities":[{"description":"Commodities","nmfc":{},"pieces":1,"weight":{"weight":500,"weightUnit":"LBS"},"packagingType":"CTN","dangerousGoods":false,"dimensions":{"length":0.0,"width":0.0,"height":0.0,"unit":"IN"}},{"description":"Commodities","nmfc":{},"pieces":1,"weight":{"weight":500,"weightUnit":"LBS"},"packagingType":"PLT","dangerousGoods":false,"dimensions":{"length":0.0,"width":0.0,"height":0.0,"unit":"IN"}}],"instructions":{"pickup":"East
+        Dock","handling":"Handle with care","delivery":"West Dock"},"serviceOptions":{"pickup":[],"delivery":["INDE","LIFD"]},"pickupRequest":{"pickup":{"date":"2024-01-22","time":"12:30:00","openTime":"08:00:00","closeTime":"16:00:00"},"requester":{"companyName":"ACME
+        Inc","contactName":"John Smith","email":"john@acme.com","phone":{"number":"123-123-1234"}},"pomIndicator":false},"documents":{"image":[{"type":"20","format":"01","label":{"type":"01","startPosition":1,"numberOfStickers":1}},{"type":"30","format":"01","label":{"type":"02","startPosition":1,"numberOfStickers":2}}]},"handlingUnitOne":{"quantity":2,"typeCode":"PLT"},"references":[{"number":"123","type":"BL"},{"number":"456","type":"PO"}]}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (darwin22 x86_64) ruby/3.2.2p53
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer secret_token
+      Content-Length:
+      - '1883'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - api.tforcefreight.com
+  response:
+    status:
+      code: 400
+      message: ContentInvalid
+    headers:
+      Content-Length:
+      - '613'
+      Content-Type:
+      - application/json
+      Request-Context:
+      - appId=cid-v1:2851e6bf-1dfd-43fd-837a-37e3cd142cdd
+      Date:
+      - Mon, 29 Jan 2024 17:41:47 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "summary": {
+                                    "responseStatus": {
+                                        "code": "ERROR",
+                                        "message": "Body of the request does not conform to the definition which is associated with the content type application/json. Required properties are missing from object: name. Line: 1, Position: 457"
+                                    },
+                                    "transactionReference": {
+                                        "transactionId": "1060bca6-e212-4cbe-8e23-bfcf02cb4354"
+                                    }
+                                }
+                            }
+  recorded_at: Mon, 29 Jan 2024 17:41:47 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/tforce_freight/create_bol/success.yml
+++ b/spec/cassettes/tforce_freight/create_bol/success.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.tforcefreight.com/shipping/bol/create?api-version=cie-v1
+    body:
+      encoding: UTF-8
+      string: '{"requestOptions":{"serviceCode":"308","pickupDate":"2024-01-22","previewRate":false,"timeInTransit":false},"shipFrom":{"name":"ACME
+        Inc","contact":"John Smith","email":"john@acme.com","phone":{"number":"123-123-1234"},"address":{"addressLine":"123
+        Maple St Suite 456","city":"Richmond","stateProvinceCode":"VA","postalCode":"23224","country":"US"},"isResidential":false},"shipTo":{"name":"Widgets
+        LLC","contact":"Jane Doe","email":"jane@widgets.com","phone":{"number":"456-456-4567"},"address":{"addressLine":"123
+        Oak Ave Suite 456","city":"Allanton","stateProvinceCode":"MO","postalCode":"63025","country":"US"},"isResidential":false},"payment":{"payer":{"name":"ACME
+        Inc","contact":"John Smith","email":"john@acme.com","phone":{"number":"123-123-1234"},"address":{"addressLine":"123
+        Maple St Suite 456","city":"Richmond","stateProvinceCode":"VA","postalCode":"23224","country":"US"}},"billingCode":"10"},"commodities":[{"description":"Widgets","class":"92.5","nmfc":{"prime":"16030","sub":"1"},"pieces":1,"weight":{"weight":500.0,"weightUnit":"LBS"},"packagingType":"CTN","dangerousGoods":false,"dimensions":{"length":0.0,"width":0.0,"height":0.0,"unit":"IN"}},{"description":"Gadgets","class":"92.5","nmfc":{"prime":"16030","sub":"1"},"pieces":1,"weight":{"weight":500.0,"weightUnit":"LBS"},"packagingType":"PLT","dangerousGoods":false,"dimensions":{"length":0.0,"width":0.0,"height":0.0,"unit":"IN"}}],"instructions":{"pickup":"East
+        Dock","handling":"Handle with care","delivery":"West Dock"},"serviceOptions":{"pickup":[],"delivery":["INDE","LIFD"]},"pickupRequest":{"pickup":{"date":"2024-01-22","time":"12:30:00","openTime":"08:00:00","closeTime":"16:00:00"},"requester":{"companyName":"ACME
+        Inc","contactName":"John Smith","email":"john@acme.com","phone":{"number":"123-123-1234"}},"pomIndicator":false},"documents":{"image":[{"type":"20","format":"01","label":{"type":"01","startPosition":1,"numberOfStickers":1}},{"type":"30","format":"01","label":{"type":"02","startPosition":1,"numberOfStickers":2}}]},"handlingUnitOne":{"quantity":2,"typeCode":"PLT"},"references":[{"number":"123","type":"BL"},{"number":"456","type":"PO"}]}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (darwin22 x86_64) ruby/3.2.2p53
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer secret_token
+      Content-Length:
+      - '2138'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - api.tforcefreight.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache,no-store,must-revalidate,max-age=0,no-cache="set-cookie"
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '1441'
+      Content-Type:
+      - application/json
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Request-Context:
+      - appId=cid-v1:2851e6bf-1dfd-43fd-837a-37e3cd142cdd
+      Date:
+      - Tue, 30 Jan 2024 14:47:32 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "summary":{
+            "code":"OK",
+            "message":"success"
+          },
+          "detail":{
+            "bolId":46178022,
+            "pro":"090509075",
+            "documents":{
+              "image":[
+                {
+                  "status":"NFO",
+                  "type":"20",
+                  "format":"PDF",
+                  "data":""
+                },
+                {
+                  "status":"NFO",
+                  "type":"30",
+                  "format":"PDF",
+                  "data":""
+                }
+              ]
+            }
+          }
+        }
+  recorded_at: Tue, 30 Jan 2024 14:47:32 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/tforce_freight/create_bol/success.json
+++ b/spec/fixtures/tforce_freight/create_bol/success.json
@@ -1,0 +1,26 @@
+{
+  "summary":{
+    "code":"OK",
+    "message":"success"
+  },
+  "detail":{
+    "bolId":46176429,
+    "pro":"020968290",
+    "documents":{
+      "image":[
+        {
+          "status":"NFO",
+          "type":"20",
+          "format":"PDF",
+          "data":""
+        },
+        {
+          "status":"NFO",
+          "type":"30",
+          "format":"PDF",
+          "data":""
+        }
+      ]
+    }
+  }
+}

--- a/spec/friendly_shipping/services/tforce_freight/bol_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/bol_options_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::BOLOptions do
+  subject(:options) do
+    described_class.new(
+      service_code: "308",
+      pickup_at: Time.parse("2024-01-22 12:30:00"),
+      pickup_time_window: Time.parse("2024-01-22 08:00:00")..Time.parse("2024-01-22 16:00:00"),
+      preview_rate: true,
+      time_in_transit: true,
+      billing: :prepaid,
+      pickup_instructions: "East Dock",
+      handling_instructions: "Handle with care",
+      delivery_instructions: "West Dock",
+      pickup_options: %w[LIFO],
+      delivery_options: %w[LIFD],
+      document_options: document_options
+    )
+  end
+
+  let(:document_options) do
+    [
+      FriendlyShipping::Services::TForceFreight::DocumentOptions.new(
+        type: :tforce_bol
+      )
+    ]
+  end
+
+  it { is_expected.to be_a(FriendlyShipping::Services::TForceFreight::BOLOptions) }
+
+  it "has the right attributes" do
+    expect(options.service_code).to eq("308")
+    expect(options.pickup_at).to eq(Time.parse("2024-01-22 12:30:00"))
+    expect(options.pickup_time_window).to eq(Time.parse("2024-01-22 08:00:00")..Time.parse("2024-01-22 16:00:00"))
+    expect(options.preview_rate).to be(true)
+    expect(options.time_in_transit).to be(true)
+    expect(options.billing_code).to eq("10")
+    expect(options.pickup_instructions).to eq("East Dock")
+    expect(options.handling_instructions).to eq("Handle with care")
+    expect(options.delivery_instructions).to eq("West Dock")
+    expect(options.pickup_options).to eq(%w[LIFO])
+    expect(options.delivery_options).to eq(%w[LIFD])
+    expect(options.document_options).to eq(document_options)
+  end
+
+  describe "#reference_numbers" do
+    subject(:options) do
+      described_class.new(
+        reference_numbers: [
+          { code: :bill_of_lading_number, value: "123" },
+          { code: :consignee_reference, value: "456" }
+        ]
+      )
+    end
+
+    it "fills codes from lookup table" do
+      expect(options.reference_numbers).to eq(
+        [
+          { code: "BL", value: "123" },
+          { code: "CO", value: "456" }
+        ]
+      )
+    end
+  end
+
+  describe "pickup option validation" do
+    subject(:options) { described_class.new(pickup_options: %w[bogus invalid]) }
+
+    it do
+      expect { options }.to raise_error(ArgumentError, "Invalid pickup option(s): bogus, invalid")
+    end
+  end
+
+  describe "delivery option validation" do
+    subject(:options) { described_class.new(delivery_options: %w[bogus invalid]) }
+
+    it do
+      expect { options }.to raise_error(ArgumentError, "Invalid delivery option(s): bogus, invalid")
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/document_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/document_options_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::DocumentOptions do
+  subject(:options) { described_class.new }
+
+  it "has good defaults" do
+    expect(options.type).to eq(:label)
+    expect(options.format).to eq(:pdf)
+    expect(options.thermal).to be(false)
+    expect(options.start_position).to eq(1)
+    expect(options.number_of_stickers).to eq(1)
+  end
+
+  it "returns expected codes" do
+    expect(options.format_code).to eq("01")
+    expect(options.document_type_code).to eq("30")
+    expect(options.thermal_code).to eq("01")
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/generate_commodity_information_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_commodity_information_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCommodityInfor
     let(:item_one) do
       Physical::Item.new(
         id: "item_one",
+        description: "Widgets",
         weight: Measured::Weight(10.523, :lbs),
         dimensions: [
           Measured::Length(1.874, :in),
@@ -38,6 +39,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCommodityInfor
     let(:item_two) do
       Physical::Item.new(
         id: "item_two",
+        description: "Gadgets",
         weight: Measured::Weight(8.243, :lbs),
         dimensions: [
           Measured::Length(1.341, :in),
@@ -86,6 +88,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCommodityInfor
       is_expected.to eq(
         [
           {
+            description: "Widgets",
             class: "92.5",
             dangerousGoods: false,
             dimensions: {
@@ -105,6 +108,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCommodityInfor
               weightUnit: "LBS"
             }
           }, {
+            description: "Gadgets",
             class: "92.5",
             dangerousGoods: false,
             dimensions: {

--- a/spec/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash_spec.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLRequestHash do
+  describe ".call" do
+    subject(:call) { described_class.call(shipment: shipment, options: options) }
+
+    let(:shipment) { Physical::Shipment.new(packages: packages, origin: origin, destination: destination) }
+
+    let(:origin) do
+      Physical::Location.new(
+        company_name: "ACME Inc",
+        name: "John Smith",
+        email: "john@acme.com",
+        phone: "123-123-1234",
+        address1: "123 Maple St",
+        address2: "Suite 456",
+        city: "Richmond",
+        zip: "23224",
+        region: "VA",
+        country: "US"
+      )
+    end
+
+    let(:destination) do
+      Physical::Location.new(
+        company_name: "Widgets LLC",
+        name: "Jane Doe",
+        email: "jane@widgets.com",
+        phone: "456-456-4567",
+        address1: "123 Oak Ave",
+        address2: "Suite 456",
+        city: "Allanton",
+        zip: "63025",
+        region: "MO",
+        country: "US"
+      )
+    end
+
+    let(:packages) { [package_one] }
+
+    let(:package_one) do
+      Physical::Package.new(
+        id: "my_package_1",
+        items: [item_one]
+      )
+    end
+
+    let(:item_one) do
+      Physical::Item.new(
+        id: "item_one",
+        description: "Can of Socks",
+        weight: Measured::Weight(500, :lbs),
+        dimensions: [
+          Measured::Length(9.874, :in),
+          Measured::Length(12.906, :in),
+          Measured::Length(5.811, :in)
+        ]
+      )
+    end
+
+    let(:options) do
+      FriendlyShipping::Services::TForceFreight::BOLOptions.new(
+        pickup_at: Time.parse("2023-05-18 12:30:00"),
+        pickup_options: %w[INPU LIFO],
+        delivery_options: %w[INDE LIFD],
+        pickup_instructions: "East Dock",
+        handling_instructions: "Handle with care",
+        delivery_instructions: "West Dock",
+        reference_numbers: [
+          { code: :bill_of_lading_number, value: "123" },
+          { code: :purchase_order_number, value: "456" }
+        ],
+        document_options: document_options,
+        package_options: package_options
+      )
+    end
+
+    let(:document_options) do
+      [
+        FriendlyShipping::Services::TForceFreight::DocumentOptions.new(
+          type: :tforce_bol
+        ),
+        FriendlyShipping::Services::TForceFreight::DocumentOptions.new(
+          type: :label,
+          thermal: true,
+          number_of_stickers: 2
+        )
+      ]
+    end
+
+    let(:package_options) do
+      [
+        FriendlyShipping::Services::TForceFreight::RatesPackageOptions.new(
+          package_id: package_one.id,
+          item_options: item_one_options
+        )
+      ]
+    end
+
+    let(:item_one_options) do
+      [
+        FriendlyShipping::Services::TForceFreight::RatesItemOptions.new(
+          item_id: "item_one",
+          packaging: :pallet,
+          freight_class: "92.5",
+          nmfc_primary_code: "16030",
+          nmfc_sub_code: "01"
+        )
+      ]
+    end
+
+    describe "keys" do
+      subject(:keys) { call.keys }
+
+      it do
+        is_expected.to eq(
+          %i[
+            requestOptions
+            shipFrom
+            shipTo
+            payment
+            commodities
+            instructions
+            serviceOptions
+            pickupRequest
+            documents
+            handlingUnitOne
+            references
+          ]
+        )
+      end
+    end
+
+    describe "requestOptions" do
+      subject(:request_options) { call[:requestOptions] }
+
+      it do
+        is_expected.to eq(
+          pickupDate: "2023-05-18",
+          serviceCode: "308",
+          previewRate: false,
+          timeInTransit: false
+        )
+      end
+    end
+
+    describe "shipFrom" do
+      subject(:ship_from) { call[:shipFrom] }
+
+      it do
+        is_expected.to eq(
+          name: "ACME Inc",
+          contact: "John Smith",
+          email: "john@acme.com",
+          phone: {
+            number: "123-123-1234"
+          },
+          address: {
+            addressLine: "123 Maple St Suite 456",
+            stateProvinceCode: "VA",
+            city: "Richmond",
+            postalCode: "23224",
+            country: "US"
+          },
+          isResidential: false
+        )
+      end
+    end
+
+    describe "shipTo" do
+      subject(:ship_to) { call[:shipTo] }
+
+      it do
+        is_expected.to eq(
+          name: "Widgets LLC",
+          contact: "Jane Doe",
+          email: "jane@widgets.com",
+          phone: {
+            number: "456-456-4567"
+          },
+          address: {
+            addressLine: "123 Oak Ave Suite 456",
+            stateProvinceCode: "MO",
+            city: "Allanton",
+            postalCode: "63025",
+            country: "US"
+          },
+          isResidential: false
+        )
+      end
+    end
+
+    describe "payment" do
+      subject(:payment) { call[:payment] }
+
+      it do
+        is_expected.to eq(
+          {
+            payer: {
+              name: "ACME Inc",
+              contact: "John Smith",
+              email: "john@acme.com",
+              phone: {
+                number: "123-123-1234"
+              },
+              address: {
+                addressLine: "123 Maple St Suite 456",
+                stateProvinceCode: "VA",
+                city: "Richmond",
+                postalCode: "23224",
+                country: "US"
+              },
+            },
+            billingCode: "10"
+          }
+        )
+      end
+    end
+
+    describe "handlingUnitOne" do
+      subject(:handling_unit_one) { call[:handlingUnitOne] }
+
+      it do
+        is_expected.to eq(
+          {
+            quantity: 1,
+            typeCode: "PLT"
+          }
+        )
+      end
+    end
+
+    describe "handlingUnitTwo" do
+      subject(:handling_unit_two) { call[:handlingUnitTwo] }
+
+      it { is_expected.to be_nil }
+    end
+
+    describe "commodities" do
+      subject(:commodities) { call[:commodities] }
+
+      it do
+        is_expected.to eq(
+          [
+            {
+              description: "Can of Socks",
+              class: "92.5",
+              nmfc: {
+                prime: "16030",
+                sub: "01"
+              },
+              pieces: 1,
+              weight: {
+                weight: 500,
+                weightUnit: "LBS"
+              },
+              packagingType: "PLT",
+              dangerousGoods: false,
+              dimensions: {
+                length: 9.87,
+                width: 12.91,
+                height: 5.81,
+                unit: "IN"
+              }
+            }
+          ]
+        )
+      end
+    end
+
+    describe "references" do
+      subject(:references) { call[:references] }
+
+      it do
+        is_expected.to eq(
+          [
+            { number: "123", type: "BL" },
+            { number: "456", type: "PO" }
+          ]
+        )
+      end
+    end
+
+    describe "instructions" do
+      subject(:instructions) { call[:instructions] }
+
+      it do
+        is_expected.to eq(
+          {
+            delivery: "West Dock",
+            handling: "Handle with care",
+            pickup: "East Dock"
+          }
+        )
+      end
+    end
+
+    describe "serviceOptions" do
+      subject(:service_options) { call[:serviceOptions] }
+
+      it do
+        is_expected.to eq(
+          {
+            pickup: %w[INPU LIFO],
+            delivery: %w[INDE LIFD]
+          }
+        )
+      end
+    end
+
+    describe "pickupRequest" do
+      subject(:pickup_request) { call[:pickupRequest] }
+
+      it do
+        is_expected.to eq(
+          {
+            pickup: {
+              date: "2023-05-18",
+              time: "12:30:00",
+              openTime: "00:00:00",
+              closeTime: "23:59:59"
+            },
+            requester: {
+              companyName: "ACME Inc",
+              contactName: "John Smith",
+              email: "john@acme.com",
+              phone: {
+                number: "123-123-1234"
+              }
+            },
+            pomIndicator: false
+          }
+        )
+      end
+    end
+
+    describe "documents" do
+      subject(:documents) { call[:documents] }
+
+      it do
+        is_expected.to eq(
+          {
+            image: [
+              {
+                type: "20",
+                format: "01",
+                label: {
+                  type: "01",
+                  startPosition: 1,
+                  numberOfStickers: 1
+                }
+              }, {
+                type: "30",
+                format: "01",
+                label: {
+                  type: "02",
+                  startPosition: 1,
+                  numberOfStickers: 2
+                }
+              }
+            ]
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/generate_document_options_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_document_options_hash_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateDocumentOptionsHash do
+  subject(:call) do
+    described_class.call(document_options: document_options)
+  end
+
+  let(:document_options) do
+    FriendlyShipping::Services::TForceFreight::DocumentOptions.new
+  end
+
+  it "has all the right things" do
+    is_expected.to eq(
+      {
+        type: "30",
+        format: "01",
+        label: {
+          type: "01",
+          startPosition: 1,
+          numberOfStickers: 1
+        }
+      }
+    )
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/generate_handling_units_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_handling_units_hash_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateHandlingUnitsHash do
+  subject { described_class.call(shipment: shipment, options: options) }
+
+  let(:shipment) { Physical::Shipment.new(packages: packages) }
+  let(:packages) { [pallet_1, pallet_2, other] }
+
+  let(:pallet_1) { Physical::Package.new(id: "pallet 1") }
+  let(:pallet_2) { Physical::Package.new(id: "pallet 2") }
+  let(:other) { Physical::Package.new(id: "other") }
+
+  let(:options) do
+    FriendlyShipping::Services::TForceFreight::RatesOptions.new(
+      billing_address: billing_address,
+      shipping_method: shipping_method,
+      package_options: [
+        FriendlyShipping::Services::TForceFreight::RatesPackageOptions.new(
+          package_id: "pallet 1",
+          handling_unit: :pallet
+        ),
+        FriendlyShipping::Services::TForceFreight::RatesPackageOptions.new(
+          package_id: "pallet 2",
+          handling_unit: :pallet
+        ),
+        FriendlyShipping::Services::TForceFreight::RatesPackageOptions.new(
+          package_id: "other",
+          handling_unit: :other
+        )
+      ]
+    )
+  end
+
+  let(:billing_address) { FactoryBot.build(:physical_location) }
+  let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: "03") }
+
+  it do
+    is_expected.to eq(
+      handlingUnitOne: {
+        quantity: 2,
+        typeCode: "PLT"
+      },
+      handlingUnitTwo: {
+        quantity: 1,
+        typeCode: "OTH"
+      }
+    )
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/generate_reference_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_reference_hash_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateReferenceHash do
+  let(:reference_numbers) do
+    [
+      { code: "BL", value: "1234" },
+      { code: "CO", value: "5678" }
+    ]
+  end
+
+  subject { described_class.call(reference_numbers: reference_numbers) }
+
+  it "has all the right things" do
+    is_expected.to eq(
+      references: [
+        {
+          number: "1234",
+          type: "BL"
+        }, {
+          number: "5678",
+          type: "CO"
+        }
+      ]
+    )
+  end
+
+  context "with nil reference numbers" do
+    let(:reference_numbers) { nil }
+    it { is_expected.to eq({}) }
+  end
+
+  context "with empty reference numbers" do
+    let(:reference_numbers) { [] }
+    it { is_expected.to eq({}) }
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/parse_create_bol_response_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/parse_create_bol_response_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::ParseCreateBOLResponse do
+  describe ".call" do
+    subject(:call) { described_class.call(request: nil, response: response) }
+
+    let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "tforce_freight", "create_bol", "success.json")) }
+    let(:response) { double(body: response_body) }
+
+    it "has the right data" do
+      expect(call.data).to eq(
+        code: "OK",
+        message: "success",
+        bol_id: 46_176_429,
+        pro_number: "020968290",
+        documents: [
+          {
+            type: "20",
+            format: "PDF",
+            status: "NFO",
+            data: ""
+          }, {
+            type: "30",
+            format: "PDF",
+            status: "NFO",
+            data: ""
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/rates_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/rates_options_spec.rb
@@ -34,24 +34,6 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::RatesOptions do
 
   it { is_expected.to be_a(FriendlyShipping::ShipmentOptions) }
 
-  [
-    :pickup_date,
-    :billing_address,
-    :billing_code,
-    :shipping_method,
-    :type_code,
-    :density_eligible,
-    :accessorial_rate,
-    :time_in_transit,
-    :quote_number,
-    :pickup_options,
-    :delivery_options,
-    :customer_context,
-    :commodity_information_generator
-  ].each do |option|
-    it { is_expected.to respond_to(option) }
-  end
-
   it_behaves_like "overrideable package options class" do
     let(:default_class) { FriendlyShipping::Services::TForceFreight::RatesPackageOptions }
     let(:required_attrs) { { billing_address: billing_location, shipping_method: shipping_method } }

--- a/spec/friendly_shipping/services/tforce_freight/rates_package_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/rates_package_options_spec.rb
@@ -5,7 +5,23 @@ require 'spec_helper'
 RSpec.describe FriendlyShipping::Services::TForceFreight::RatesPackageOptions do
   subject(:options) { described_class.new(package_id: "package") }
 
+  it "has the right attributes" do
+    expect(subject.handling_unit_code).to eq("PLT")
+    expect(subject.handling_unit_description).to eq("Pallet")
+    expect(subject.handling_unit_tag).to eq("handlingUnitOne")
+  end
+
   it_behaves_like "overrideable item options class" do
     let(:default_class) { FriendlyShipping::Services::TForceFreight::RatesItemOptions }
+  end
+
+  context "with loose packaging" do
+    subject(:options) { described_class.new(package_id: "package", handling_unit: :loose) }
+
+    it "has the right attributes" do
+      expect(subject.handling_unit_code).to eq("LOO")
+      expect(subject.handling_unit_description).to eq("Loose")
+      expect(subject.handling_unit_tag).to eq("handlingUnitTwo")
+    end
   end
 end


### PR DESCRIPTION
TForce (formerly UPS Freight) is building [a new API](https://developer.tforcefreight.com/) distinct from UPS. This PR implements the [Create BOL](https://developer.tforcefreight.com/api-details#api=shipping-cie-vnext&operation=shipping-create-bol) call.