### PR TITLE
Add additional response data to ShipEngine rates

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/parse_rate_estimates_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_rate_estimates_response.rb
@@ -23,6 +23,7 @@ module FriendlyShipping
 
               shipping_method = FriendlyShipping::ShippingMethod.new(
                 carrier: carrier,
+                name: rate['service_type'],
                 service_code: rate['service_code']
               )
 
@@ -35,7 +36,15 @@ module FriendlyShipping
                 delivery_date: rate['estimated_delivery_date'] && Time.parse(rate['estimated_delivery_date']),
                 guaranteed: rate['guaranteed_service'],
                 warnings: rate['warning_messages'],
-                errors: rate['error_messages']
+                errors: rate['error_messages'],
+                data: {
+                  package_type: rate['package_type'],
+                  delivery_days: rate['delivery_days'],
+                  carrier_delivery_days: rate['carrier_delivery_days'],
+                  negotiated_rate: rate['negotiated_rate'],
+                  trackable: rate['trackable'],
+                  validation_status: rate['validation_status']
+                }
               )
             end.compact
 

--- a/lib/friendly_shipping/services/ship_engine/parse_rates_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_rates_response.rb
@@ -71,7 +71,15 @@ module FriendlyShipping
                 remote_service_id: rate['rate_id'],
                 delivery_date: rate['estimated_delivery_date'] && Time.parse(rate['estimated_delivery_date']),
                 warnings: rate['warning_messages'],
-                errors: rate['error_messages']
+                errors: rate['error_messages'],
+                data: {
+                  package_type: rate['package_type'],
+                  delivery_days: rate['delivery_days'],
+                  carrier_delivery_days: rate['carrier_delivery_days'],
+                  negotiated_rate: rate['negotiated_rate'],
+                  trackable: rate['trackable'],
+                  validation_status: rate['validation_status']
+                }
               )
             end.compact
           end

--- a/spec/friendly_shipping/services/ship_engine/parse_rate_estimates_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_rate_estimates_response_spec.rb
@@ -30,7 +30,14 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::ParseRateEstimatesRespons
     expect(rate_estimate.guaranteed).to be(true)
     expect(rate_estimate.warnings).to eq([])
     expect(rate_estimate.errors).to eq([])
-    expect(rate_estimate.data).to eq({})
+    expect(rate_estimate.data).to eq(
+      carrier_delivery_days: "6",
+      delivery_days: 7,
+      negotiated_rate: false,
+      package_type: "package",
+      trackable: true,
+      validation_status: "unknown"
+    )
     expect(subject.value!.original_request).to eq(request)
     expect(subject.value!.original_response).to eq(response)
   end
@@ -50,7 +57,14 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::ParseRateEstimatesRespons
       expect(rate_estimate.guaranteed).to be(false)
       expect(rate_estimate.warnings).to eq([])
       expect(rate_estimate.errors).to eq([])
-      expect(rate_estimate.data).to eq({})
+      expect(rate_estimate.data).to eq(
+        carrier_delivery_days: nil,
+        delivery_days: nil,
+        negotiated_rate: false,
+        package_type: nil,
+        trackable: false,
+        validation_status: "unknown"
+      )
       expect(subject.value!.original_request).to eq(request)
       expect(subject.value!.original_response).to eq(response)
     end

--- a/spec/friendly_shipping/services/ship_engine/parse_rates_response_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/parse_rates_response_spec.rb
@@ -28,7 +28,14 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::ParseRatesResponse do
     expect(rate_estimate.delivery_date).to be_nil
     expect(rate_estimate.warnings).to eq([])
     expect(rate_estimate.errors).to eq([])
-    expect(rate_estimate.data).to eq({})
+    expect(rate_estimate.data).to eq(
+      carrier_delivery_days: nil,
+      delivery_days: nil,
+      negotiated_rate: false,
+      package_type: nil,
+      trackable: false,
+      validation_status: "valid"
+    )
     expect(subject.value!.original_request).to eq(request)
     expect(subject.value!.original_response).to eq(response)
   end


### PR DESCRIPTION
This adds additional data to rates returned by ShipEngine. These values are specific to ShipEngine and as such are added to the `data` hash on each returned `Rate` object.