### PR TITLE
USPS Ship: Fix machinable criteria

### DIFF
--- a/lib/friendly_shipping/services/usps_ship/machinable_package.rb
+++ b/lib/friendly_shipping/services/usps_ship/machinable_package.rb
@@ -15,9 +15,9 @@ module FriendlyShipping
         MIN_WIDTH = Measured::Length(3, :inches)
         MIN_HEIGHT = Measured::Length(0.25, :inches)
 
-        MAX_LENGTH = Measured::Length(27, :inches)
-        MAX_WIDTH = Measured::Length(17, :inches)
-        MAX_HEIGHT = Measured::Length(17, :inches)
+        MAX_LENGTH = Measured::Length(22, :inches)
+        MAX_WIDTH = Measured::Length(18, :inches)
+        MAX_HEIGHT = Measured::Length(15, :inches)
 
         MAX_WEIGHT = Measured::Weight(25, :pounds)
 

--- a/lib/friendly_shipping/services/usps_ship/machinable_package.rb
+++ b/lib/friendly_shipping/services/usps_ship/machinable_package.rb
@@ -19,6 +19,7 @@ module FriendlyShipping
         MAX_WIDTH = Measured::Length(18, :inches)
         MAX_HEIGHT = Measured::Length(15, :inches)
 
+        MIN_WEIGHT = Measured::Weight(6, :ounces)
         MAX_WEIGHT = Measured::Weight(25, :pounds)
 
         # @param package [Physical::Package]
@@ -37,7 +38,8 @@ module FriendlyShipping
         def at_least_minimum
           package.length >= MIN_LENGTH &&
             package.width >= MIN_WIDTH &&
-            package.height >= MIN_HEIGHT
+            package.height >= MIN_HEIGHT &&
+            package.weight >= MIN_WEIGHT
         end
 
         # @return [Boolean]

--- a/spec/friendly_shipping/services/usps_ship/machinable_package_spec.rb
+++ b/spec/friendly_shipping/services/usps_ship/machinable_package_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FriendlyShipping::Services::USPSShip::MachinablePackage do
   let(:package) { Physical::Package.new(weight: weight, dimensions: dimensions) }
 
   describe "#machinable?" do
-    let(:weight) { Measured::Weight(3, :ounces) }
+    let(:weight) { Measured::Weight(8, :ounces) }
     let(:dimensions) { [8, 4, 2].map { |e| Measured::Length(e, :inches) } }
 
     it { is_expected.to be_machinable }
@@ -32,6 +32,12 @@ RSpec.describe FriendlyShipping::Services::USPSShip::MachinablePackage do
 
     context "with overweight package" do
       let(:weight) { Measured::Weight(50, :pounds) }
+
+      it { is_expected.to_not be_machinable }
+    end
+
+    context "with underweight package" do
+      let(:weight) { Measured::Weight(2, :ounces) }
 
       it { is_expected.to_not be_machinable }
     end


### PR DESCRIPTION
During the transition to the new USPS Ship API, I noticed the machinable criteria has changed (either that or our criteria was wrong to begin with). This adjusts the dimensions and adds a min weight per section 7.5 here:

https://pe.usps.com/text/dmm300/201.htm#ep1097220