### PR TITLE
Fix ShipEngine address validation return value

### DIFF
--- a/lib/friendly_shipping/services/ship_engine.rb
+++ b/lib/friendly_shipping/services/ship_engine.rb
@@ -116,6 +116,11 @@ module FriendlyShipping
         end
       end
 
+      # Void a ShipEngine label
+      #
+      # @param label [FriendlyShipping::Label]
+      # @param debug [Boolean] whether to append debug information to the API result
+      # @return [Result<ApiResult<String>>] the result message
       def void(label, debug: false)
         request = FriendlyShipping::Request.new(
           url: "#{API_BASE}labels/#{label.id}/void",

--- a/lib/friendly_shipping/services/ship_engine.rb
+++ b/lib/friendly_shipping/services/ship_engine.rb
@@ -134,8 +134,10 @@ module FriendlyShipping
         end
       end
 
-      # @param locations [Array<Physical::Location>]
-      # @return [Success<ApiResult>, Failure<ApiFailure>]
+      # Validate an address using ShipEngine
+      #
+      # @param location [Physical::Location] the address to validate
+      # @return [Success<ApiResult<Array<Physical::Location>>>, Failure<ApiFailure>]
       def validate_address(location, debug: false)
         request = FriendlyShipping::Request.new(
           url: "#{API_BASE}addresses/validate",

--- a/spec/friendly_shipping/services/ship_engine/parse_address_validation_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_address_validation_response_spec.rb
@@ -14,11 +14,12 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::ParseAddressValidationRes
     result = call
     expect(result).to be_success
     expect(result.value!).to be_a(FriendlyShipping::ApiResult)
-    expect(result.value!.data).to be_a(Physical::Location)
+    expect(result.value!.data).to be_a(Array)
+    expect(result.value!.data.first).to be_a(Physical::Location)
     expect(subject.value!.original_request).to eq(request)
     expect(subject.value!.original_response).to eq(response)
 
-    location = result.value!.data
+    location = result.value!.data.first
     expect(location.name).to eq("JOHN SMITH")
     expect(location.phone).to eq("123-123-1234")
     expect(location.email).to be_nil


### PR DESCRIPTION
This updates the return value from the ShipEngine `#validate_address` method to be an array of locations instead of just a single location. The API is capable of validating multiple addresses at the same time, and we should be consistent with our other service classes which also return an array of locations when validating addresses.