### PR TITLE
Fix Poland's ISO code

### DIFF
--- a/lib/friendly_shipping/services/ups/shipping_methods.rb
+++ b/lib/friendly_shipping/services/ups/shipping_methods.rb
@@ -4,7 +4,7 @@ module FriendlyShipping
   module Services
     class Ups
       EU_COUNTRIES = %w(
-        AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE IT LT LU LV MT NL PO PT RO SE SI SK
+        AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE IT LT LU LV MT NL PL PT RO SE SI SK
       ).map { |country_code| Carmen::Country.coded(country_code) }
 
       class << self


### PR DESCRIPTION
Poland's ISO code is PL, not PO. This error leads to a country being `nil`, and further errors.