### PR TITLE
Fix TForce shipping label codes

### DIFF
--- a/lib/friendly_shipping/services/tforce_freight/document_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/document_options.rb
@@ -11,8 +11,11 @@ module FriendlyShipping
         # @return [Symbol] the document format (see {DOCUMENT_FORMATS})
         attr_reader :format
 
-        # @return [Boolean] whether or not the label is for thermal printers
+        # @return [Boolean] whether or not the label is for thermal printers (DEPRECATED: use `label_type` instead)
         attr_reader :thermal
+
+        # @return [String] the type of label
+        attr_reader :label_type
 
         # @return [Integer] the start position of the sticker
         attr_reader :start_position
@@ -38,21 +41,35 @@ module FriendlyShipping
           true => "02"
         }.freeze
 
+        # Maps friendly names to label types.
+        LABEL_TYPE_CODES = {
+          address_labels_with_pro_nums: "01",
+          address_labels_without_pro_nums: "02",
+          pro_stickers: "03",
+          address_labels_1x1: "04",
+          address_labels_2x1: "05",
+          address_labels_2x2: "06",
+          thermal_labels_4x6: "07",
+          thermal_labels_4x8: "08"
+        }.freeze
+
         # @param type [Symbol] the document type (see [DOCUMENT_TYPES])
         # @param format [Symbol] the document format (see [DOCUMENT_FORMATS])
-        # @param thermal [Boolean] whether or not the label is for thermal printers
+        # @param thermal [Boolean] whether or not the label is for thermal printers (DEPRECATED: use `label_type` instead)
         # @param start_position [Integer] the start position of the sticker
         # @param number_of_stickers [Integer] the number of stickers
         def initialize(
           type: :label,
           format: :pdf,
           thermal: false,
+          label_type: :thermal_labels_4x6,
           start_position: 1,
           number_of_stickers: 1
         )
           @type = type
           @format = format
           @thermal = thermal
+          @label_type = label_type
           @start_position = start_position
           @number_of_stickers = number_of_stickers
         end
@@ -68,8 +85,14 @@ module FriendlyShipping
         end
 
         # @return [String]
+        # @deprecated Use `label_type` instead.
         def thermal_code
           THERMAL_CODE.fetch(thermal)
+        end
+
+        # @return [String]
+        def label_type_code
+          LABEL_TYPE_CODES.fetch(label_type)
         end
       end
     end

--- a/lib/friendly_shipping/services/tforce_freight/generate_document_options_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_document_options_hash.rb
@@ -5,18 +5,30 @@ module FriendlyShipping
     class TForceFreight
       # Generates a document options hash for JSON serialization.
       class GenerateDocumentOptionsHash
-        # @param document_options [DocumentOptions] the document options
-        # @return [Hash] document options hash suitable for JSON request
-        def self.call(document_options:)
-          {
-            type: document_options.document_type_code,
-            format: document_options.format_code,
-            label: {
-              type: document_options.thermal_code,
+        class << self
+          # @param document_options [DocumentOptions] the document options
+          # @return [Hash] document options hash suitable for JSON request
+          def call(document_options:)
+            {
+              type: document_options.document_type_code,
+              format: document_options.format_code,
+              label: label(document_options)
+            }.compact
+          end
+
+          private
+
+          # @param document_options [DocumentOptions] the document options
+          # @return [Hash, nil] label hash or nil if this is a BOL
+          def label(document_options)
+            return unless document_options.type == :label
+
+            {
+              type: document_options.label_type_code,
               startPosition: document_options.start_position,
               numberOfStickers: document_options.number_of_stickers
             }
-          }
+          end
         end
       end
     end

--- a/spec/friendly_shipping/services/tforce_freight/document_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/document_options_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::DocumentOptions do
     expect(options.type).to eq(:label)
     expect(options.format).to eq(:pdf)
     expect(options.thermal).to be(false)
+    expect(options.label_type).to eq(:thermal_labels_4x6)
     expect(options.start_position).to eq(1)
     expect(options.number_of_stickers).to eq(1)
   end
@@ -17,5 +18,6 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::DocumentOptions do
     expect(options.format_code).to eq("01")
     expect(options.document_type_code).to eq("30")
     expect(options.thermal_code).to eq("01")
+    expect(options.label_type_code).to eq("07")
   end
 end

--- a/spec/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash_spec.rb
@@ -357,16 +357,11 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
               {
                 type: "20",
                 format: "01",
-                label: {
-                  type: "01",
-                  startPosition: 1,
-                  numberOfStickers: 1
-                }
               }, {
                 type: "30",
                 format: "01",
                 label: {
-                  type: "02",
+                  type: "07",
                   startPosition: 1,
                   numberOfStickers: 2
                 }

--- a/spec/friendly_shipping/services/tforce_freight/generate_document_options_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_document_options_hash_spec.rb
@@ -11,17 +11,34 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateDocumentOption
     FriendlyShipping::Services::TForceFreight::DocumentOptions.new
   end
 
-  it "has all the right things" do
+  it do
     is_expected.to eq(
       {
         type: "30",
         format: "01",
         label: {
-          type: "01",
+          type: "07",
           startPosition: 1,
           numberOfStickers: 1
         }
       }
     )
+  end
+
+  context "when document type is BOL" do
+    let(:document_options) do
+      FriendlyShipping::Services::TForceFreight::DocumentOptions.new(
+        type: :tforce_bol
+      )
+    end
+
+    it do
+      is_expected.to eq(
+        {
+          type: "20",
+          format: "01"
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
The old TForce (UPS) API used 2 codes to determine whether the shipping label was thermal or not. The new TForce API uses a wide variety of label type codes for different label sizes and formats. This commit adds the new codes to the document options class and deprecates the old `thermal` attribute.