### PR TITLE
Change USPS Ship package option default value

### DIFF
--- a/lib/friendly_shipping/services/usps_ship/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps_ship/rate_estimate_package_options.rb
@@ -109,7 +109,7 @@ module FriendlyShipping
         # @option [Class] :item_options_class the class to use for item options when none are provided
         def initialize(
           processing_category: :machinable,
-          rate_indicator: :dimensional_rectangular,
+          rate_indicator: :single_piece,
           price_type: :retail,
           **kwargs
         )

--- a/spec/friendly_shipping/services/usps_ship/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps_ship/rate_estimate_package_options_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FriendlyShipping::Services::USPSShip::RateEstimatePackageOptions 
 
   it "sets reasonable defaults" do
     expect(options.processing_category).to eq("MACHINABLE")
-    expect(options.rate_indicator).to eq("DR")
+    expect(options.rate_indicator).to eq("SP")
     expect(options.price_type).to eq("RETAIL")
   end
 end

--- a/spec/friendly_shipping/services/usps_ship/serialize_rate_estimates_request_spec.rb
+++ b/spec/friendly_shipping/services/usps_ship/serialize_rate_estimates_request_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe FriendlyShipping::Services::USPSShip::SerializeRateEstimatesReque
       height: 3.94,
       mailClass: "USPS_GROUND_ADVANTAGE",
       processingCategory: "MACHINABLE",
-      rateIndicator: "DR",
+      rateIndicator: "SP",
       destinationEntryFacilityType: "NONE",
       priceType: "RETAIL",
       mailingDate: "2024-04-01"


### PR DESCRIPTION
This changes the default value for rate indicator from "DP" (dimensional rate) to "SP" (single piece). The reasoning behind this change is that far more packages qualify as single piece vs. dimensional.