### PR TITLE
Add `comparison_rate_type` to ShipEngine rates requests

### DIFF
--- a/lib/friendly_shipping/services/ship_engine/rates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_options.rb
@@ -9,25 +9,39 @@ module FriendlyShipping
       #
       # @attribute carriers [Array<FriendlyShipping::Carrier>] a list of the carriers we want to get IDs from.
       # @attribute service_code [String] The service code we want to get rates for.
+      # @attribute ship_date [Time] The date we want to ship on.
+      # @attribute comparison_rate_type [String] Set to "retail" for retail rates (UPS/USPS only).
       class RatesOptions < FriendlyShipping::ShipmentOptions
         attr_reader :carriers,
                     :service_code,
-                    :ship_date
+                    :ship_date,
+                    :comparison_rate_type
 
         def initialize(
           carriers:,
           service_code:,
           ship_date: Time.now,
+          comparison_rate_type: nil,
           **kwargs
         )
           @carriers = carriers
           @service_code = service_code
           @ship_date = ship_date
+          @comparison_rate_type = comparison_rate_type
+          validate_comparison_rate_type!
           super(**kwargs.reverse_merge(package_options_class: RatesPackageOptions))
         end
 
         def carrier_ids
           carriers.map(&:id)
+        end
+
+        private
+
+        def validate_comparison_rate_type!
+          return if comparison_rate_type.nil? || comparison_rate_type == "retail"
+
+          raise ArgumentError, "Invalid comparison rate type: #{comparison_rate_type}"
         end
       end
     end

--- a/lib/friendly_shipping/services/ship_engine/serialize_address_residential_indicator.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_address_residential_indicator.rb
@@ -16,7 +16,7 @@ module FriendlyShipping
           # @param location [Physical::Location]
           # @return [String]
           def residential_indicator(location)
-            return "unknown" if location.address_type.nil?
+            return "unknown" if location&.address_type.nil?
 
             location.address_type == "residential" ? "yes" : "no"
           end

--- a/lib/friendly_shipping/services/ship_engine/serialize_rates_request.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_rates_request.rb
@@ -15,6 +15,7 @@ module FriendlyShipping
                 ship_from: serialize_address(shipment.origin),
                 items: serialize_items(shipment.packages.first),
                 packages: serialize_packages(shipment, options),
+                comparison_rate_type: options.comparison_rate_type,
                 confirmation: 'none'
               }.merge(SerializeAddressResidentialIndicator.call(shipment.destination)),
               rate_options: {

--- a/lib/friendly_shipping/services/ship_engine/serialize_rates_request.rb
+++ b/lib/friendly_shipping/services/ship_engine/serialize_rates_request.rb
@@ -17,7 +17,7 @@ module FriendlyShipping
                 packages: serialize_packages(shipment, options),
                 comparison_rate_type: options.comparison_rate_type,
                 confirmation: 'none'
-              }.merge(SerializeAddressResidentialIndicator.call(shipment.destination)),
+              }.merge(SerializeAddressResidentialIndicator.call(shipment.destination)).compact_blank,
               rate_options: {
                 carrier_ids: options.carrier_ids,
                 service_codes: [options.service_code],
@@ -37,6 +37,8 @@ module FriendlyShipping
           private
 
           def serialize_items(package)
+            return [] unless package&.items.present?
+
             package.items.group_by(&:sku).map do |sku, items|
               reference_item = items.first
               {

--- a/spec/friendly_shipping/services/ship_engine/rates_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/rates_options_spec.rb
@@ -7,17 +7,32 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::RatesOptions do
     described_class.new(
       carriers: [double(id: "se-12345")],
       service_code: "usps_priority_mail",
-      ship_date: Time.parse("2023-11-16")
+      ship_date: Time.parse("2023-11-16"),
+      comparison_rate_type: comparison_rate_type
     )
   end
+
+  let(:comparison_rate_type) { "retail" }
 
   it { is_expected.to respond_to(:carriers) }
   it { is_expected.to respond_to(:service_code) }
   it { is_expected.to respond_to(:ship_date) }
+  it { is_expected.to respond_to(:comparison_rate_type) }
   it { is_expected.to be_a(FriendlyShipping::ShipmentOptions) }
 
   it_behaves_like "overrideable package options class" do
     let(:default_class) { FriendlyShipping::PackageOptions }
     let(:required_attrs) { { carriers: [], service_code: nil } }
+  end
+
+  describe "comparison rate type validation" do
+    let(:comparison_rate_type) { "bogus" }
+
+    it do
+      expect { options }.to raise_error(
+        ArgumentError,
+        "Invalid comparison rate type: bogus"
+      )
+    end
   end
 end

--- a/spec/friendly_shipping/services/ship_engine/serialize_rates_request_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_rates_request_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeRatesRequest do
       carriers: [carrier],
       service_code: "usps_priority_mail",
       ship_date: ship_date,
+      comparison_rate_type: "retail",
       package_options: [
         FriendlyShipping::Services::ShipEngine::RatesPackageOptions.new(
           package_id: "package 1",
@@ -91,6 +92,7 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeRatesRequest do
               }
             }]
           }],
+          comparison_rate_type: "retail",
           confirmation: "none",
           address_residential_indicator: "unknown"
         },

--- a/spec/friendly_shipping/services/ship_engine/serialize_rates_request_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/serialize_rates_request_spec.rb
@@ -103,4 +103,30 @@ RSpec.describe FriendlyShipping::Services::ShipEngine::SerializeRatesRequest do
       )
     )
   end
+
+  context "with missing values" do
+    let(:shipment) { FactoryBot.build(:physical_shipment, packages: []) }
+    let(:options) do
+      FriendlyShipping::Services::ShipEngine::RatesOptions.new(
+        carriers: [carrier],
+        service_code: "usps_priority_mail"
+      )
+    end
+
+    it do
+      is_expected.to match(
+        shipment: hash_including(
+          address_residential_indicator: "unknown",
+          carrier_ids: ["se-123456"],
+          confirmation: "none",
+          service_code: "usps_priority_mail",
+          ship_date: Time.now.strftime("%Y-%m-%d")
+        ),
+        rate_options: {
+          carrier_ids: ["se-123456"],
+          service_codes: ["usps_priority_mail"]
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
When `comparison_rate_type` is set to "retail" ShipEngine returns retail rates (instead of commercial rates) from the rates API endpoint. Note that this only works for UPS/USPS carriers.