### PR TITLE
Truncate R+L BOL address lines to 30 chars

### DIFF
--- a/lib/friendly_shipping/services/rl/serialize_location.rb
+++ b/lib/friendly_shipping/services/rl/serialize_location.rb
@@ -11,8 +11,8 @@ module FriendlyShipping
           def call(location)
             {
               CompanyName: location.company_name.presence || location.name,
-              AddressLine1: location.address1,
-              AddressLine2: location.address2,
+              AddressLine1: truncate(location.address1),
+              AddressLine2: truncate(location.address2),
               City: clean_city(location.city),
               StateOrProvince: location.region.code,
               ZipOrPostalCode: location.zip,
@@ -38,6 +38,13 @@ module FriendlyShipping
           # @return [String]
           def clean_phone(phone)
             phone.gsub(/^1-/, "").strip
+          end
+
+          # @param value [String]
+          # @param length [Integer]
+          # @return [String]
+          def truncate(value, length: 30)
+            value && value[0..(length - 1)].strip
           end
         end
       end

--- a/spec/friendly_shipping/services/rl/serialize_location_spec.rb
+++ b/spec/friendly_shipping/services/rl/serialize_location_spec.rb
@@ -68,4 +68,23 @@ RSpec.describe FriendlyShipping::Services::RL::SerializeLocation do
       )
     end
   end
+
+  context "when address lines are too long" do
+    let(:location) do
+      FactoryBot.build(
+        :physical_location,
+        address1: "This is the longest street address",
+        address2: "This is another very long street address"
+      )
+    end
+
+    it do
+      is_expected.to match(
+        hash_including(
+          AddressLine1: "This is the longest street add",
+          AddressLine2: "This is another very long stre"
+        )
+      )
+    end
+  end
 end


### PR DESCRIPTION
R+L does not accept values over 30 chars.