### PR TITLE
Never send empty UPS `ShipmentRatingOptions`

### DIFF
--- a/lib/friendly_shipping/services/ups_json/generate_rates_payload.rb
+++ b/lib/friendly_shipping/services/ups_json/generate_rates_payload.rb
@@ -18,7 +18,6 @@ module FriendlyShipping
                   Code: options.customer_classification_code
                 },
                 Shipment: {
-                  ShipmentRatingOptions: {},
                   Shipper: GenerateAddressHash.call(location: options.shipper || shipment.origin, international: international?(shipment), shipper_number: options.shipper_number),
                   ShipTo: GenerateAddressHash.call(location: shipment.destination, international: international?(shipment)),
                   ShipFrom: GenerateAddressHash.call(location: shipment.origin),
@@ -72,6 +71,7 @@ module FriendlyShipping
           }.compact
 
           if options.negotiated_rates
+            payload[:RateRequest][:Shipment][:ShipmentRatingOptions] ||= {}
             payload[:RateRequest][:Shipment][:ShipmentRatingOptions][:NegotiatedRatesIndicator] = "X"
           end
 

--- a/spec/friendly_shipping/services/ups_json/generate_rates_payload_spec.rb
+++ b/spec/friendly_shipping/services/ups_json/generate_rates_payload_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe FriendlyShipping::Services::UpsJson::GenerateRatesPayload do
     expect(subject[:RateRequest][:Shipment][:ShipTo][:Address][:AddressLine]).to eq(["11 Lovely Street", "Suite 100"])
     expect(subject[:RateRequest][:Shipment][:ShipFrom][:Address][:AddressLine]).to eq(["2 Main St"])
     expect(subject[:RateRequest][:Shipment][:PaymentDetails][:ShipmentCharge]).to eq([{ BillShipper: { AccountNumber: "123456" }, Type: "01" }])
+    expect(subject[:RateRequest][:Shipment][:ShipmentRatingOptions]).to be_nil
   end
 
   context "with additional options" do


### PR DESCRIPTION
This fixes a bug when the UPS rates option `negotiated_rates` flag is set to false. The `ShipmentRatingOptions` value ends up being an empty hash. The UPS API used to tolerate this just fine, but in a recent update they began complaining with an error response like this:

`Atleast one shipment rating option either negotiated or FRS rates or ratechart indicator is required.`

This changes the rates payload generator to leave out the `ShipmentRatingOptions` key when `negotiated_rates` is false.