### PR TITLE
Fix UPS json rate details, add specs

### DIFF
--- a/lib/friendly_shipping/services/ups_json/parse_rate_modifier_hash.rb
+++ b/lib/friendly_shipping/services/ups_json/parse_rate_modifier_hash.rb
@@ -6,7 +6,7 @@ module FriendlyShipping
       class ParseRateModifierHash
         # @param [Hash] hash the RateModifier hash from the source JSON
         # @param [String] currency_code The currency code for this modifier's amount (i.e. 'USD')
-        # @return [Hash]
+        # @return [Array] The label and the amount of the rate modifier
         def self.call(rate_modifier, currency_code:)
           return unless rate_modifier
 
@@ -20,7 +20,7 @@ module FriendlyShipping
           modifier_description = rate_modifier['ModifierDesc']
           label = "#{modifier_type} (#{modifier_description})"
 
-          { label => amount }
+          [label, amount]
         end
       end
     end

--- a/lib/friendly_shipping/services/ups_json/parse_rates_response.rb
+++ b/lib/friendly_shipping/services/ups_json/parse_rates_response.rb
@@ -32,13 +32,9 @@ module FriendlyShipping
               days_to_delivery = rated_shipment.dig('GuaranteedDelivery', 'BusinessDaysInTransit').to_i
               total_cost = ParseMoneyHash.call(rated_shipment['TotalCharges'], 'TotalCharges').last
               insurance_price = ParseMoneyHash.call(rated_shipment['ServiceOptionsCharges'], 'ServiceOptionsCharges')&.last
-              negotiated_rate = ParseMoneyHash.call(rated_shipment.dig('NegotiatedRates', 'NetSummaryCharges', 'GrandTotal'), 'GrandTotal')&.last
-              negotiated_charges = ParseMoneyHash.call(rated_shipment.dig('NegotiatedRates', 'ItemizedCharges'), 'ItemizedCharges')&.last
-
-              itemized_charges = Array.wrap(rated_shipment['ItemizedCharges'])
-              itemized_charges = itemized_charges.map do |charge|
-                ParseMoneyHash.call(charge, 'MonetaryValue')
-              end
+              negotiated_rate = ParseMoneyHash.call(rated_shipment.dig('NegotiatedRateCharges', 'TotalCharge'), 'TotalCharge')&.last
+              negotiated_charges = extract_charges(rated_shipment.dig('NegotiatedRateCharges', 'ItemizedCharges'), 'ItemizedCharges')
+              itemized_charges = extract_charges(rated_shipment['ItemizedCharges'], 'ItemizedCharges')
 
               rated_shipment_warnings = Array.wrap(rated_shipment['RatedShipmentAlert'])
               rated_shipment_warnings = rated_shipment_warnings.map { |alert| alert["Description"] }
@@ -74,13 +70,13 @@ module FriendlyShipping
             package_array.map do |rated_package|
               currency_code = rated_package.dig('TotalCharges', 'CurrencyCode')
               {
-                transportation_charges: ParseMoneyHash.call(rated_package['TransportationCharges'], 'TransportationCharges'),
-                base_service_charge: ParseMoneyHash.call(rated_package['BaseServiceCharge'], 'BaseServiceCharge'),
-                service_options_charges: ParseMoneyHash.call(rated_package['ServiceOptionsCharges'], 'ServiceOptionsCharges'),
+                transportation_charges: ParseMoneyHash.call(rated_package['TransportationCharges'], 'TransportationCharges')&.last,
+                base_service_charge: ParseMoneyHash.call(rated_package['BaseServiceCharge'], 'BaseServiceCharge')&.last,
+                service_options_charges: ParseMoneyHash.call(rated_package['ServiceOptionsCharges'], 'ServiceOptionsCharges')&.last,
                 itemized_charges: extract_charges(rated_package['ItemizedCharges'], 'ItemizedCharges'),
-                total_charges: ParseMoneyHash.call(rated_package['TotalCharges'], 'TotalCharges'),
-                negotiated_charges: extract_charges(rated_package.dig('NegotiatedRateCharges', 'ItemizedCharges'), 'ItemizedCharges'),
-                rate_modifiers: extract_modifiers(rated_package['RateModifier'], currency_code: currency_code).inject(:merge),
+                total_charges: ParseMoneyHash.call(rated_package['TotalCharges'], 'TotalCharges')&.last,
+                negotiated_charges: extract_charges(rated_package.dig('NegotiatedCharges', 'ItemizedCharges'), 'ItemizedCharges'),
+                rate_modifiers: extract_modifiers(rated_package['RateModifier'], currency_code: currency_code),
                 weight: BigDecimal(rated_package['Weight']),
                 billing_weight: BigDecimal(rated_package.dig('BillingWeight', 'Weight'))
               }.compact
