### PR TITLE
Remove periods from city names for R+L requests

### DIFF
--- a/lib/friendly_shipping/services/rl/serialize_location.rb
+++ b/lib/friendly_shipping/services/rl/serialize_location.rb
@@ -13,7 +13,7 @@ module FriendlyShipping
               CompanyName: location.company_name.presence || location.name,
               AddressLine1: location.address1,
               AddressLine2: location.address2,
-              City: location.city,
+              City: clean_city(location.city),
               StateOrProvince: location.region.code,
               ZipOrPostalCode: location.zip,
               CountryCode: location.country.alpha_3_code,
@@ -23,6 +23,14 @@ module FriendlyShipping
           end
 
           private
+
+          # R+L does not support periods in city names.
+          #
+          # @param city [String]
+          # @return [String]
+          def clean_city(city)
+            city.delete(".").strip
+          end
 
           # R+L does not support leading country codes in phone numbers.
           #

--- a/spec/friendly_shipping/services/rl/serialize_location_spec.rb
+++ b/spec/friendly_shipping/services/rl/serialize_location_spec.rb
@@ -56,4 +56,16 @@ RSpec.describe FriendlyShipping::Services::RL::SerializeLocation do
       )
     end
   end
+
+  context "when city has period" do
+    let(:location) { FactoryBot.build(:physical_location, city: "  St. Augustine  ") }
+
+    it do
+      is_expected.to match(
+        hash_including(
+          City: "St Augustine"
+        )
+      )
+    end
+  end
 end


### PR DESCRIPTION
R+L does not accept periods in city names. We need to remove them before sending requests containing addresses.