### PR TITLE
Fix YARD docs for ShipEngine rates options

### DIFF
--- a/lib/friendly_shipping/carrier.rb
+++ b/lib/friendly_shipping/carrier.rb
@@ -4,7 +4,7 @@ module FriendlyShipping
   class Carrier
     attr_reader :id, :name, :code, :shipping_methods, :balance, :data
 
-    # @param [Integer] id The carrier's ID
+    # @param [Integer, String] id The carrier's ID
     # @param [String] name The carrier's name
     # @param [String] code The carrier's unique code
     # @param [Array] shipping_methods The shipping methods available on this carrier

--- a/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
@@ -5,14 +5,19 @@ require 'friendly_shipping/shipment_options'
 module FriendlyShipping
   module Services
     class ShipEngine
-      # options for the rate estimates call
-      #
-      # @attribute carriers [Array<FriendlyShipping::Carrier] a list of the carriers we want to get IDs from.
-      # @attribute ship_date [#strftime] the date we want to ship on.
+      # Options for generating rate estimates for a shipment.
       class RateEstimatesOptions < ShipmentOptions
-        attr_reader :carriers,
-                    :ship_date
+        # @return [Array<Carrier>]
+        attr_reader :carriers
 
+        # @return [#strftime]
+        attr_reader :ship_date
+
+        # @param carriers [Array<Carrier>] the carriers for which we want to get rate estimates
+        # @param ship_date [#strftime] the date we want to ship on
+        # @param kwargs [Hash]
+        # @option kwargs [Enumerable<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           carriers:,
           ship_date: Date.today,
@@ -23,6 +28,7 @@ module FriendlyShipping
           super(**kwargs)
         end
 
+        # @return [Array<String>]
         def carrier_ids
           carriers.map(&:id)
         end

--- a/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
@@ -8,13 +8,14 @@ module FriendlyShipping
       # options for the rate estimates call
       #
       # @attribute carriers [Array<FriendlyShipping::Carrier] a list of the carriers we want to get IDs from.
+      # @attribute ship_date [#strftime] the date we want to ship on.
       class RateEstimatesOptions < ShipmentOptions
         attr_reader :carriers,
                     :ship_date
 
         def initialize(
           carriers:,
-          ship_date: Time.now,
+          ship_date: Date.today,
           **kwargs
         )
           @carriers = carriers

--- a/lib/friendly_shipping/services/ship_engine/rates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_options.rb
@@ -5,18 +5,27 @@ require 'friendly_shipping/shipment_options'
 module FriendlyShipping
   module Services
     class ShipEngine
-      # Options for generating rates for a shipment
-      #
-      # @attribute carriers [Array<FriendlyShipping::Carrier>] a list of the carriers we want to get IDs from.
-      # @attribute service_code [String] The service code we want to get rates for.
-      # @attribute ship_date [#strftime] The date we want to ship on.
-      # @attribute comparison_rate_type [String] Set to "retail" for retail rates (UPS/USPS only).
+      # Options for generating rates for a shipment.
       class RatesOptions < FriendlyShipping::ShipmentOptions
-        attr_reader :carriers,
-                    :service_code,
-                    :ship_date,
-                    :comparison_rate_type
+        # @return [Array<Carrier>]
+        attr_reader :carriers
 
+        # @return [String]
+        attr_reader :service_code
+
+        # @return [#strftime]
+        attr_reader :ship_date
+
+        # @return [String]
+        attr_reader :comparison_rate_type
+
+        # @param carriers [Array<Carrier>] the carriers for which we want to get rates
+        # @param service_code [String] the service code for which we want to get rates
+        # @param ship_date [#strftime] the date we want to ship on
+        # @param comparison_rate_type [String] set to "retail" for retail rates (UPS/USPS only)
+        # @param kwargs [Hash]
+        # @option kwargs [Enumerable<PackageOptions>] :package_options the options for packages in this shipment
+        # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
         def initialize(
           carriers:,
           service_code:,
@@ -32,12 +41,15 @@ module FriendlyShipping
           super(**kwargs.reverse_merge(package_options_class: RatesPackageOptions))
         end
 
+        # @return [Array<String>]
         def carrier_ids
           carriers.map(&:id)
         end
 
         private
 
+        # @raise [ArgumentError] invalid comparison rate type
+        # @return [nil]
         def validate_comparison_rate_type!
           return if comparison_rate_type.nil? || comparison_rate_type == "retail"
 

--- a/lib/friendly_shipping/services/ship_engine/rates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_options.rb
@@ -9,7 +9,7 @@ module FriendlyShipping
       #
       # @attribute carriers [Array<FriendlyShipping::Carrier>] a list of the carriers we want to get IDs from.
       # @attribute service_code [String] The service code we want to get rates for.
-      # @attribute ship_date [Time] The date we want to ship on.
+      # @attribute ship_date [#strftime] The date we want to ship on.
       # @attribute comparison_rate_type [String] Set to "retail" for retail rates (UPS/USPS only).
       class RatesOptions < FriendlyShipping::ShipmentOptions
         attr_reader :carriers,
@@ -20,7 +20,7 @@ module FriendlyShipping
         def initialize(
           carriers:,
           service_code:,
-          ship_date: Time.now,
+          ship_date: Date.today,
           comparison_rate_type: nil,
           **kwargs
         )


### PR DESCRIPTION
There was some confusion surrounding the `ship_date` attribute. Was it a date or a time? This clarifies that it can be anything as long as it responds to the `#strftime` method.

Also took the opportunity to clean up and finish the YARD docs for these 2 options classes.