### PR TITLE
Remove TForce company name sanitization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Metrics/BlockLength:
 Style/AccessorGrouping:
   Enabled: false
 
+Style/ArgumentsForwarding:
+  Enabled: false
+
 Style/HashEachMethods:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,5 +28,8 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: true
 
+Style/SuperArguments:
+  Enabled: false
+
 Naming/VariableNumber:
   Enabled: false

--- a/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
@@ -46,7 +46,7 @@ module FriendlyShipping
           # @return [Hash]
           def location(location)
             {
-              name: clean_company_name(location.company_name.presence || location.name),
+              name: truncate(location.company_name.presence || location.name),
               contact: truncate(location.name),
               email: truncate(location.email, length: 50),
               phone: {
@@ -127,7 +127,7 @@ module FriendlyShipping
           # @return [Hash]
           def requester(location)
             {
-              companyName: clean_company_name(location.company_name.presence || location.name),
+              companyName: truncate(location.company_name.presence || location.name),
               contactName: truncate(location.name),
               email: truncate(location.email, length: 50),
               phone: {
@@ -147,16 +147,6 @@ module FriendlyShipping
           # @return [String]
           def truncate(value, length: 35)
             value && value[0..(length - 1)].strip
-          end
-
-          # TForce does not support special characters like &, <, or > in company names.
-          #
-          # @param name [String]
-          # @return [String]
-          def clean_company_name(name)
-            return if name.nil?
-
-            truncate(CGI.escapeHTML(name).strip)
           end
         end
       end

--- a/spec/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash_spec.rb
@@ -199,22 +199,6 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
           )
         end
       end
-
-      context "with special chars in company name" do
-        let(:origin) do
-          Physical::Location.new(
-            company_name: "A.> & \"F\" <Co.",
-          )
-        end
-
-        it do
-          is_expected.to match(
-            hash_including(
-              name: "A.&gt; &amp; &quot;F&quot; &lt;Co."
-            )
-          )
-        end
-      end
     end
 
     describe "shipTo" do
@@ -266,22 +250,6 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
                 addressLine: "This is the longest street address",
                 postalCode: "63025-"
               )
-            )
-          )
-        end
-      end
-
-      context "with special chars in company name" do
-        let(:destination) do
-          Physical::Location.new(
-            company_name: "A.> & \"F\" <Co.",
-          )
-        end
-
-        it do
-          is_expected.to match(
-            hash_including(
-              name: "A.&gt; &amp; &quot;F&quot; &lt;Co."
             )
           )
         end
@@ -497,24 +465,6 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateCreateBOLReque
                   number: "123-123-1234 x1"
                 }
               }
-            )
-          )
-        end
-      end
-
-      context "with special chars in company name" do
-        let(:origin) do
-          Physical::Location.new(
-            company_name: "A.> & \"F\" <Co.",
-          )
-        end
-
-        it do
-          is_expected.to match(
-            hash_including(
-              requester: hash_including(
-                companyName: "A.&gt; &amp; &quot;F&quot; &lt;Co."
-              )
             )
           )
         end


### PR DESCRIPTION
We were escaping special characters like ampersands because the TForce API was returning server errors. They have since fixed the problem so the sanitization code can be safely removed.