### PR TITLE
Fix ups label cost breakdown

### DIFF
--- a/lib/friendly_shipping/services/ups_json/parse_labels_response.rb
+++ b/lib/friendly_shipping/services/ups_json/parse_labels_response.rb
@@ -33,7 +33,7 @@ module FriendlyShipping
                 usps_tracking_number: package["USPSPICNumber"],
                 label_data: Base64.decode64(package["ShippingLabel"]["GraphicImage"]),
                 label_format: package["ShippingLabel"]["ImageFormat"]["Code"],
-                label_href: package["LabelURL"],
+                label_href: package["LabelURL"] || shipment_result["LabelURL"],
                 cost: package_cost,
                 shipment_cost: get_shipment_cost(shipment_result),
                 data: {
@@ -47,9 +47,9 @@ module FriendlyShipping
 
           def build_cost_breakdown(package)
             costs = [
-              package["BaseServiceCharge"],
-              Array.wrap(package["ServiceOptionsCharges"]),
-              Array.wrap(package["ItemizedCharges"])
+              package["BaseServiceCharge"]&.merge("Code" => "BaseServiceCharge"),
+              package["ServiceOptionsCharges"],
+              package["ItemizedCharges"]
             ].flatten
 
             costs.map { |cost| ParseMoneyHash.call(cost, "UnknownSurcharge") }.compact.to_h

--- a/lib/friendly_shipping/services/ups_json/parse_money_hash.rb
+++ b/lib/friendly_shipping/services/ups_json/parse_money_hash.rb
@@ -15,7 +15,7 @@ module FriendlyShipping
           amount = Money.new(monetary_value * currency.subunit_to_unit, currency)
 
           surcharge_code = money_hash['Code']
-          label = surcharge_code ? UPS_SURCHARGE_CODES[surcharge_code] : key_name
+          label = UPS_SURCHARGE_CODES[surcharge_code] || surcharge_code || key_name
 
           [label, amount]
         end

--- a/spec/fixtures/ups_json/labels_two_packages.json
+++ b/spec/fixtures/ups_json/labels_two_packages.json
@@ -1,0 +1,97 @@
+{
+  "ShipmentResponse": {
+    "Response": {
+      "ResponseStatus": {
+        "Code": "1",
+        "Description": "Success"
+      },
+      "TransactionReference": ""
+    },
+    "ShipmentResults": {
+      "ShipmentCharges": {
+        "TransportationCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "56.99"
+        },
+        "ItemizedCharges": {
+          "Code": "270",
+          "CurrencyCode": "USD",
+          "MonetaryValue": "11.30"
+        },
+        "ServiceOptionsCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "0.00"
+        },
+        "TotalCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "56.99"
+        }
+      },
+      "BillingWeight": {
+        "UnitOfMeasurement": {
+          "Code": "LBS",
+          "Description": "Pounds"
+        },
+        "Weight": "30.0"
+      },
+      "ShipmentIdentificationNumber": "1ZXXXXXXXXXXXXXXXX",
+      "PackageResults": [
+        {
+          "TrackingNumber": "1ZXXXXXXXXXXXXXXXX",
+          "BaseServiceCharge": {
+            "CurrencyCode": "USD",
+            "MonetaryValue": "25.79"
+          },
+          "ServiceOptionsCharges": {
+            "CurrencyCode": "USD",
+            "MonetaryValue": "0.00"
+          },
+          "ShippingLabel": {
+            "ImageFormat": {
+              "Code": "ZPL",
+              "Description": "ZPL"
+            },
+            "GraphicImage": "Cl5YQQ0KXkxSTg0K=="
+          },
+          "ItemizedCharges": {
+            "Code": "375",
+            "CurrencyCode": "USD",
+            "MonetaryValue": "4.95"
+          }
+        },
+        {
+          "TrackingNumber": "1ZXXXXXXXXXXXXXXXX",
+          "BaseServiceCharge": {
+            "CurrencyCode": "USD",
+            "MonetaryValue": "12.15"
+          },
+          "ServiceOptionsCharges": {
+            "CurrencyCode": "USD",
+            "MonetaryValue": "0.00"
+          },
+          "ShippingLabel": {
+            "ImageFormat": {
+              "Code": "ZPL",
+              "Description": "ZPL"
+            },
+            "GraphicImage": "Cl5YQQ0KXkxSTg0K=="
+          },
+          "ItemizedCharges": [
+            {
+              "Code": "430",
+              "CurrencyCode": "USD",
+              "MonetaryValue": "1.00",
+              "SubType": "EVS"
+            },
+            {
+              "Code": "375",
+              "CurrencyCode": "USD",
+              "MonetaryValue": "1.80"
+            }
+          ]
+        }
+      ],
+      "LabelURL": "https://www.ups.com/uel/llp/1ZY9319W0399389763/link/labelAll/XSA/fq3Gmu0fyI6kwlDU5kQBgjKtuyD1mNfat76UjFtChj8e/en_US?loc=en_US&cie=true&pdr=false"
+    }
+  }
+}

