### PR TITLE
Attach cost breakdown to R+L rates data

### DIFF
--- a/friendly_shipping.gemspec
+++ b/friendly_shipping.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "dry-monads", "~> 1.0"
-  spec.add_runtime_dependency "jwt", "~> 2.7"
-  spec.add_runtime_dependency "money", "~> 6.0"
-  spec.add_runtime_dependency "nokogiri", "~> 1.6"
-  spec.add_runtime_dependency "physical", "~> 0.5", ">= 0.5.1"
-  spec.add_runtime_dependency "rest-client", "~> 2.0"
+  spec.add_dependency "dry-monads", "~> 1.0"
+  spec.add_dependency "jwt", "~> 2.7"
+  spec.add_dependency "money", "~> 6.0"
+  spec.add_dependency "nokogiri", "~> 1.6"
+  spec.add_dependency "physical", "~> 0.5", ">= 0.5.1"
+  spec.add_dependency "rest-client", "~> 2.0"
 
   spec.required_ruby_version = '>= 3.0'
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/spec/friendly_shipping/services/rl/parse_rate_quote_response_spec.rb
+++ b/spec/friendly_shipping/services/rl/parse_rate_quote_response_spec.rb
@@ -25,7 +25,42 @@ RSpec.describe FriendlyShipping::Services::RL::ParseRateQuoteResponse do
       expect(rate.shipping_method.service_code).to eq("STD")
       expect(rate.warnings).to be_empty
       expect(rate.errors).to be_empty
-      expect(rate.data).to eq({})
+      expect(rate.data).to eq(
+        cost_breakdown: [
+          { "Amount" => "$11.25", "Description" => "Class: 92.5", "Rate" => "$1,124.72", "Weight" => "1" },
+          { "Amount" => "$11.25", "Description" => "Class: 92.5", "Rate" => "$1,124.72", "Weight" => "1" },
+          { "Amount" => "$11.25", "Description" => "Class: 92.5", "Rate" => "$1,124.72", "Weight" => "1" },
+          { "Amount" => "$11.25", "Description" => "Class: 92.5", "Rate" => "$1,124.72", "Weight" => "1" },
+          { "Amount" => "$1,690.72", "Description" => "Minimum Charge", "Type" => "MINIMUM" },
+          { "Amount" => "$1,487.83", "Description" => "R+L Discount Saves This Much", "Rate" => "88%", "Type" => "DISCNT" },
+          { "Amount" => "$202.89", "Description" => "Discounted Freight Charge", "Type" => "DISCNF" },
+          { "Amount" => "$71.62", "Description" => "Fuel Surcharge", "Rate" => "35.3%", "Type" => "FUEL" },
+          { "Amount" => "$110.90", "Description" => "Manhattan Arbitrary Charge", "Type" => "ARBMH" },
+          { "Amount" => "$51.30", "Description" => "Hazmat Fee", "Rate" => "$51.30", "Type" => "HAZM" },
+          { "Amount" => "$436.71", "Description" => "Net Charge", "Type" => "NET" }
+        ]
+      )
+    end
+
+    it "adds non-standard service level charges to cost breakdowns" do
+      non_standard_rates = api_result.data.reject { |rate| rate.shipping_method.service_code == "STD" }
+      expect(non_standard_rates.size).to eq(1)
+      expect(non_standard_rates.first.data[:cost_breakdown]).to eq(
+        [
+          { "Amount" => "$11.25", "Description" => "Class: 92.5", "Rate" => "$1,124.72", "Weight" => "1" },
+          { "Amount" => "$11.25", "Description" => "Class: 92.5", "Rate" => "$1,124.72", "Weight" => "1" },
+          { "Amount" => "$11.25", "Description" => "Class: 92.5", "Rate" => "$1,124.72", "Weight" => "1" },
+          { "Amount" => "$11.25", "Description" => "Class: 92.5", "Rate" => "$1,124.72", "Weight" => "1" },
+          { "Amount" => "$1,690.72", "Description" => "Minimum Charge", "Type" => "MINIMUM" },
+          { "Amount" => "$1,487.83", "Description" => "R+L Discount Saves This Much", "Rate" => "88%", "Type" => "DISCNT" },
+          { "Amount" => "$202.89", "Description" => "Discounted Freight Charge", "Type" => "DISCNF" },
+          { "Amount" => "$71.62", "Description" => "Fuel Surcharge", "Rate" => "35.3%", "Type" => "FUEL" },
+          { "Amount" => "$110.90", "Description" => "Manhattan Arbitrary Charge", "Type" => "ARBMH" },
+          { "Amount" => "$51.30", "Description" => "Hazmat Fee", "Rate" => "$51.30", "Type" => "HAZM" },
+          { "Amount" => "$436.71", "Description" => "Net Charge", "Type" => "NET" },
+          { "Amount" => "$51.30", "Description" => "Guaranteed Service", "Type" => "GSDS" }
+        ]
+      )
     end
   end
 


### PR DESCRIPTION
The cost breakdown includes additional detail about the various rates and surcharges that makes up the total R+L rate.