@@ -88,15 +84,21 @@ module FriendlyShipping
           end
 
           def extract_charges(charges, key_name)
+            non_zero_charges = {}
             Array.wrap(charges).map do |charge|
-              ParseMoneyHash.call(charge, key_name)
-            end.compact
+              parsed_charge = ParseMoneyHash.call(charge, key_name)
+              non_zero_charges[parsed_charge[0]] = parsed_charge[1] if parsed_charge.present?
+            end
+            non_zero_charges
           end
 
           def extract_modifiers(modifiers, currency_code:)
+            rate_modifiers = {}
             Array.wrap(modifiers).map do |modifier|
-              ParseRateModifierHash.call(modifier, currency_code: currency_code)
-            end.compact
+              parsed_modifier = ParseRateModifierHash.call(modifier, currency_code: currency_code)
+              rate_modifiers[parsed_modifier[0]] = parsed_modifier[1] if parsed_modifier.present?
+            end
+            rate_modifiers
           end
         end
       end

--- a/spec/fixtures/ups_json/rates_with_negotiated_charges.json
+++ b/spec/fixtures/ups_json/rates_with_negotiated_charges.json
@@ -1,0 +1,634 @@
+{
+  "RateResponse" : {
+    "RatedShipment" : [
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "GuaranteedDelivery" : {
+          "BusinessDaysInTransit" : "1"
+        },
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "41.35"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "95.59"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "11.0"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "376",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "4.90",
+              "SubType" : "Rural Extended"
+            },
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "16.58"
+            }
+          ],
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "30.59"
+            },
+            "ItemizedCharges" : [
+              {
+                "Code" : "376",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "4.90",
+                "SubType" : "Rural Extended"
+              },
+              {
+                "Code" : "375",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "5.86"
+              }
+            ],
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "41.35"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "41.35"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "117.07"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "117.07"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "01",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "117.07"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "117.07"
+        }
+      },
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "GuaranteedDelivery" : {
+          "BusinessDaysInTransit" : "2"
+        },
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "24.27"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "41.92"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "11.0"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "376",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "4.90",
+              "SubType" : "Rural Extended"
+            },
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "7.73"
+            }
+          ],
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "15.93"
+            },
+            "ItemizedCharges" : [
+              {
+                "Code" : "376",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "4.90",
+                "SubType" : "Rural Extended"
+              },
+              {
+                "Code" : "375",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "3.44"
+              }
+            ],
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "24.27"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "24.27"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "54.55"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "54.55"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "02",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "54.55"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "54.55"
+        }
+      },
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "14.62"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "15.64"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "11.0"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "376",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "4.90",
+              "SubType" : "Rural Extended"
+            },
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "3.24"
+            }
+          ],
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "9.20"
+            },
+            "ItemizedCharges" : [
+              {
+                "Code" : "376",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "3.43",
+                "SubType" : "Rural Extended"
+              },
+              {
+                "Code" : "375",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "1.99"
+              }
+            ],
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "14.62"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "14.62"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "23.78"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "23.78"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "03",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "23.78"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "23.78"
+        }
+      },
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "GuaranteedDelivery" : {
+          "BusinessDaysInTransit" : "3"
+        },
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "21.97"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "32.46"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "11.0"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "376",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "4.90",
+              "SubType" : "Rural Extended"
+            },
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "6.16"
+            }
+          ],
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "13.96"
+            },
+            "ItemizedCharges" : [
+              {
+                "Code" : "376",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "4.90",
+                "SubType" : "Rural Extended"
+              },
+              {
+                "Code" : "375",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "3.11"
+              }
+            ],
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "21.97"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "21.97"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "43.52"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "43.52"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "12",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "43.52"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "43.52"
+        }
+      },
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "GuaranteedDelivery" : {
+          "BusinessDaysInTransit" : "1",
+          "DeliveryByTime" : "2:00 P.M."
+        },
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "152.02"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "125.59"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "11.0"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "376",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "4.90",
+              "SubType" : "Rural Extended"
+            },
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "21.53"
+            }
+          ],
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "125.59"
+            },
+            "ItemizedCharges" : [
+              {
+                "Code" : "376",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "4.90",
+                "SubType" : "Rural Extended"
+              },
+              {
+                "Code" : "375",
+                "CurrencyCode" : "USD",
+                "MonetaryValue" : "21.53"
+              }
+            ],
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "152.02"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "152.02"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "152.02"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "152.02"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "14",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "152.02"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "152.02"
+        }
+      }
+    ],
+    "Response" : {
+      "Alert" : [
+        {
+          "Code" : "110971",
+          "Description" : "Your invoice may vary from the displayed reference rates"
+        },
+        {
+          "Code" : "110920",
+          "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+        }
+      ],
+      "ResponseStatus" : {
+        "Code" : "1",
+        "Description" : "Success"
+      },
+      "TransactionReference" : {
+        "CustomerContext" : "testing",
+        "TransactionIdentifier" : "xwssoat275n7l3jVpV9NLB"
+      }
+    }
+  }
+}

