### PR TITLE
Update TForce handling units class to use structures instead of packages

### DIFF
--- a/lib/friendly_shipping/services/tforce_freight/generate_handling_units_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_handling_units_hash.rb
@@ -19,20 +19,28 @@ module FriendlyShipping
           # @param options [FriendlyShipping::ShipmentOptions]
           # @return [Array<Hash>]
           def handling_units(shipment, options)
-            all_package_options = shipment.packages.map { |package| options.options_for_package(package) }
-            all_package_options.group_by(&:handling_unit_code).map do |_handling_unit_code, options_group|
-              [options_group.first, options_group.length]
-            end.map { |package_options, quantity| handling_unit_hash(package_options, quantity) }
+            if shipment.packages.any?
+              warn "[DEPRECATION] `packages` is deprecated.  Please use `structures` instead."
+              all_package_options = shipment.packages.map { |package| options.options_for_package(package) }
+              all_package_options.group_by(&:handling_unit_code).map do |_handling_unit_code, options_group|
+                [options_group.first, options_group.length]
+              end.map { |package_options, quantity| handling_unit_hash(package_options, quantity) }
+            else
+              all_structure_options = shipment.structures.map { |structure| options.options_for_structure(structure) }
+              all_structure_options.group_by(&:handling_unit_code).map do |_handling_unit_code, options_group|
+                [options_group.first, options_group.length]
+              end.map { |structure_options, quantity| handling_unit_hash(structure_options, quantity) }
+            end
           end
 
-          # @param package_options [FriendlyShipping::PackageOptions]
+          # @param options [PackageOptions, StructureOptions]
           # @param quantity [Integer]
           # @return [Hash]
-          def handling_unit_hash(package_options, quantity)
+          def handling_unit_hash(options, quantity)
             {
-              package_options.handling_unit_tag.to_sym => {
+              options.handling_unit_tag.to_sym => {
                 quantity: quantity,
-                typeCode: package_options.handling_unit_code
+                typeCode: options.handling_unit_code
               }
             }
           end

--- a/lib/friendly_shipping/services/tforce_freight/structure_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/structure_options.rb
@@ -3,8 +3,39 @@
 module FriendlyShipping
   module Services
     class TForceFreight
+      # Options for structures/pallets within a TForce Freight shipment.
       class StructureOptions < FriendlyShipping::StructureOptions
-        def initialize(**kwargs)
+        # Maps friendly names to handling unit types.
+        HANDLING_UNIT_TYPES = {
+          pallet: { code: "PLT", description: "Pallet", handling_unit_tag: 'One' },
+          skid: { code: "SKD", description: "Skid", handling_unit_tag: 'One' },
+          carboy: { code: "CBY", description: "Carboy", handling_unit_tag: 'One' },
+          totes: { code: "TOT", description: "Totes", handling_unit_tag: 'One' },
+          other: { code: "OTH", description: "Other", handling_unit_tag: 'Two' },
+          loose: { code: "LOO", description: "Loose", handling_unit_tag: 'Two' }
+        }.freeze
+
+        # @return [String]
+        attr_reader :handling_unit_description
+
+        # @return [String]
+        attr_reader :handling_unit_tag
+
+        # @return [String]
+        attr_reader :handling_unit_code
+
+        # @param handling_unit [Symbol] how this shipment is divided (see {HANDLING_UNIT_TYPES})
+        # @param kwargs [Hash]
+        # @options kwargs [Object] :structure_id unique identifier for this set of options
+        # @options kwargs [Array<PackageOptions>] :package_options the options for packages in this structure
+        # @options kwargs [Class] :package_options_class the class to use for package options when none are provided
+        def initialize(
+          handling_unit: :pallet,
+          **kwargs
+        )
+          @handling_unit_code = HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:code)
+          @handling_unit_description = HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:description)
+          @handling_unit_tag = "handlingUnit#{HANDLING_UNIT_TYPES.fetch(handling_unit).fetch(:handling_unit_tag)}"
           super(**kwargs.reverse_merge(package_options_class: RatesPackageOptions))
         end
       end

--- a/lib/friendly_shipping/services/ups_freight/generate_handling_units_hash.rb
+++ b/lib/friendly_shipping/services/ups_freight/generate_handling_units_hash.rb
@@ -3,6 +3,7 @@
 module FriendlyShipping
   module Services
     class UpsFreight
+      # Generates a handling units hash for JSON serialization.
       class GenerateHandlingUnitsHash
         class << self
           # @param shipment [Physical::Shipment]

--- a/lib/friendly_shipping/services/ups_freight/rates_structure_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_structure_options.rb
@@ -5,7 +5,7 @@ require 'friendly_shipping/services/ups_freight/rates_package_options'
 module FriendlyShipping
   module Services
     class UpsFreight
