### PR TITLE
Fix rates path and remove ignored attributes

### DIFF
--- a/lib/friendly_shipping/services/ups_json.rb
+++ b/lib/friendly_shipping/services/ups_json.rb
@@ -93,12 +93,13 @@ module FriendlyShipping
 
       # Get rates for a shipment
       # @param [Physical::Shipment] shipment The shipment we want to get rates for
-      # @param [FriendlyShipping::Services::UpsJson::RateOptions] options What options
-      #    to use for this rate request
+      # @param [FriendlyShipping::Services::UpsJson::RatesOptions] options What options
+      #    to use for this rates request
       # @return [Result<ApiResult<Array<Rate>>>] The rates returned from UPS encoded in a
       #   `FriendlyShipping::ApiResult` object.
       def rates(shipment, options:, debug: false)
-        url = "#{base_url}/api/rating/v#{options.sub_version || '1'}/Shop"
+        rate_or_shop = options.shipping_method ? "Rate" : "Shop"
+        url = "#{base_url}/api/rating/v#{options.sub_version || '1'}/#{rate_or_shop}"
         headers = required_headers(access_token)
         rates_request_body = GenerateRatesPayload.call(shipment: shipment, options: options).to_json
 

--- a/lib/friendly_shipping/services/ups_json/generate_rates_payload.rb
+++ b/lib/friendly_shipping/services/ups_json/generate_rates_payload.rb
@@ -11,10 +11,6 @@ module FriendlyShipping
           payload =
             {
               RateRequest: {
-                Request: {
-                  RequestOption: options.shipping_method.present? ? "Rate" : "Shop",
-                  SubVersion: options.sub_version
-                },
                 PickupType: {
                   Code: options.pickup_type_code
                 },

--- a/spec/cassettes/ups_json/rates/rate_modifier.yml
+++ b/spec/cassettes/ups_json/rates/rate_modifier.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://wwwcie.ups.com/api/rating/v2205/Shop
+    uri: https://wwwcie.ups.com/api/rating/v2205/Rate
     body:
       encoding: UTF-8
-      string: '{"RateRequest":{"Request":{"RequestOption":"Rate","SubVersion":"v2205"},"PickupType":{"Code":"01"},"CustomerClassification":{"Code":"00"},"Shipment":{"Shipper":{"AttentionName":"Jane
+      string: '{"RateRequest":{"PickupType":{"Code":"01"},"CustomerClassification":{"Code":"00"},"Shipment":{"Shipper":{"AttentionName":"Jane
         Doe","Name":"Company","ShipperNumber":"%UPS_SHIPPER_NUMBER%","PhoneNumber":"555-555-0199","Address":{"AddressLine":[],"City":"Reno","PostalCode":"89502","StateProvinceCode":"NV","CountryCode":"US"}},"ShipTo":{"AttentionName":"Jane
         Doe","Name":"Company","PhoneNumber":"555-555-0199","Address":{"AddressLine":["1
         Richland Ave"],"City":"San Francisco","PostalCode":"94110","StateProvinceCode":"CA","CountryCode":"US","ResidentialAddressIndicator":"X"}},"ShipFrom":{"AttentionName":"Jane

--- a/spec/cassettes/ups_json/rates/success.yml
+++ b/spec/cassettes/ups_json/rates/success.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://wwwcie.ups.com/api/rating/v2205/Shop
     body:
       encoding: UTF-8
-      string: '{"RateRequest":{"Request":{"RequestOption":"Shop","SubVersion":"v2205","TransactionReference":{"CustomerContext":null}},"PickupType":{"Code":"01"},"CustomerClassification":{"Code":"01"},"Shipment":{"Shipper":{"AttentionName":"Jane
+      string: '{"RateRequest":{"Request":{"TransactionReference":{"CustomerContext":null}},"PickupType":{"Code":"01"},"CustomerClassification":{"Code":"01"},"Shipment":{"Shipper":{"AttentionName":"Jane
         Doe","Name":"Company","ShipperNumber":"Y9319W","PhoneNumber":"555-555-0199","Address":{"AddressLine1":"11
         Lovely Street","AddressLine2":"Suite 100","City":"Herndon","PostalCode":"27703","StateProvinceCode":"NC","CountryCode":"US","ResidentialAddressIndicator":"T"}},"ShipTo":{"AttentionName":"Jane
         Doe","Name":"Company","PhoneNumber":"555-555-0199","Address":{"AddressLine1":"11

--- a/spec/cassettes/ups_json/rates/sure_post_rate.yml
+++ b/spec/cassettes/ups_json/rates/sure_post_rate.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://wwwcie.ups.com/api/rating/v2205/Shop
+    uri: https://wwwcie.ups.com/api/rating/v2205/Rate
     body:
       encoding: UTF-8
-      string: '{"RateRequest":{"Request":{"RequestOption":"Rate","SubVersion":"v2205","TransactionReference":{"CustomerContext":null}},"PickupType":{"Code":"01"},"CustomerClassification":{"Code":"01"},"Shipment":{"Shipper":{"AttentionName":"Jane
+      string: '{"RateRequest":{"Request":{"TransactionReference":{"CustomerContext":null}},"PickupType":{"Code":"01"},"CustomerClassification":{"Code":"01"},"Shipment":{"Shipper":{"AttentionName":"Jane
         Doe","Name":"Company","ShipperNumber":"%UPS_SHIPPER_NUMBER%","PhoneNumber":"555-555-0199","Address":{"AddressLine1":"11
         Lovely Street","AddressLine2":"Suite 100","City":"Herndon","PostalCode":"27703","StateProvinceCode":"NC","CountryCode":"US","ResidentialAddressIndicator":"T"}},"ShipTo":{"AttentionName":"Jane
         Doe","Name":"Company","PhoneNumber":"555-555-0199","Address":{"AddressLine1":"11

--- a/spec/cassettes/ups_json/rates/sure_post_success.yml
+++ b/spec/cassettes/ups_json/rates/sure_post_success.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://wwwcie.ups.com/api/rating/v2205/Shop
+    uri: https://wwwcie.ups.com/api/rating/v2205/Rate
     body:
       encoding: UTF-8
-      string: '{"RateRequest":{"Request":{"RequestOption":"Rate","SubVersion":"v2205","TransactionReference":{"CustomerContext":null}},"PickupType":{"Code":"01"},"CustomerClassification":{"Code":"01"},"Shipment":{"Shipper":{"AttentionName":"Jane
+      string: '{"RateRequest":{"Request":{"TransactionReference":{"CustomerContext":null}},"PickupType":{"Code":"01"},"CustomerClassification":{"Code":"01"},"Shipment":{"Shipper":{"AttentionName":"Jane
         Doe","Name":"Company","ShipperNumber":"%UPS_SHIPPER_NUMBER%","PhoneNumber":"555-555-0199","Address":{"AddressLine1":"11
         Lovely Street","AddressLine2":"Suite 100","City":"Herndon","PostalCode":"27703","StateProvinceCode":"NC","CountryCode":"US","ResidentialAddressIndicator":"T"}},"ShipTo":{"AttentionName":"Jane
         Doe","Name":"Company","PhoneNumber":"555-555-0199","Address":{"AddressLine1":"11


### PR DESCRIPTION
UPS [documents](https://developer.ups.com/api/reference?loc=en_US#operation/Rate) the requestoption and version as required in both the path and the body of the request, but only the values in the path are used. This removes the ignored body attributes and fixes the path (the one that is actually used).