### PR TITLE
Expand TForce cost breakdown detail

### DIFF
--- a/lib/friendly_shipping/services/rl/parse_rate_quote_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_rate_quote_response.rb
@@ -67,6 +67,9 @@ module FriendlyShipping
             end
           end
 
+          # @param [Array<Hash>] charges
+          # @param [Hash] service_level
+          # @return [Array<Hash>]
           def build_cost_breakdown(charges, service_level)
             result = charges.map do |charge|
               {

--- a/lib/friendly_shipping/services/tforce_freight/parse_rates_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_rates_response.rb
@@ -25,15 +25,11 @@ module FriendlyShipping
               total_currency = detail.dig("shipmentCharges", "total", "currency")
               total = Money.new(total_amount.to_f * 100, total_currency)
 
-              rates = detail['rate']
-              data = rates.each_with_object({}) do |rate, result|
-                result[rate['code'].downcase.to_sym] = rate['value'].to_f
-              end
-
-              data.merge(
+              data = {
                 customer_context: transaction_id,
-                commodities: Array.wrap(json['commodities'])
-              )
+                commodities: Array.wrap(json['commodities']),
+                cost_breakdown: detail['rate'].map { |rate| rate.slice(*%w[code description value unit]) }
+              }
 
               days_in_transit = detail.dig("timeInTransit", "timeInTransit")
               data[:days_in_transit] = days_in_transit.to_i if days_in_transit

--- a/spec/friendly_shipping/services/tforce_freight/parse_rates_response_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/parse_rates_response_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::ParseRatesResponse do
       expect(rate).to be_a(FriendlyShipping::Rate)
       expect(rate.total_amount).to eq(Money.new(157_356, "USD"))
       expect(rate.shipping_method.name).to eq("TForce Freight LTL")
+      expect(rate.data).to eq(
+        customer_context: "140fdff5-3df5-419e-bc3f-84b781f55cc9",
+        commodities: [],
+        days_in_transit: 3,
+        cost_breakdown: [
+          { "code" => "DSCNT", "description" => "Discount", "unit" => "USD", "value" => "1987.05" },
+          { "code" => "DSCNT_RATE", "description" => "DiscountRate", "unit" => "%", "value" => "75.00" },
+          { "code" => "INDE", "description" => "INSIDE_DL", "unit" => "USD", "value" => "169.00" },
+          { "code" => "INPU", "description" => "INSIDE_PU", "unit" => "USD", "value" => "169.00" },
+          { "code" => "LIFD", "description" => "LIFT_GATE_DL", "unit" => "USD", "value" => "175.00" },
+          { "code" => "LIFO", "description" => "LIFT_GATE_PU", "unit" => "USD", "value" => "175.00" },
+          { "code" => "FUEL_SUR", "description" => "FuelSurcharge Fee", "unit" => "USD", "value" => "223.21" },
+          { "code" => "LND_GROSS", "description" => "LND_GROSS", "unit" => "USD", "value" => "2649.40" },
+          { "code" => "AFTR_DSCNT", "description" => "AFTR_DSCNT", "unit" => "USD", "value" => "662.35" }
+        ]
+      )
     end
   end
 end


### PR DESCRIPTION
Before, we were only returning the code and value for each charge returned in the TForce API response. Now we're returning the description and unit as well.
    
The charges have also been moved under their own `cost_breakdown` key.