### PR TITLE
Escape special chars in TForce BOL API request

### DIFF
--- a/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
@@ -46,7 +46,7 @@ module FriendlyShipping
           # @return [Hash]
           def location(location)
             {
-              name: truncate(location.company_name.presence || location.name),
+              name: clean_company_name(location.company_name.presence || location.name),
               contact: truncate(location.name),
               email: truncate(location.email, length: 50),
               phone: {
@@ -127,7 +127,7 @@ module FriendlyShipping
           # @return [Hash]
           def requester(location)
             {
-              companyName: truncate(location.company_name.presence || location.name),
+              companyName: clean_company_name(location.company_name.presence || location.name),
               contactName: truncate(location.name),
               email: truncate(location.email, length: 50),
               phone: {
@@ -147,6 +147,16 @@ module FriendlyShipping
           # @return [String]
           def truncate(value, length: 35)
             value && value[0..(length - 1)].strip
+          end
+
+          # TForce does not support special characters like &, <, or > in company names.
+          #
+          # @param name [String]
+          # @return [String]
+          def clean_company_name(name)
+            return if name.nil?
+
+            truncate(CGI.escapeHTML(name).strip)
           end
         end
       end

--- a/spec/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash_spec.rb
@@ -171,11 +171,11 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
       context "with values that are too long" do
         let(:origin) do
           Physical::Location.new(
-            company_name: "This is the world's longest company name",
-            name: "This is the world's longest person name",
+            company_name: "This is the longest company name in the world",
+            name: "This is the longest person name in the world",
             email: "john@thisistheworldslongestdomainnameijusttgoesonandon.com",
             phone: "123-123-1234 x1234",
-            address1: "This is the world's longest street address",
+            address1: "This is the longest street address in the world",
             address2: "Suite 456",
             city: "Richmond",
             zip: "23224-1234",
@@ -187,14 +187,30 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
         it do
           is_expected.to match(
             hash_including(
-              name: "This is the world's longest company",
-              contact: "This is the world's longest person",
+              name: "This is the longest company name in",
+              contact: "This is the longest person name in",
               email: "john@thisistheworldslongestdomainnameijusttgoesona",
               phone: { number: "123-123-1234 x1" },
               address: hash_including(
-                addressLine: "This is the world's longest street",
+                addressLine: "This is the longest street address",
                 postalCode: "23224-"
               )
+            )
+          )
+        end
+      end
+
+      context "with special chars in company name" do
+        let(:origin) do
+          Physical::Location.new(
+            company_name: "A.> & \"F\" <Co.",
+          )
+        end
+
+        it do
+          is_expected.to match(
+            hash_including(
+              name: "A.&gt; &amp; &quot;F&quot; &lt;Co."
             )
           )
         end
@@ -226,11 +242,11 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
       context "with values that are too long" do
         let(:destination) do
           Physical::Location.new(
-            company_name: "This is the world's longest company name",
-            name: "This is the world's longest person name",
+            company_name: "This is the longest company name in the world",
+            name: "This is the longest person name in the world",
             email: "john@thisistheworldslongestdomainnameijusttgoesonandon.com",
             phone: "456-456-4567 x4567",
-            address1: "This is the world's longest street address",
+            address1: "This is the longest street address in the world",
             address2: "Suite 456",
             city: "Allanton",
             zip: "63025-1234",
@@ -242,14 +258,30 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
         it do
           is_expected.to match(
             hash_including(
-              name: "This is the world's longest company",
-              contact: "This is the world's longest person",
+              name: "This is the longest company name in",
+              contact: "This is the longest person name in",
               email: "john@thisistheworldslongestdomainnameijusttgoesona",
               phone: { number: "456-456-4567 x4" },
               address: hash_including(
-                addressLine: "This is the world's longest street",
+                addressLine: "This is the longest street address",
                 postalCode: "63025-"
               )
+            )
+          )
+        end
+      end
+
+      context "with special chars in company name" do
+        let(:destination) do
+          Physical::Location.new(
+            company_name: "A.> & \"F\" <Co.",
+          )
+        end
+
+        it do
+          is_expected.to match(
+            hash_including(
+              name: "A.&gt; &amp; &quot;F&quot; &lt;Co."
             )
           )
         end
@@ -296,11 +328,11 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
       context "with values that are too long" do
         let(:origin) do
           Physical::Location.new(
-            company_name: "This is the world's longest company name",
-            name: "This is the world's longest person name",
+            company_name: "This is the longest company name in the world",
+            name: "This is the longest person name in the world",
             email: "john@thisistheworldslongestdomainnameijusttgoesonandon.com",
             phone: "123-123-1234 x1234",
-            address1: "This is the world's longest street address",
+            address1: "This is the longest street address in the world",
             address2: "Suite 456",
             city: "Richmond",
             zip: "23224-1234",
@@ -313,12 +345,12 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
           is_expected.to match(
             hash_including(
               payer: hash_including(
-                name: "This is the world's longest company",
-                contact: "This is the world's longest person",
+                name: "This is the longest company name in",
+                contact: "This is the longest person name in",
                 email: "john@thisistheworldslongestdomainnameijusttgoesona",
                 phone: { number: "123-123-1234 x1" },
                 address: hash_including(
-                  addressLine: "This is the world's longest street",
+                  addressLine: "This is the longest street address",
                   postalCode: "23224-"
                 )
               )
@@ -447,8 +479,8 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
       context "with values that are too long" do
         let(:origin) do
           Physical::Location.new(
-            company_name: "This is the world's longest company name",
-            name: "This is the world's longest person name",
+            company_name: "This is the longest company name in the world",
+            name: "This is the longest person name in the world",
             email: "john@thisistheworldslongestdomainnameijusttgoesonandon.com",
             phone: "123-123-1234 x1234"
           )
@@ -458,13 +490,31 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
           is_expected.to match(
             hash_including(
               requester: {
-                companyName: "This is the world's longest company",
-                contactName: "This is the world's longest person",
+                companyName: "This is the longest company name in",
+                contactName: "This is the longest person name in",
                 email: "john@thisistheworldslongestdomainnameijusttgoesona",
                 phone: {
                   number: "123-123-1234 x1"
                 }
               }
+            )
+          )
+        end
+      end
+
+      context "with special chars in company name" do
+        let(:origin) do
+          Physical::Location.new(
+            company_name: "A.> & \"F\" <Co.",
+          )
+        end
+
+        it do
+          is_expected.to match(
+            hash_including(
+              requester: hash_including(
+                companyName: "A.&gt; &amp; &quot;F&quot; &lt;Co."
+              )
             )
           )
         end


### PR DESCRIPTION
TForce does not like certain chars like ampersands in company names. This commit replaces these chars with HTML entities which appear as expected on the resulting Bill of Lading (BOL).