### PR TITLE
Remove duplicate package deprecation warnings

### DIFF
--- a/lib/friendly_shipping/services/rl/bol_options.rb
+++ b/lib/friendly_shipping/services/rl/bol_options.rb
@@ -33,6 +33,10 @@ module FriendlyShipping
         # @return [Callable] the structures serializer
         attr_reader :structures_serializer
 
+        # @return [Callable]
+        # @deprecated Use {#structures_serializer} instead.
+        attr_reader :packages_serializer
+
         # @param pickup_time_window [Range]
         # @param pickup_instructions [String]
         # @param declared_value [Numeric]
@@ -83,13 +87,6 @@ module FriendlyShipping
           Freezable
           DeliveryAppointment
         ].freeze
-
-        # @return [Callable]
-        # @deprecated Use {#structures_serializer} instead.
-        def packages_serializer
-          warn "[DEPRECATION] `packages_serializer` is deprecated.  Please use `structures_serializer` instead."
-          @packages_serializer
-        end
 
         private
 

--- a/lib/friendly_shipping/services/rl/rate_quote_options.rb
+++ b/lib/friendly_shipping/services/rl/rate_quote_options.rb
@@ -21,6 +21,10 @@ module FriendlyShipping
         # @return [Callable] the serializer for this shipment's structures
         attr_reader :structures_serializer
 
+        # @return [Callable] the serializer for this shipment's packages
+        # @deprecated Use {#structures_serializer} instead.
+        attr_reader :packages_serializer
+
         # @param pickup_date [Time] the pickup date
         # @param declared_value [Numeric] the declared value of this shipment
         # @param additional_service_codes [Array<String>] additional service codes
@@ -62,13 +66,6 @@ module FriendlyShipping
           SortAndSegregate
           OverDimension
         ].freeze
-
-        # @return [Callable]
-        # @deprecated Use {#structures_serializer} instead.
-        def packages_serializer
-          warn "[DEPRECATION] `packages_serializer` is deprecated.  Please use `structures_serializer` instead."
-          @packages_serializer
-        end
 
         private
 

--- a/lib/friendly_shipping/services/rl/shipment_options.rb
+++ b/lib/friendly_shipping/services/rl/shipment_options.rb
@@ -38,11 +38,12 @@ module FriendlyShipping
         attr_reader :structure_options_class
 
         # @return [Array<PackageOptions>]
-        # @deprecated Use {#structure_options} instead.
-        def package_options
-          warn "[DEPRECATION] `package_options` is deprecated.  Please use `structure_options` instead."
-          @package_options
-        end
+        # @deprecated Use {#structures_serializer} instead.
+        attr_reader :package_options
+
+        # @return [Class]
+        # @deprecated Use {#structures_serializer_class} instead.
+        attr_reader :package_options_class
       end
     end
   end

--- a/lib/friendly_shipping/services/ship_engine_ltl/quote_options.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/quote_options.rb
@@ -17,6 +17,10 @@ module FriendlyShipping
         # @return [Class] the class to use for serializing structures
         attr_reader :structures_serializer_class
 
+        # @return [Class] the class to use for serializing packages
+        # @deprecated Use {#structures_serializer_class} instead.
+        attr_reader :packages_serializer_class
+
         # @param service_code [String] the service code to use when getting rates
         # @param pickup_date [Time] the pickup date
         # @param accessorial_service_codes [Array<String>] the accessorial service codes (if any)
@@ -41,13 +45,6 @@ module FriendlyShipping
           @structures_serializer_class = structures_serializer_class
           @packages_serializer_class = packages_serializer_class
           super(**kwargs)
-        end
-
-        # @return [Class]
-        # @deprecated Use {#structures_serializer_class} instead.
-        def packages_serializer_class
-          warn "[DEPRECATION] `packages_serializer_class` is deprecated.  Please use `structures_serializer_class` instead."
-          @packages_serializer_class
         end
       end
     end


### PR DESCRIPTION
This cleans up some deprecation warnings that were duplicating warnings elsewhere in the code.

For example, we were checking `if options.package_options` in some places and warning about deprecations if the options existed, but this would also trigger the warning within the `#package_options` method itself which was unnecessary.