--- a/spec/fixtures/ups_json/labels_with_negotiated_rates.json
+++ b/spec/fixtures/ups_json/labels_with_negotiated_rates.json
@@ -1,0 +1,76 @@
+{
+  "ShipmentResponse": {
+    "Response": {
+      "ResponseStatus": {
+        "Code": "1",
+        "Description": "Success"
+      },
+      "TransactionReference": ""
+    },
+    "ShipmentResults": {
+      "ShipmentCharges": {
+        "TransportationCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "14.51"
+        },
+        "ItemizedCharges": {
+          "Code": "250",
+          "CurrencyCode": "USD",
+          "MonetaryValue": "1.05"
+        },
+        "ServiceOptionsCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "1.05"
+        },
+        "TotalCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "15.56"
+        }
+      },
+      "NegotiatedRateCharges": {
+        "TotalCharge": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "14.36"
+        }
+      },
+      "BillingWeight": {
+        "UnitOfMeasurement": {
+          "Code": "LBS",
+          "Description": "Pounds"
+        },
+        "Weight": "5.0"
+      },
+      "ShipmentIdentificationNumber": "1ZXXXXXXXXXXXXXXXX",
+      "PackageResults": {
+        "TrackingNumber": "1ZXXXXXXXXXXXXXXXX",
+        "BaseServiceCharge": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "12.56"
+        },
+        "ServiceOptionsCharges": {
+          "CurrencyCode": "USD",
+          "MonetaryValue": "1.05"
+        },
+        "ShippingLabel": {
+          "ImageFormat": {
+            "Code": "GIF",
+            "Description": "GIF"
+          },
+          "GraphicImage": "Cl5YQQ0KXkxSTg0K=="
+        },
+        "ShippingReceipt": {
+          "ImageFormat": {
+            "Code": "HTML",
+            "Description": "HTML"
+          },
+          "GraphicImage": "Cl5YQQ0KXkxSTg0K=="
+        },
+        "ItemizedCharges": {
+          "Code": "375",
+          "CurrencyCode": "USD",
+          "MonetaryValue": "1.95"
+        }
+      }
+    }
+  }
+}

