### PR TITLE
Add `.env.test.local.template` file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,8 @@
 # .env.template
+
 # NO PASSWORDS OR SENSITIVE INFORMATION SHOULD BE STORED HERE
 # Only pass along how those passwords/info are reference via ENV VARS
+
 RL_API_KEY=RL API Key
 
 SHIPENGINE_API_KEY=ShipEngine API key

--- a/.env.test.local.template
+++ b/.env.test.local.template
@@ -1,0 +1,6 @@
+# .env.test.local.template
+
+# When recording VCR cassettes for TForce and UPS JSON service classes, this env var
+# should be set to a valid token for either service.
+
+ACCESS_TOKEN=secret_token

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@
 # Gemfile.lock
 Gemfile.lock
 .env
+.env.test.local
 coverage

--- a/spec/friendly_shipping/services/tforce_freight_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight do
       token_type: "Bearer",
       expires_in: 3599,
       ext_expires_in: 3599,
-      raw_token: "secret_token"
+      raw_token: ENV.fetch('ACCESS_TOKEN', nil)
     )
   end
 


### PR DESCRIPTION
This does a few things:

- Adds `.env.test.local` to `.gitignore`
- Adds `.env.test.local.template` with example `ACCESS_KEY` entry
- Updates TForce specs to reference `ACCESS_KEY`

The idea is to make it easy to re-record VCR cassettes for service class specs without having to hard-code access tokens in the specs themselves. Instead, the access token can be added to `.env.local.test` without risk of accidentally committing a sensitive value to the repository.