### PR TITLE
TForce Freight: Parse pickup confirmation numbers

### DIFF
--- a/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
@@ -18,6 +18,7 @@ module FriendlyShipping
 
             bol_id = json.dig("detail", "bolId")
             pro_number = json.dig("detail", "pro")
+            pickup_confirmation_number = json.dig("detail", "pickup", "transactionReference", "confirmationNumber")
 
             rate_detail = json.dig("detail", "rateDetail")&.first
             if rate_detail
@@ -53,6 +54,7 @@ module FriendlyShipping
               ShipmentInformation.new(
                 bol_id: bol_id,
                 pro_number: pro_number,
+                pickup_confirmation_number: pickup_confirmation_number,
                 origin_service_center: origin_service_center,
                 email_sent: email_sent,
                 origin_is_rural: origin_is_rural,

--- a/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
@@ -42,9 +42,9 @@ module FriendlyShipping
             end
 
             origin_service_center = json.dig("detail", "originServiceCenter")
-            email_sent = json.dig("detail", "pickup", "emailSent") == "true"
-            origin_is_rural = json.dig("detail", "pickup", "originIsRural") == "true"
-            destination_is_rural = json.dig("detail", "pickup", "destinationIsRural") == "true"
+            email_sent = json.dig("detail", "pickup", "transactionReference", "emailSent") == "true"
+            origin_is_rural = json.dig("detail", "pickup", "transactionReference", "originIsRural") == "true"
+            destination_is_rural = json.dig("detail", "pickup", "transactionReference", "destinationIsRural") == "true"
 
             documents = json.dig("detail", "documents", "image")&.map do |image_data|
               ParseShipmentDocument.call(image_data: image_data)

--- a/lib/friendly_shipping/services/tforce_freight/shipment_information.rb
+++ b/lib/friendly_shipping/services/tforce_freight/shipment_information.rb
@@ -11,6 +11,9 @@ module FriendlyShipping
         # @return [String] the shipment's PRO number
         attr_reader :pro_number
 
+        # @return [String] the shipment's pickup confirmation number
+        attr_reader :pickup_confirmation_number
+
         # @return [String] the origin service center
         attr_reader :origin_service_center
 
@@ -49,6 +52,7 @@ module FriendlyShipping
 
         # @param bol_id [String] the shipment's BOL ID number
         # @param pro_number [String] the shipment's PRO number
+        # @param pickup_confirmation_number [String] the shipment's pickup confirmation number
         # @param origin_service_center [String] the origin service center
         # @param email_sent [Boolean] whether or not the email was sent
         # @param origin_is_rural [Boolean] whether or not the origin is rural
@@ -64,6 +68,7 @@ module FriendlyShipping
         def initialize(
           bol_id:,
           pro_number: nil,
+          pickup_confirmation_number: nil,
           origin_service_center: nil,
           email_sent: nil,
           origin_is_rural: nil,
@@ -79,6 +84,7 @@ module FriendlyShipping
         )
           @bol_id = bol_id
           @pro_number = pro_number
+          @pickup_confirmation_number = pickup_confirmation_number
           @origin_service_center = origin_service_center
           @email_sent = email_sent
           @origin_is_rural = origin_is_rural

--- a/spec/fixtures/tforce_freight/create_bol/success.json
+++ b/spec/fixtures/tforce_freight/create_bol/success.json
@@ -115,7 +115,7 @@
       },
       "transactionReference": {
         "confirmationNumber": "WBU43159139",
-        "emailSent": "false",
+        "emailSent": "true",
         "originIsRural": "false",
         "destinationIsRural": "false"
       }

--- a/spec/fixtures/tforce_freight/create_bol/success.json
+++ b/spec/fixtures/tforce_freight/create_bol/success.json
@@ -108,11 +108,17 @@
         }
       }
     ],
-    "pickup": {
-      "confirmationNumber": "WBU1234567",
-      "emailSent": "false",
-      "originIsRural": "true",
-      "destinationIsRural": "false"
+    "pickup":{
+      "responseStatus": {
+        "code": "1",
+        "description": "Success"
+      },
+      "transactionReference": {
+        "confirmationNumber": "WBU43159139",
+        "emailSent": "false",
+        "originIsRural": "false",
+        "destinationIsRural": "false"
+      }
     },
     "documents": {
       "image": [

--- a/spec/friendly_shipping/services/tforce_freight/parse_create_bol_response_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/parse_create_bol_response_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::ParseCreateBOLResponse
       expect(result.pro_number).to eq("020968290")
       expect(result.pickup_confirmation_number).to eq("WBU43159139")
       expect(result.origin_service_center).to eq("LOS")
-      expect(result.email_sent).to eq(false)
+      expect(result.email_sent).to eq(true)
       expect(result.origin_is_rural).to eq(false)
       expect(result.destination_is_rural).to eq(false)
 

--- a/spec/friendly_shipping/services/tforce_freight/parse_create_bol_response_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/parse_create_bol_response_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::ParseCreateBOLResponse
       expect(result).to be_a(FriendlyShipping::Services::TForceFreight::ShipmentInformation)
       expect(result.bol_id).to eq(46_176_429)
       expect(result.pro_number).to eq("020968290")
+      expect(result.pickup_confirmation_number).to eq("WBU43159139")
       expect(result.origin_service_center).to eq("LOS")
       expect(result.email_sent).to eq(false)
-      expect(result.origin_is_rural).to eq(true)
+      expect(result.origin_is_rural).to eq(false)
       expect(result.destination_is_rural).to eq(false)
 
       expect(result.rates).to eq(

--- a/spec/friendly_shipping/services/tforce_freight/shipment_information_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/shipment_information_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::ShipmentInformation do
     described_class.new(
       pro_number: "1234",
       bol_id: "2345",
+      pickup_confirmation_number: "WBU123",
       documents: docs
     )
   end
@@ -16,6 +17,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::ShipmentInformation do
   it "stores passed information" do
     expect(shipment_info.bol_id).to eq("2345")
     expect(shipment_info.pro_number).to eq("1234")
+    expect(shipment_info.pickup_confirmation_number).to eq("WBU123")
     expect(shipment_info.documents).to eq(docs)
   end
 end


### PR DESCRIPTION
Capturing these numbers is helpful when a pickup request needs to be cancelled.