### PR TITLE
Add debug param to ShipEngine labels method

### DIFF
--- a/lib/friendly_shipping/services/ship_engine.rb
+++ b/lib/friendly_shipping/services/ship_engine.rb
@@ -113,13 +113,15 @@ module FriendlyShipping
       #   Note: Some ShipEngine carriers, notably USPS, only support one package per shipment, and that's
       #   all that the integration supports at this point.
       # @param options [LabelOptions] the options for getting labels (see object description)
+      # @param debug [Boolean] whether to attach debugging information to the response
       # @return [ApiResult<Array<Label>>, Failure<ApiFailure>] the shipping labels
-      def labels(shipment, options:)
+      def labels(shipment, options:, debug: false)
         request = FriendlyShipping::Request.new(
           url: API_BASE + API_PATHS[:labels],
           http_method: "POST",
           body: SerializeLabelShipment.call(shipment: shipment, options: options, test: test).to_json,
-          headers: request_headers
+          headers: request_headers,
+          debug: debug
         )
         client.post(request).fmap do |response|
           ParseLabelResponse.call(request: request, response: response)

--- a/spec/friendly_shipping/services/ship_engine_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine_spec.rb
@@ -211,6 +211,20 @@ RSpec.describe FriendlyShipping::Services::ShipEngine do
           expect(label.label_format).to eq(:pdf)
         end
       end
+
+      context 'with debug set to true' do
+        subject(:labels) { service.labels(shipment, options: options, debug: true) }
+
+        it 'returns original request and response along with the data' do
+          aggregate_failures do
+            is_expected.to be_success
+            expect(subject.value!.data).to be_a(Array)
+            expect(subject.value!.data.first).to be_a(FriendlyShipping::Label)
+            expect(subject.value!.original_request).to be_present
+            expect(subject.value!.original_response).to be_present
+          end
+        end
+      end
     end
 
     context 'when requesting an inline label', vcr: { cassette_name: 'shipengine/labels/success_inline_label' } do


### PR DESCRIPTION
This was overlooked in the original implementation. The other service methods already have debug params. Only `#labels` needs one. Setting `debug: true` causes the API request and response to be included with the API result.