--- a/spec/fixtures/ups_json/rates_with_rate_modifiers.json
+++ b/spec/fixtures/ups_json/rates_with_rate_modifiers.json
@@ -1,0 +1,850 @@
+{
+  "RateResponse": {
+    "Response": {
+      "ResponseStatus": {
+        "Code": "1",
+        "Description": "Success"
+      },
+      "Alert": [
+        {
+          "Code": "111730",
+          "Description": "Invalid Date. Changed to today's date"
+        },
+        {
+          "Code": "110971",
+          "Description": "Your invoice may vary from the displayed reference rates"
+        },
+        {
+          "Code": "112237",
+          "Description": "Modifier is applied on Package(s);"
+        }
+      ],
+      "TransactionReference": ""
+    },
+    "RatedShipment": [
+      {
+        "Service": {
+          "Code": "13",
+          "Description": ""
+        },
+        "RatedShipmentAlert": [
+          {
+            "Code": "111730",
+            "Description": "Invalid Date. Changed the pickup date"
+          },
+          {
+            "Code": "110971",
+            "Description": "Your invoice may vary from the displayed reference rates"
+          }
+        ],
+        "BillingWeight": {
+          "UnitOfMeasurement": {
+            "Code": "LBS",
+            "Description": "Pounds"
+          },
+          "Weight": "10.0"
+        },
+        "TransportationCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "168.74"
+        },
+        "BaseServiceCharge": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "ItemizedCharges": {
+          "Code": "270",
+          "CurrencyCode": "USD",
+          "MonetaryValue": "12.40"
+        },
+        "ServiceOptionsCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "TotalCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "168.74"
+        },
+        "GuaranteedDelivery": {
+          "BusinessDaysInTransit": "1"
+        },
+        "RatedPackage": [
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "84.37"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "60.68"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "11.64"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "84.37"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          },
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "84.37"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "60.68"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "11.64"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "84.37"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          }
+        ]
+      },
+      {
+        "Service": {
+          "Code": "01",
+          "Description": ""
+        },
+        "RatedShipmentAlert": {
+          "Code": "110971",
+          "Description": "Your invoice may vary from the displayed reference rates"
+        },
+        "BillingWeight": {
+          "UnitOfMeasurement": {
+            "Code": "LBS",
+            "Description": "Pounds"
+          },
+          "Weight": "10.0"
+        },
+        "TransportationCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "186.20"
+        },
+        "BaseServiceCharge": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "ItemizedCharges": {
+          "Code": "270",
+          "CurrencyCode": "USD",
+          "MonetaryValue": "12.40"
+        },
+        "ServiceOptionsCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "TotalCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "186.20"
+        },
+        "GuaranteedDelivery": {
+          "BusinessDaysInTransit": "1",
+          "DeliveryByTime": "10:30 A.M."
+        },
+        "RatedPackage": [
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "93.10"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "68.21"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "12.84"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "93.10"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          },
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "93.10"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "68.21"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "12.84"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "93.10"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          }
+        ]
+      },
+      {
+        "Service": {
+          "Code": "12",
+          "Description": ""
+        },
+        "RatedShipmentAlert": {
+          "Code": "110971",
+          "Description": "Your invoice may vary from the displayed reference rates"
+        },
+        "BillingWeight": {
+          "UnitOfMeasurement": {
+            "Code": "LBS",
+            "Description": "Pounds"
+          },
+          "Weight": "10.0"
+        },
+        "TransportationCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "82.04"
+        },
+        "BaseServiceCharge": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "ItemizedCharges": {
+          "Code": "270",
+          "CurrencyCode": "USD",
+          "MonetaryValue": "12.40"
+        },
+        "ServiceOptionsCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "TotalCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "82.04"
+        },
+        "GuaranteedDelivery": {
+          "BusinessDaysInTransit": "3"
+        },
+        "RatedPackage": [
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "41.02"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "23.31"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.66"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "41.02"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          },
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "41.02"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "23.31"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.66"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "41.02"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          }
+        ]
+      },
+      {
+        "Service": {
+          "Code": "03",
+          "Description": ""
+        },
+        "RatedShipmentAlert": [
+          {
+            "Code": "112237",
+            "Description": "Destination Modifier is applied on Package 0"
+          },
+          {
+            "Code": "112237",
+            "Description": "Destination Modifier is applied on Package 1"
+          },
+          {
+            "Code": "110971",
+            "Description": "Your invoice may vary from the displayed reference rates"
+          }
+        ],
+        "BillingWeight": {
+          "UnitOfMeasurement": {
+            "Code": "LBS",
+            "Description": "Pounds"
+          },
+          "Weight": "10.0"
+        },
+        "TransportationCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "57.24"
+        },
+        "BaseServiceCharge": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "ItemizedCharges": {
+          "Code": "270",
+          "CurrencyCode": "USD",
+          "MonetaryValue": "11.30"
+        },
+        "ServiceOptionsCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "TotalCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "57.24"
+        },
+        "RatedPackage": [
+          {
+            "RateModifier": {
+              "ModifierType": "DTM",
+              "ModifierDesc": "Destination Modifier",
+              "Amount": "-0.60"
+            },
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "28.62"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "13.95"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.70",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "3.92"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "28.62"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          },
+          {
+            "RateModifier": {
+              "ModifierType": "DTM",
+              "ModifierDesc": "Destination Modifier",
+              "Amount": "-0.60"
+            },
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "28.62"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "13.95"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.70",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "3.92"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "28.62"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          }
+        ]
+      },
+      {
+        "Service": {
+          "Code": "14",
+          "Description": ""
+        },
+        "RatedShipmentAlert": {
+          "Code": "110971",
+          "Description": "Your invoice may vary from the displayed reference rates"
+        },
+        "BillingWeight": {
+          "UnitOfMeasurement": {
+            "Code": "LBS",
+            "Description": "Pounds"
+          },
+          "Weight": "10.0"
+        },
+        "TransportationCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "255.80"
+        },
+        "BaseServiceCharge": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "ItemizedCharges": {
+          "Code": "270",
+          "CurrencyCode": "USD",
+          "MonetaryValue": "12.40"
+        },
+        "ServiceOptionsCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "TotalCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "255.80"
+        },
+        "GuaranteedDelivery": {
+          "BusinessDaysInTransit": "1",
+          "DeliveryByTime": "8:00 A.M."
+        },
+        "RatedPackage": [
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "127.90"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "98.21"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "17.64"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "127.90"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          },
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "127.90"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "98.21"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "17.64"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "127.90"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          }
+        ]
+      },
+      {
+        "Service": {
+          "Code": "02",
+          "Description": ""
+        },
+        "RatedShipmentAlert": {
+          "Code": "110971",
+          "Description": "Your invoice may vary from the displayed reference rates"
+        },
+        "BillingWeight": {
+          "UnitOfMeasurement": {
+            "Code": "LBS",
+            "Description": "Pounds"
+          },
+          "Weight": "10.0"
+        },
+        "TransportationCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "94.82"
+        },
+        "BaseServiceCharge": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "ItemizedCharges": {
+          "Code": "270",
+          "CurrencyCode": "USD",
+          "MonetaryValue": "12.40"
+        },
+        "ServiceOptionsCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "TotalCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "94.82"
+        },
+        "GuaranteedDelivery": {
+          "BusinessDaysInTransit": "2"
+        },
+        "RatedPackage": [
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "47.41"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "28.82"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "6.54"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "47.41"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          },
+          {
+            "TransportationCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "47.41"
+            },
+            "BaseServiceCharge": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "28.82"
+            },
+            "ServiceOptionsCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "0.00"
+            },
+            "ItemizedCharges": [
+              {
+                "Code": "376",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "5.85",
+                "SubType": "Rural"
+              },
+              {
+                "Code": "400",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "0.00",
+                "SubType": "EVS"
+              },
+              {
+                "Code": "375",
+                "CurrencyCode": "USD",
+                "MonetaryValue": "6.54"
+              }
+            ],
+            "TotalCharges": {
+              "CurrencyCode": "USD",
+              "MonetaryValue": "47.41"
+            },
+            "Weight": "1.0",
+            "BillingWeight": {
+              "UnitOfMeasurement": {
+                "Code": "LBS",
+                "Description": "Pounds"
+              },
+              "Weight": "5.0"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/spec/fixtures/ups_json/ups_rates_canadian.json
+++ b/spec/fixtures/ups_json/ups_rates_canadian.json
@@ -1,0 +1,633 @@
+{
+  "RateResponse" : {
+    "RatedShipment" : [
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "188.07"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "GuaranteedDelivery" : {
+          "BusinessDaysInTransit" : "1",
+          "DeliveryByTime" : "10:30 A.M."
+        },
+        "ItemizedCharges" : [
+          {
+            "Code" : "375",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "35.57"
+          },
+          {
+            "Code" : "430",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "1.65",
+            "SubType" : "Commercial_Seasonal_Surcharge"
+          }
+        ],
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "69.94"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "13.42"
+            },
+            {
+              "Code" : "430",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "1.65",
+              "SubType" : "Commercial_Seasonal_Surcharge"
+            }
+          ],
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "85.01"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "0.0"
+          },
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "07",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "225.29"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "225.29"
+        }
+      },
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "174.23"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "ItemizedCharges" : [
+          {
+            "Code" : "375",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "32.98"
+          },
+          {
+            "Code" : "430",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "1.65",
+            "SubType" : "Commercial_Seasonal_Surcharge"
+          }
+        ],
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "62.96"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "12.12"
+            },
+            {
+              "Code" : "430",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "1.65",
+              "SubType" : "Commercial_Seasonal_Surcharge"
+            }
+          ],
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "76.73"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "0.0"
+          },
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "08",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "208.86"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "208.86"
+        }
+      },
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "42.70"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "ItemizedCharges" : [
+          {
+            "Code" : "375",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "7.10"
+          },
+          {
+            "Code" : "430",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.30",
+            "SubType" : "Commercial_Seasonal_Surcharge"
+          }
+        ],
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "25.47"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "4.26"
+            },
+            {
+              "Code" : "430",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.30",
+              "SubType" : "Commercial_Seasonal_Surcharge"
+            }
+          ],
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "30.03"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "0.0"
+          },
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "11",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "50.10"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "50.10"
+        }
+      },
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "188.07"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "ItemizedCharges" : [
+          {
+            "Code" : "375",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "43.07"
+          },
+          {
+            "Code" : "430",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "1.65",
+            "SubType" : "Commercial_Seasonal_Surcharge"
+          }
+        ],
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "69.94"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "20.92"
+            },
+            {
+              "Code" : "430",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "1.65",
+              "SubType" : "Commercial_Seasonal_Surcharge"
+            }
+          ],
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "132.51"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "0.0"
+          },
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "113005",
+            "Description" : "The selected service may not guarantee early AM arrival to the requested location."
+          },
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "54",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "272.79"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "272.79"
+        }
+      },
+      {
+        "BaseServiceCharge" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "182.59"
+        },
+        "BillingWeight" : {
+          "UnitOfMeasurement" : {
+            "Code" : "LBS",
+            "Description" : "Pounds"
+          },
+          "Weight" : "11.0"
+        },
+        "ItemizedCharges" : [
+          {
+            "Code" : "375",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "34.55"
+          },
+          {
+            "Code" : "430",
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "1.65",
+            "SubType" : "Commercial_Seasonal_Surcharge"
+          }
+        ],
+        "NegotiatedRateCharges" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "67.24"
+          },
+          "ItemizedCharges" : [
+            {
+              "Code" : "375",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "12.92"
+            },
+            {
+              "Code" : "430",
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "1.65",
+              "SubType" : "Commercial_Seasonal_Surcharge"
+            }
+          ],
+          "TotalCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "81.81"
+          }
+        },
+        "RatedPackage" : {
+          "BaseServiceCharge" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "BillingWeight" : {
+            "UnitOfMeasurement" : {
+              "Code" : "LBS",
+              "Description" : "Pounds"
+            },
+            "Weight" : "0.0"
+          },
+          "NegotiatedCharges" : {
+            "BaseServiceCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "ServiceOptionsCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TotalCharge" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            },
+            "TransportationCharges" : {
+              "CurrencyCode" : "USD",
+              "MonetaryValue" : "0.00"
+            }
+          },
+          "ServiceOptionsCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TotalCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "TransportationCharges" : {
+            "CurrencyCode" : "USD",
+            "MonetaryValue" : "0.00"
+          },
+          "Weight" : "10.2"
+        },
+        "RatedShipmentAlert" : [
+          {
+            "Code" : "110971",
+            "Description" : "Your invoice may vary from the displayed reference rates"
+          },
+          {
+            "Code" : "110920",
+            "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+          }
+        ],
+        "Service" : {
+          "Code" : "65",
+          "Description" : ""
+        },
+        "ServiceOptionsCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "0.00"
+        },
+        "TotalCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "218.79"
+        },
+        "TransportationCharges" : {
+          "CurrencyCode" : "USD",
+          "MonetaryValue" : "218.79"
+        }
+      }
+    ],
+    "Response" : {
+      "Alert" : [
+        {
+          "Code" : "110971",
+          "Description" : "Your invoice may vary from the displayed reference rates"
+        },
+        {
+          "Code" : "110920",
+          "Description" : "Ship To Address Classification is changed from Residential to Commercial"
+        },
+        {
+          "Code" : "113005",
+          "Description" : "The selected service may not guarantee early AM arrival to the requested location."
+        }
+      ],
+      "ResponseStatus" : {
+        "Code" : "1",
+        "Description" : "Success"
+      },
+      "TransactionReference" : {
+        "CustomerContext" : "testing",
+        "TransactionIdentifier" : "xwssoas285n5cVZPvNcJlT"
+      }
+    }
+  }
+}