-      # Options for structures/pallets within a UPS Freight shipment
+      # Options for structures/pallets within a UPS Freight shipment.
       class RatesStructureOptions < FriendlyShipping::StructureOptions
         # Maps friendly names to handling unit types.
         HANDLING_UNIT_TYPES = {

--- a/spec/friendly_shipping/services/tforce_freight/generate_handling_units_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_handling_units_hash_spec.rb
@@ -5,28 +5,28 @@ require 'spec_helper'
 RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateHandlingUnitsHash do
   subject { described_class.call(shipment: shipment, options: options) }
 
-  let(:shipment) { Physical::Shipment.new(packages: packages) }
-  let(:packages) { [pallet_1, pallet_2, other] }
+  let(:shipment) { Physical::Shipment.new(structures: pallets) }
+  let(:pallets) { [pallet_1, pallet_2, other] }
 
-  let(:pallet_1) { Physical::Package.new(id: "pallet 1") }
-  let(:pallet_2) { Physical::Package.new(id: "pallet 2") }
-  let(:other) { Physical::Package.new(id: "other") }
+  let(:pallet_1) { Physical::Structure.new(id: "pallet 1") }
+  let(:pallet_2) { Physical::Structure.new(id: "pallet 2") }
+  let(:other) { Physical::Structure.new(id: "other") }
 
   let(:options) do
     FriendlyShipping::Services::TForceFreight::RatesOptions.new(
       billing_address: billing_address,
       shipping_method: shipping_method,
-      package_options: [
-        FriendlyShipping::Services::TForceFreight::PackageOptions.new(
-          package_id: "pallet 1",
+      structure_options: [
+        FriendlyShipping::Services::TForceFreight::StructureOptions.new(
+          structure_id: "pallet 1",
           handling_unit: :pallet
         ),
-        FriendlyShipping::Services::TForceFreight::PackageOptions.new(
-          package_id: "pallet 2",
+        FriendlyShipping::Services::TForceFreight::StructureOptions.new(
+          structure_id: "pallet 2",
           handling_unit: :pallet
         ),
-        FriendlyShipping::Services::TForceFreight::PackageOptions.new(
-          package_id: "other",
+        FriendlyShipping::Services::TForceFreight::StructureOptions.new(
+          structure_id: "other",
           handling_unit: :other
         )
       ]
@@ -47,5 +47,53 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateHandlingUnitsH
         typeCode: "OTH"
       }
     )
+  end
+
+  describe "deprecated packages behavior" do
+    # TODO: Remove when deprecated packages are removed
+
+    let(:shipment) { Physical::Shipment.new(packages: packages) }
+    let(:packages) { [pallet_1, pallet_2, other] }
+
+    let(:pallet_1) { Physical::Package.new(id: "pallet 1") }
+    let(:pallet_2) { Physical::Package.new(id: "pallet 2") }
+    let(:other) { Physical::Package.new(id: "other") }
+
+    let(:options) do
+      FriendlyShipping::Services::TForceFreight::RatesOptions.new(
+        billing_address: billing_address,
+        shipping_method: shipping_method,
+        package_options: [
+          FriendlyShipping::Services::TForceFreight::PackageOptions.new(
+            package_id: "pallet 1",
+            handling_unit: :pallet
+          ),
+          FriendlyShipping::Services::TForceFreight::PackageOptions.new(
+            package_id: "pallet 2",
+            handling_unit: :pallet
+          ),
+          FriendlyShipping::Services::TForceFreight::PackageOptions.new(
+            package_id: "other",
+            handling_unit: :other
+          )
+        ]
+      )
+    end
+
+    let(:billing_address) { FactoryBot.build(:physical_location) }
+    let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: "03") }
+
+    it do
+      is_expected.to eq(
+        handlingUnitOne: {
+          quantity: 2,
+          typeCode: "PLT"
+        },
+        handlingUnitTwo: {
+          quantity: 1,
+          typeCode: "OTH"
+        }
+      )
+    end
   end
 end

--- a/spec/friendly_shipping/services/tforce_freight/structure_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/structure_options_spec.rb
@@ -5,6 +5,22 @@ require 'spec_helper'
 RSpec.describe FriendlyShipping::Services::TForceFreight::StructureOptions do
   subject(:options) { described_class.new(structure_id: "structure") }
 
+  it "has the right attributes" do
+    expect(subject.handling_unit_code).to eq("PLT")
+    expect(subject.handling_unit_description).to eq("Pallet")
+    expect(subject.handling_unit_tag).to eq("handlingUnitOne")
+  end
+
+  context "with loose packaging" do
+    subject { described_class.new(structure_id: nil, handling_unit: :loose) }
+
+    it "has the right attributes" do
+      expect(subject.handling_unit_code).to eq("LOO")
+      expect(subject.handling_unit_description).to eq("Loose")
+      expect(subject.handling_unit_tag).to eq("handlingUnitTwo")
+    end
+  end
+
   it_behaves_like "overrideable package options class" do
     let(:default_class) { FriendlyShipping::Services::TForceFreight::RatesPackageOptions }
     let(:required_attrs) { { structure_id: "structure" } }

--- a/spec/friendly_shipping/services/ups_freight/generate_handling_units_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_handling_units_hash_spec.rb
@@ -2,33 +2,32 @@
 
 require 'spec_helper'
 
-# TODO write specs for structures
 RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateHandlingUnitsHash do
   subject { described_class.call(shipment: shipment, options: options) }
 
-  let(:shipment) { Physical::Shipment.new(packages: packages) }
-  let(:packages) { [pallet_1, pallet_2, other] }
+  let(:shipment) { Physical::Shipment.new(structures: pallets) }
+  let(:pallets) { [pallet_1, pallet_2, other] }
 
-  let(:pallet_1) { Physical::Package.new(id: "pallet 1") }
-  let(:pallet_2) { Physical::Package.new(id: "pallet 2") }
-  let(:other) { Physical::Package.new(id: "other") }
+  let(:pallet_1) { Physical::Structure.new(id: "pallet 1") }
+  let(:pallet_2) { Physical::Structure.new(id: "pallet 2") }
+  let(:other) { Physical::Structure.new(id: "other") }
 
   let(:options) do
     FriendlyShipping::Services::UpsFreight::RatesOptions.new(
       shipper_number: "123",
       billing_address: billing_address,
       shipping_method: shipping_method,
-      package_options: [
-        FriendlyShipping::Services::UpsFreight::RatesPackageOptions.new(
-          package_id: "pallet 1",
+      structure_options: [
+        FriendlyShipping::Services::UpsFreight::RatesStructureOptions.new(
+          structure_id: "pallet 1",
           handling_unit: :pallet
         ),
-        FriendlyShipping::Services::UpsFreight::RatesPackageOptions.new(
-          package_id: "pallet 2",
+        FriendlyShipping::Services::UpsFreight::RatesStructureOptions.new(
+          structure_id: "pallet 2",
           handling_unit: :pallet
         ),
-        FriendlyShipping::Services::UpsFreight::RatesPackageOptions.new(
-          package_id: "other",
+        FriendlyShipping::Services::UpsFreight::RatesStructureOptions.new(
+          structure_id: "other",
           handling_unit: :other
         )
       ]
@@ -57,5 +56,62 @@ RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateHandlingUnitsHash
         }
       }
     )
+  end
+
+  describe "deprecated packages behavior" do
+    # TODO: Remove when deprecated packages are removed
+
+    let(:shipment) { Physical::Shipment.new(packages: packages) }
+    let(:packages) { [pallet_1, pallet_2, other] }
+
+    let(:pallet_1) { Physical::Package.new(id: "pallet 1") }
+    let(:pallet_2) { Physical::Package.new(id: "pallet 2") }
+    let(:other) { Physical::Package.new(id: "other") }
+
+    let(:options) do
+      FriendlyShipping::Services::UpsFreight::RatesOptions.new(
+        shipper_number: "123",
+        billing_address: billing_address,
+        shipping_method: shipping_method,
+        package_options: [
+          FriendlyShipping::Services::UpsFreight::RatesPackageOptions.new(
+            package_id: "pallet 1",
+            handling_unit: :pallet
+          ),
+          FriendlyShipping::Services::UpsFreight::RatesPackageOptions.new(
+            package_id: "pallet 2",
+            handling_unit: :pallet
+          ),
+          FriendlyShipping::Services::UpsFreight::RatesPackageOptions.new(
+            package_id: "other",
+            handling_unit: :other
+          )
+        ]
+      )
+    end
+
+    let(:billing_address) { FactoryBot.build(:physical_location) }
+    let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: "03") }
+
+    it do
+      is_expected.to eq(
+        {
+          HandlingUnitOne: {
+            Quantity: "2",
+            Type: {
+              Code: "PLT",
+              Description: "Pallet"
+            }
+          },
+          HandlingUnitTwo: {
+            Quantity: "1",
+            Type: {
+              Code: "OTH",
+              Description: "Other"
+            }
+          }
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
Updates the TForce `GenerateHandlingUnitsHash` class to use structures instead of packages. This was overlooked during the [recent updates](https://github.com/friendlycart/friendly_shipping/pull/201) of our Freight service classes to use structures (pallets) and packages.