### PR TITLE
Deprecate legacy First Class mail types

### DIFF
--- a/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
@@ -42,8 +42,13 @@ module FriendlyShipping
           CONTAINERS.fetch(box_name)
         end
 
+        # @return [String, nil]
         def first_class_mail_type_code
-          FIRST_CLASS_MAIL_TYPES[first_class_mail_type]
+          if %i[parcel package_service package_service_retail].include?(first_class_mail_type)
+            warn "[DEPRECATION] First Class `:#{first_class_mail_type}` has been replaced by Ground Advantage."
+          else
+            FIRST_CLASS_MAIL_TYPES[first_class_mail_type]
+          end
         end
 
         def service_code

--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -23,7 +23,7 @@ module FriendlyShipping
                   package_options = options.options_for_package(package)
                   xml.Package('ID' => index) do
                     xml.Service(package_options.service_code)
-                    if package_options.first_class_mail_type
+                    if package_options.first_class_mail_type && package_options.first_class_mail_type_code
                       xml.FirstClassMailType(package_options.first_class_mail_type_code)
                     end
                     xml.ZipOrigination(shipment.origin.zip)

--- a/lib/friendly_shipping/services/usps/shipping_methods.rb
+++ b/lib/friendly_shipping/services/usps/shipping_methods.rb
@@ -23,10 +23,11 @@ module FriendlyShipping
       FIRST_CLASS_MAIL_TYPES = {
         letter: 'LETTER',
         flat: 'FLAT',
-        parcel: 'PARCEL',
+        parcel: 'PARCEL', # @deprecated
         post_card: 'POSTCARD',
-        package_service: 'PACKAGE SERVICE',
-        package_service_retail: 'PACKAGE SERVICE RETAIL'
+        large_post_card: 'LARGE POSTCARD',
+        package_service: 'PACKAGE SERVICE', # @deprecated
+        package_service_retail: 'PACKAGE SERVICE RETAIL' # @deprecated
       }.freeze
 
       CLASS_IDS = {

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -4,12 +4,21 @@ require 'spec_helper'
 require 'friendly_shipping/services/usps/rate_estimate_package_options'
 
 RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
-  subject { described_class.new(package_id: package_id) }
+  subject(:options) do
+    described_class.new(
+      **kwargs.merge(
+        package_id: package_id
+      )
+    )
+  end
+
   let(:package_id) { 'my_package_id' }
+  let(:kwargs) { { box_name: :large_flat_rate_box } }
 
   [
     :box_name,
     :commercial_pricing,
+    :first_class_mail_type,
     :hold_for_pickup,
     :shipping_method,
     :transmit_dimensions,
@@ -20,68 +29,83 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
     it { is_expected.to respond_to(message) }
   end
 
-  describe 'box_name' do
-    context 'when setting it to something that is no USPS box' do
-      subject do
-        described_class.new(
-          package_id: package_id,
-          box_name: :package
-        )
-      end
+  describe '#box_name' do
+    subject(:box_name) { options.box_name }
 
-      it 'become "variable"' do
-        expect(subject.box_name).to eq(:variable)
-      end
+    it { is_expected.to eq(:large_flat_rate_box) }
+
+    context 'when setting it to something that is not a USPS box' do
+      let(:kwargs) { { box_name: :package } }
+      it { is_expected.to eq(:variable) }
+    end
+  end
+
+  describe '#container_code' do
+    subject(:container_code) { options.container_code }
+
+    it { is_expected.to eq('LG FLAT RATE BOX') }
+  end
+
+  describe '#first_class_mail_type_code' do
+    subject(:first_class_mail_type_code) { options.first_class_mail_type_code }
+
+    let(:kwargs) { { first_class_mail_type: :letter } }
+    it { is_expected.to eq('LETTER') }
+
+    context 'with deprecated first class mail type' do
+      let(:kwargs) { { first_class_mail_type: :parcel } }
+      it { is_expected.to be_nil }
     end
   end
 
   describe '#service_code' do
-    subject do
-      described_class.new(
-        package_id: package_id,
+    subject(:service_code) { options.service_code }
+
+    let(:kwargs) do
+      {
         shipping_method: shipping_method,
         commercial_pricing: commercial_pricing,
         hold_for_pickup: hold_for_pickup
-      )
+      }
     end
 
     let(:shipping_method) { FriendlyShipping::ShippingMethod.new(service_code: service_code) }
-    let(:service_code) { "PRIORITY" }
+    let(:service_code) { 'PRIORITY' }
     let(:commercial_pricing) { false }
     let(:hold_for_pickup) { false }
 
     it 'returns service code from shipping method' do
-      expect(subject.service_code).to eq('PRIORITY')
+      expect(options.service_code).to eq('PRIORITY')
     end
 
     context 'with no shipping method' do
       let(:shipping_method) { nil }
 
       it 'returns ALL' do
-        expect(subject.service_code).to eq('ALL')
+        expect(options.service_code).to eq('ALL')
       end
     end
 
-    context "with cubic shipping method" do
-      let(:service_code) { "PRIORITY MAIL CUBIC" }
+    context 'with cubic shipping method' do
+      let(:service_code) { 'PRIORITY MAIL CUBIC' }
 
-      it "returns unmodified service code" do
-        expect(subject.service_code).to eq("PRIORITY MAIL CUBIC")
+      it 'returns unmodified service code' do
+        expect(options.service_code).to eq('PRIORITY MAIL CUBIC')
       end
 
-      context "with commercial pricing" do
+      context 'with commercial pricing' do
         let(:commercial_pricing) { true }
 
-        it "returns unmodified service code" do
-          expect(subject.service_code).to eq("PRIORITY MAIL CUBIC")
+        it 'returns unmodified service code' do
+          expect(options.service_code).to eq('PRIORITY MAIL CUBIC')
         end
       end
 
-      context "with hold for pickup" do
+      context 'with hold for pickup' do
         let(:hold_for_pickup) { true }
 
-        it "returns unmodified service code" do
-          expect(subject.service_code).to eq("PRIORITY MAIL CUBIC")
+        it 'returns unmodified service code' do
+          expect(options.service_code).to eq('PRIORITY MAIL CUBIC')
         end
       end
     end
@@ -90,7 +114,7 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
       let(:commercial_pricing) { true }
 
       it 'appends COMMERCIAL to service code' do
-        expect(subject.service_code).to eq('PRIORITY COMMERCIAL')
+        expect(options.service_code).to eq('PRIORITY COMMERCIAL')
       end
     end
 
@@ -98,7 +122,7 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
       let(:hold_for_pickup) { true }
 
       it 'appends HFP to service code' do
-        expect(subject.service_code).to eq('PRIORITY HFP')
+        expect(options.service_code).to eq('PRIORITY HFP')
       end
     end
 
@@ -107,7 +131,7 @@ RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
       let(:hold_for_pickup) { true }
 
       it 'appends HFP and COMMERCIAL to service code' do
-        expect(subject.service_code).to eq('PRIORITY HFP COMMERCIAL')
+        expect(options.service_code).to eq('PRIORITY HFP COMMERCIAL')
       end
     end
   end

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -126,6 +126,19 @@ RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
     end
   end
 
+  context 'with deprecated first class mail type' do
+    let(:package_options) do
+      FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(
+        package_id: package.id,
+        first_class_mail_type: :parcel
+      )
+    end
+
+    it 'does not include first class mail type' do
+      expect(node.at_xpath('FirstClassMailType')).to be_nil
+    end
+  end
+
   context 'with large package' do
     # Package is considered large if any dimension exceeds 12 in
     let(:dimensions) { [35, 21.321539, 24].map { |e| Measured::Length(e, :cm) } }


### PR DESCRIPTION
The USPS API replaced First Class package mail types with Ground Advantage last year. This commit marks the deprecated package mail types and shows a warning if/when they get used.