### PR TITLE
Fix ShipEngine address validation serializer

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/serialize_address_validation_request.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_address_validation_request.rb
@@ -6,22 +6,24 @@ module FriendlyShipping
       class SerializeAddressValidationRequest
         class << self
           # @param location [Physical::Location]
-          # @return [Hash]
+          # @return [Array<Hash>]
           def call(location:)
-            {
-              name: location.name,
-              phone: location.phone,
-              email: location.email,
-              company_name: location.company_name,
-              address_line1: location.address1,
-              address_line2: location.address2,
-              address_line3: location.address3,
-              city_locality: location.city,
-              state_province: location.region&.code,
-              postal_code: location.zip,
-              country_code: location.country&.code,
-              address_residential_indicator: residential_indicator(location)
-            }
+            [
+              {
+                name: location.name,
+                phone: location.phone,
+                email: location.email,
+                company_name: location.company_name,
+                address_line1: location.address1,
+                address_line2: location.address2,
+                address_line3: location.address3,
+                city_locality: location.city,
+                state_province: location.region&.code,
+                postal_code: location.zip,
+                country_code: location.country&.code,
+                address_residential_indicator: residential_indicator(location)
+              }
+            ]
           end
 
           private

--- a/spec/cassettes/shipengine/validate_address/success.yml
+++ b/spec/cassettes/shipengine/validate_address/success.yml
@@ -28,23 +28,23 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 29 Feb 2024 19:15:00 GMT
+      - Fri, 01 Mar 2024 17:05:11 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
       - '930'
       Connection:
       - keep-alive
-      Ratelimit-Limit:
-      - '20'
       Ratelimit-Remaining:
       - '19'
+      Ratelimit-Limit:
+      - '20'
       Ratelimit-Reset:
-      - '60'
+      - '49'
       X-Shipengine-Requestid:
-      - 6e354a51-e777-48a4-aa0e-26b4c60cfe40
+      - 5c58e523-0662-4dbb-87f5-c2e59f35c9bc
       Request-Id:
-      - 6e354a51-e777-48a4-aa0e-26b4c60cfe40
+      - 5c58e523-0662-4dbb-87f5-c2e59f35c9bc
       Branch-Name:
       - bWFpbg
       Permissions-Policy:
@@ -74,5 +74,5 @@ http_interactions:
         \"VA\",\r\n      \"postal_code\": \"23226\",\r\n      \"country_code\": \"US\",\r\n
         \     \"address_residential_indicator\": \"unknown\"\r\n    },\r\n    \"messages\":
         []\r\n  }\r\n]"
-  recorded_at: Thu, 29 Feb 2024 19:15:00 GMT
+  recorded_at: Fri, 01 Mar 2024 17:05:11 GMT
 recorded_with: VCR 6.1.0

--- a/spec/friendly_shipping/services/ship_engine/serialize_address_validation_request_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_address_validation_request_spec.rb
@@ -23,18 +23,22 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeAddressValidatio
 
   it do
     is_expected.to eq(
-      name: "John Smith",
-      phone: "123-123-1234",
-      email: "john@acme.com",
-      company_name: "ACME Inc",
-      address_line1: "123 Maple St",
-      address_line2: "Suite 456",
-      address_line3: nil,
-      city_locality: "Richmond",
-      state_province: "VA",
-      postal_code: "23224",
-      country_code: "US",
-      address_residential_indicator: "yes"
+      [
+        {
+          name: "John Smith",
+          phone: "123-123-1234",
+          email: "john@acme.com",
+          company_name: "ACME Inc",
+          address_line1: "123 Maple St",
+          address_line2: "Suite 456",
+          address_line3: nil,
+          city_locality: "Richmond",
+          state_province: "VA",
+          postal_code: "23224",
+          country_code: "US",
+          address_residential_indicator: "yes"
+        }
+      ]
     )
   end
 end


### PR DESCRIPTION
The API expects an array of hashes, we were just passing a single hash.