--- a/spec/friendly_shipping/services/ups_json/parse_labels_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_json/parse_labels_response_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe FriendlyShipping::Services::UpsJson::ParseLabelsResponse do
+  subject(:call) { described_class.call(request: request, response: response) }
+
+  let(:request) { FriendlyShipping::Request.new(url: "http://www.example.com", debug: true) }
+  let(:response) { double(body: response_body, headers: {}) }
+  let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "ups_json", "labels_two_packages.json")) }
+
+  it "returns a successful result with the expected data for two packages" do
+    expect(call).to be_success
+    expect(call.value!.data).to be_a(Array)
+    expect(call.value!.data.length).to eq(2)
+    first_label = call.value!.data.first
+    expect(first_label).to be_a(FriendlyShipping::Services::UpsJson::Label)
+    expect(first_label.shipment_id).to eq("1ZXXXXXXXXXXXXXXXX")
+    expect(first_label.tracking_number).to eq("1ZXXXXXXXXXXXXXXXX")
+    expect(first_label.usps_tracking_number).to be_nil
+    expect(first_label.label_data).to be_a(String)
+    expect(first_label.label_format).to eq("ZPL")
+    expect(first_label.label_href).to eq("https://www.ups.com/uel/llp/1ZY9319W0399389763/link/labelAll/XSA/fq3Gmu0fyI6kwlDU5kQBgjKtuyD1mNfat76UjFtChj8e/en_US?loc=en_US&cie=true&pdr=false")
+    expect(first_label.cost).to eq(Money.new(3074, "USD"))
+    expect(first_label.shipment_cost).to eq(Money.new(5699, "USD"))
+    expect(first_label.data).to be_a(Hash)
+    expect(first_label.data[:cost_breakdown]).to eq({
+                                                      "BaseServiceCharge" => Money.new(2579, 'USD'),
+                                                      "FUEL SURCHARGE" => Money.new(495, 'USD')
+                                                    })
+    expect(first_label.data[:negotiated_rate]).to be_nil
+    expect(first_label.data[:customer_context]).to be_nil
+
+    second_label = call.value!.data.last
+    expect(second_label).to be_a(FriendlyShipping::Services::UpsJson::Label)
+    expect(second_label.shipment_id).to eq("1ZXXXXXXXXXXXXXXXX")
+    expect(second_label.tracking_number).to eq("1ZXXXXXXXXXXXXXXXX")
+    expect(second_label.label_data).to be_a(String)
+    expect(second_label.label_format).to eq("ZPL")
+    expect(second_label.label_href).to eq("https://www.ups.com/uel/llp/1ZY9319W0399389763/link/labelAll/XSA/fq3Gmu0fyI6kwlDU5kQBgjKtuyD1mNfat76UjFtChj8e/en_US?loc=en_US&cie=true&pdr=false")
+    expect(second_label.cost).to eq(Money.new(1495, "USD"))
+    expect(second_label.shipment_cost).to eq(Money.new(5699, "USD"))
+    expect(second_label.data).to be_a(Hash)
+    expect(second_label.data[:cost_breakdown]).to eq({
+                                                       "BaseServiceCharge" => Money.new(1215, 'USD'),
+                                                       "FUEL SURCHARGE" => Money.new(180, 'USD'),
+                                                       "PEAK SEASON" => Money.new(100, 'USD')
+                                                     })
+    expect(second_label.data[:negotiated_rate]).to be_nil
+    expect(second_label.data[:customer_context]).to be_nil
+  end
+
+  context "with a negotiated rate" do
+    let!(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "ups_json", "labels_with_negotiated_rates.json")) }
+
+    it "returns the negotiated rate if available" do
+      expect(call.value!.data.first.data[:negotiated_rate]).to eq(Money.new(1436, "USD"))
+    end
+  end
+end

--- a/spec/friendly_shipping/services/ups_json_spec.rb
+++ b/spec/friendly_shipping/services/ups_json_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe FriendlyShipping::Services::UpsJson do
         expect(first_label.tracking_number).to be_present
         expect(first_label.label_data.first(5)).to eq("GIF89")
         expect(first_label.label_format).to eq("GIF")
-        expect(first_label.cost).to eq(Money.new(252, 'USD'))
+        expect(first_label.cost).to eq(Money.new(1846, 'USD'))
         expect(first_label.shipment_cost).to eq(Money.new(1846, 'USD'))
         expect(first_label.data[:negotiated_rate]).to eq(Money.new(1823, 'USD'))
         expect(first_label.data[:customer_context]).to eq('request-id-12345')
@@ -394,7 +394,7 @@ RSpec.describe FriendlyShipping::Services::UpsJson do
         expect(first_label.tracking_number).to be_present
         expect(first_label.label_data.first(5)).to eq("GIF89")
         expect(first_label.label_format).to eq("GIF")
-        expect(first_label.cost).to eq(Money.new(300, 'USD'))
+        expect(first_label.cost).to eq(Money.new(1556, 'USD'))
         expect(first_label.shipment_cost).to eq(Money.new(1556, 'USD'))
         expect(first_label.data[:negotiated_rate]).to eq(Money.new(1436, 'USD'))
       end
@@ -425,7 +425,7 @@ RSpec.describe FriendlyShipping::Services::UpsJson do
         expect(first_label.tracking_number).to be_present
         expect(first_label.label_data.first(5)).to eq("GIF89")
         expect(first_label.label_format).to eq("GIF")
-        expect(first_label.cost).to eq(Money.new(201, 'USD'))
+        expect(first_label.cost).to eq(Money.new(1436, 'USD'))
         expect(first_label.shipment_cost).to eq(Money.new(2862, 'USD'))
       end
     end


### PR DESCRIPTION
The base service charge was not getting named correctly. Multiple charges in the same category were also getting dropped.