### PR TITLE
Update payload location of NegotiatedRatesIndicator within UPS JSON

### DIFF
--- a/lib/friendly_shipping/services/ups_json/generate_rates_payload.rb
+++ b/lib/friendly_shipping/services/ups_json/generate_rates_payload.rb
@@ -18,6 +18,7 @@ module FriendlyShipping
                   Code: options.customer_classification_code
                 },
                 Shipment: {
+                  ShipmentRatingOptions: {},
                   Shipper: GenerateAddressHash.call(location: options.shipper || shipment.origin, international: international?(shipment), shipper_number: options.shipper_number),
                   ShipTo: GenerateAddressHash.call(location: shipment.destination, international: international?(shipment)),
                   ShipFrom: GenerateAddressHash.call(location: shipment.origin),
@@ -71,7 +72,7 @@ module FriendlyShipping
           }.compact
 
           if options.negotiated_rates
-            payload[:RateRequest][:Shipment][:NegotiatedRatesIndicator] = options.negotiated_rates
+            payload[:RateRequest][:Shipment][:ShipmentRatingOptions][:NegotiatedRatesIndicator] = "X"
           end
 
           payload

--- a/spec/friendly_shipping/services/ups_json/generate_rates_payload_spec.rb
+++ b/spec/friendly_shipping/services/ups_json/generate_rates_payload_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe FriendlyShipping::Services::UpsJson::GenerateRatesPayload do
       }
 
       it 'returns a hash with the required fields' do
-        expect(subject[:RateRequest][:Shipment][:NegotiatedRatesIndicator]).to be true
+        expect(subject[:RateRequest][:Shipment][:ShipmentRatingOptions][:NegotiatedRatesIndicator]).to eq "X"
       end
     end
   end


### PR DESCRIPTION
The `NegotiatedRatesIndicator` here must be submitted within `ShipmentRatingOptions` according to the UPS documentation:

[link to docs](https://developer.ups.com/api/reference?loc=en_US#operation/Rate!path=RateRequest/Shipment/ShipmentRatingOptions/NegotiatedRatesIndicator&t=request)

Similar to other `*Indicator` values for UPS Json, it also should be a `string`.

This is similar to how the option is handled for generating labels, which is already being set correctly:

https://github.com/friendlycart/friendly_shipping/blob/932e5a81d3a67f179c46f6ff556fdc960e6a3002/lib/friendly_shipping/services/ups_json/generate_labels_payload.rb#L59-L61