--- a/spec/friendly_shipping/services/ups_json/parse_rates_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_json/parse_rates_response_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe FriendlyShipping::Services::UpsJson::ParseRatesResponse do
+  subject(:call) { described_class.call(request: request, response: response, shipment: shipment) }
+
+  let(:request) { FriendlyShipping::Request.new(url: "http://www.example.com", debug: true) }
+  let(:response) { double(body: response_body, headers: {}) }
+  let(:shipment) { FactoryBot.build(:physical_shipment) }
+  let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "ups_json", "rates_with_rate_modifiers.json")) }
+
+  it "returns rates for each shipping method" do
+    rates = subject.value!.data
+    expect(rates).to be_a(Array)
+    expect(rates.length).to eq(6)
+    expect(rates.map(&:total_amount)).to contain_exactly(*[
+      168_74, 186_20, 82_04, 57_24, 255_80, 94_82
+    ].map { |cents| Money.new(cents, 'USD') })
+    expect(rates.map(&:shipping_method).map(&:name)).to contain_exactly(
+      "UPS Ground",
+      "UPS 3 Day Select®",
+      "UPS 2nd Day Air®",
+      "UPS Next Day Air Saver®",
+      "UPS Next Day Air® Early",
+      "UPS Next Day Air®"
+    )
+  end
+
+  it "returns itemized charges for each shipping method" do
+    rates = subject.value!.data
+    expect(rates.map { |r| r.data[:itemized_charges] }).to contain_exactly(
+      { 'RESIDENTIAL ADDRESS' => Money.new(1130, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(1240, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(1240, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(1240, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(1240, 'USD') },
+      { 'RESIDENTIAL ADDRESS' => Money.new(1240, 'USD') }
+    )
+  end
+
+  context "with negotiated rates" do
+    let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "ups_json", "rates_with_negotiated_charges.json")) }
+
+    it "returns negotiated rates for each shipping method and the individual packages" do
+      rates = subject.value!.data
+      expect(rates.map { |r| r.data[:negotiated_rate] }).to contain_exactly(
+        Money.new(4135, 'USD'),
+        Money.new(2427, 'USD'),
+        Money.new(1462, 'USD'),
+        Money.new(2197, 'USD'),
+        Money.new(15_202, 'USD')
+      )
+
+      expect(rates.map { |r| r.data[:packages].map { |package| package[:negotiated_charges] } }).to contain_exactly(
+        [
+          {
+            'DELIVERY AREA' => Money.new(490, 'USD'),
+            'FUEL SURCHARGE' => Money.new(586, 'USD')
+          }
+        ],
+        [
+          {
+            'DELIVERY AREA' => Money.new(490, 'USD'),
+            'FUEL SURCHARGE' => Money.new(344, 'USD')
+          }
+        ],
+        [
+          {
+            'DELIVERY AREA' => Money.new(343, 'USD'),
+            'FUEL SURCHARGE' => Money.new(199, 'USD')
+          }
+        ],
+        [
+          {
+            'DELIVERY AREA' => Money.new(490, 'USD'),
+            'FUEL SURCHARGE' => Money.new(311, 'USD')
+          }
+        ],
+        [
+          {
+            'DELIVERY AREA' => Money.new(490, 'USD'),
+            'FUEL SURCHARGE' => Money.new(2153, 'USD')
+          }
+        ]
+      )
+    end
+
+    it "returns the changed address type for each shipping method" do
+      rates = subject.value!.data
+      expect(rates.map { |r| r.data[:new_address_type] }).to contain_exactly(
+        "commercial",
+        "commercial",
+        "commercial",
+        "commercial",
+        "commercial"
+      )
+    end
+  end
+
+  describe "packages" do
+    it "returns data for each package" do
+      rates = subject.value!.data
+      expect(rates.first.data[:packages].first).to eq(
+        {
+          transportation_charges: Money.new(8437, "USD"),
+          base_service_charge: Money.new(6068, "USD"),
+          total_charges: Money.new(8437, "USD"),
+          itemized_charges: {
+            "DELIVERY AREA" => Money.new(585, "USD"),
+            "FUEL SURCHARGE" => Money.new(1164, "USD"),
+          },
+          negotiated_charges: {},
+          rate_modifiers: {},
+          weight: 1.0,
+          billing_weight: 5.0
+        }
+      )
+    end
+
+    context "when packages have zero rates" do
+      let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "ups_json", "ups_rates_canadian.json")) }
+
+      it "returns data for each package" do
+        rates = subject.value!.data
+        expect(rates.first.data[:packages]).to eq(
+          [
+            itemized_charges: {},
+            negotiated_charges: {},
+            rate_modifiers: {},
+            weight: 10.2,
+            billing_weight: 0
+          ]
+        )
+      end
+    end
+
+    context "when packages have rate modifiers" do
+      it "returns modifiers in the data for each package" do
+        ground_rate = subject.value!.data.detect { |rate| rate.shipping_method.service_code == "03" }
+        expect(ground_rate.data[:packages]).to eq(
+          [
+            {
+              transportation_charges: Money.new(2862, "USD"),
+              base_service_charge: Money.new(1395, "USD"),
+              itemized_charges: {
+                "DELIVERY AREA" => Money.new(570, "USD"),
+                "FUEL SURCHARGE" => Money.new(392, "USD"),
+              },
+              total_charges: Money.new(2862, "USD"),
+              negotiated_charges: {},
+              rate_modifiers: {
+                "DTM (Destination Modifier)" => Money.new(-60, "USD"),
+              },
+              weight: 1.0,
+              billing_weight: 5.0
+            }, {
+              transportation_charges: Money.new(2862, "USD"),
+              base_service_charge: Money.new(1395, "USD"),
+              itemized_charges: {
+                "DELIVERY AREA" => Money.new(570, "USD"),
+                "FUEL SURCHARGE" => Money.new(392, "USD"),
+              },
+              total_charges: Money.new(2862, "USD"),
+              negotiated_charges: {},
+              rate_modifiers: {
+                "DTM (Destination Modifier)" => Money.new(-60, "USD"),
+              },
+              weight: 1.0,
+              billing_weight: 5.0
+            }
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
There were a bunch of problems with the extra data being returned with the rates response. This is not too surprising given that only the top level rate costs were the only thing covered by tests.

I am not a fan of the `[label, amount]` array that mostly acts like a hash but will clean that up later.