### PR TITLE
Exclude dimensions from ShipEngine rate estimates when zero

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/serialize_rate_estimate_request.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_rate_estimate_request.rb
@@ -4,28 +4,30 @@ module FriendlyShipping
   module Services
     class ShipEngine
       class SerializeRateEstimateRequest
-        def self.call(shipment:, options:)
-          {
-            carrier_ids: options.carrier_ids,
-            from_country_code: shipment.origin.country.alpha_2_code,
-            from_postal_code: shipment.origin.zip,
-            to_country_code: shipment.destination.country.alpha_2_code,
-            to_postal_code: shipment.destination.zip,
-            to_city_locality: shipment.destination.city,
-            to_state_province: shipment.destination.region.code,
-            weight: {
-              value: shipment.packages.map { |p| p.weight.convert_to(:pound).value.to_f }.sum.round(2),
-              unit: 'pound'
-            },
-            dimensions: {
-              unit: 'inch',
-              length: shipment.packages.map { |p| p.length.convert_to(:inch).value.to_f }.sum.round(2),
-              width: shipment.packages.map { |p| p.width.convert_to(:inch).value.to_f }.sum.round(2),
-              height: shipment.packages.map { |p| p.height.convert_to(:inch).value.to_f }.sum.round(2)
-            },
-            confirmation: 'none',
-            ship_date: options.ship_date.strftime('%Y-%m-%d'),
-          }.merge(SerializeAddressResidentialIndicator.call(shipment.destination))
+        class << self
+          def call(shipment:, options:)
+            {
+              carrier_ids: options.carrier_ids,
+              from_country_code: shipment.origin.country.alpha_2_code,
+              from_postal_code: shipment.origin.zip,
+              to_country_code: shipment.destination.country.alpha_2_code,
+              to_postal_code: shipment.destination.zip,
+              to_city_locality: shipment.destination.city,
+              to_state_province: shipment.destination.region.code,
+              weight: {
+                value: shipment.packages.map { |p| p.weight.convert_to(:pound).value.to_f }.sum.round(2),
+                unit: 'pound'
+              },
+              dimensions: {
+                unit: 'inch',
+                length: shipment.packages.map { |p| p.length.convert_to(:inch).value.to_f }.sum.round(2),
+                width: shipment.packages.map { |p| p.width.convert_to(:inch).value.to_f }.sum.round(2),
+                height: shipment.packages.map { |p| p.height.convert_to(:inch).value.to_f }.sum.round(2)
+              },
+              confirmation: 'none',
+              ship_date: options.ship_date.strftime('%Y-%m-%d'),
+            }.merge(SerializeAddressResidentialIndicator.call(shipment.destination))
+          end
         end
       end
     end

--- a/lib/friendly_shipping/services/ship_engine/serialize_rate_estimate_request.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_rate_estimate_request.rb
@@ -18,15 +18,26 @@ module FriendlyShipping
                 value: shipment.packages.map { |p| p.weight.convert_to(:pound).value.to_f }.sum.round(2),
                 unit: 'pound'
               },
-              dimensions: {
-                unit: 'inch',
-                length: shipment.packages.map { |p| p.length.convert_to(:inch).value.to_f }.sum.round(2),
-                width: shipment.packages.map { |p| p.width.convert_to(:inch).value.to_f }.sum.round(2),
-                height: shipment.packages.map { |p| p.height.convert_to(:inch).value.to_f }.sum.round(2)
-              },
+              dimensions: dimensions(shipment.packages),
               confirmation: 'none',
               ship_date: options.ship_date.strftime('%Y-%m-%d'),
-            }.merge(SerializeAddressResidentialIndicator.call(shipment.destination))
+            }.merge(SerializeAddressResidentialIndicator.call(shipment.destination)).compact_blank
+          end
+
+          private
+
+          def dimensions(packages)
+            length = packages.map { |p| p.length.convert_to(:inch).value.to_f }.sum.round(2)
+            width = packages.map { |p| p.width.convert_to(:inch).value.to_f }.sum.round(2)
+            height = packages.map { |p| p.height.convert_to(:inch).value.to_f }.sum.round(2)
+            return {} if length == 0 && width == 0 && height == 0
+
+            {
+              unit: 'inch',
+              length: length,
+              width: width,
+              height: height
+            }
           end
         end
       end

--- a/spec/friendly_shipping/services/ship_engine/serialize_rate_estimate_request_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_rate_estimate_request_spec.rb
@@ -39,4 +39,21 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeRateEstimateRequ
       )
     )
   end
+
+  context "when dimensions are missing" do
+    let(:container) do
+      FactoryBot.build(
+        :physical_box,
+        dimensions: [
+          Measured::Length(0, :in),
+          Measured::Length(0, :in),
+          Measured::Length(0, :in)
+        ]
+      )
+    end
+
+    it "excludes dimensions from result" do
+      is_expected.to match(hash_excluding(:dimensions))
+    end
+  end
 end


### PR DESCRIPTION
Instead of passing length/width/height of zero to ShipEngine's rate estimates API endpoint, let's just exclude the dimensions entirely. They aren't required for this API call anyway.