### PR TITLE
Add reference numbers to packages

### DIFF
--- a/lib/friendly_shipping/services/ups_json/generate_labels_payload.rb
+++ b/lib/friendly_shipping/services/ups_json/generate_labels_payload.rb
@@ -179,7 +179,8 @@ module FriendlyShipping
                 delivery_confirmation_code: delivery_confirmation_code,
                 shipper_release: package_options.shipper_release,
                 declared_value: package_options.declared_value,
-                package_flavor: 'labels'
+                package_flavor: 'labels',
+                reference_numbers: package_options.reference_numbers
               )
             end
           end

--- a/lib/friendly_shipping/services/ups_json/generate_package_hash.rb
+++ b/lib/friendly_shipping/services/ups_json/generate_package_hash.rb
@@ -10,7 +10,8 @@ module FriendlyShipping
                    shipper_release: false,
                    transmit_dimensions: true,
                    declared_value: false,
-                   package_flavor: nil)
+                   package_flavor: nil,
+                   reference_numbers: nil)
             # UPS consistency across apis is a bit of a mess
             packaging_type_key = package_flavor == "rates" ? "PackagingType" : "Packaging"
 
@@ -54,6 +55,15 @@ module FriendlyShipping
                 CurrencyCode: total_value.currency.iso_code,
                 MonetaryValue: total_value.to_s
               }
+            end
+
+            if reference_numbers.present?
+              package_hash[:ReferenceNumber] = reference_numbers.map do |code, value|
+                {
+                  Code: code.to_s,
+                  Value: value.to_s
+                }
+              end
             end
 
             package_hash[:PackageServiceOptions].compact_blank!


### PR DESCRIPTION
This was overlooked in the initial implementation. These appear at the bottom of the label.