### PR TITLE
Add city/state lookup endpoint for UPS JSON API

### DIFF
--- a/lib/friendly_shipping/services/ups_json.rb
+++ b/lib/friendly_shipping/services/ups_json.rb
@@ -5,12 +5,14 @@ require 'friendly_shipping/http_client'
 require 'friendly_shipping/services/ups_json/access_token'
 require 'friendly_shipping/services/ups_json/api_error'
 require 'friendly_shipping/services/ups_json/generate_address_classification_payload'
+require 'friendly_shipping/services/ups_json/generate_city_state_lookup_payload'
 require 'friendly_shipping/services/ups_json/generate_labels_payload'
 require 'friendly_shipping/services/ups_json/generate_rates_payload'
 require 'friendly_shipping/services/ups_json/generate_timings_payload'
 require 'friendly_shipping/services/ups_json/label'
 require 'friendly_shipping/services/ups_json/label_options'
 require 'friendly_shipping/services/ups_json/parse_address_classification_response'
+require 'friendly_shipping/services/ups_json/parse_city_state_lookup_response'
 require 'friendly_shipping/services/ups_json/parse_json_response'
 require 'friendly_shipping/services/ups_json/parse_labels_response'
 require 'friendly_shipping/services/ups_json/parse_money_hash'
@@ -179,6 +181,28 @@ module FriendlyShipping
 
         client.post(request).bind do |response|
           ParseAddressClassificationResponse.call(response: response, request: request)
+        end
+      end
+
+      # Find city and state for a given ZIP code
+      # @param [Physical::Location] location A location object with country and ZIP code set
+      # @return [Result<ApiResult<Array<Physical::Location>>>] The response data from UPS encoded in a
+      #   `Physical::Location` object. Country, City and ZIP code will be set, everything else nil.
+      def city_state_lookup(location, debug: false)
+        url = "#{base_url}/api/addressvalidation/v2/1"
+        headers = required_headers(access_token)
+        body = GenerateCityStateLookupPayload.call(location: location).to_json
+
+        request = FriendlyShipping::Request.new(
+          url: url,
+          http_method: "POST",
+          headers: headers,
+          body: body,
+          debug: debug
+        )
+
+        client.post(request).bind do |response|
+          ParseCityStateLookupResponse.call(response: response, request: request)
         end
       end
 

--- a/lib/friendly_shipping/services/ups_json/generate_city_state_lookup_payload.rb
+++ b/lib/friendly_shipping/services/ups_json/generate_city_state_lookup_payload.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class UpsJson
+      class GenerateCityStateLookupPayload
+        def self.call(location:)
+          {
+            XAVRequest: {
+              RegionalRequestIndicator: "1",
+              AddressKeyFormat: [
+                {
+                  PostcodePrimaryLow: location.zip,
+                  CountryCode: location.country.code
+                }
+              ]
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/ups_json/parse_city_state_lookup_response.rb
+++ b/lib/friendly_shipping/services/ups_json/parse_city_state_lookup_response.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class UpsJson
+      class ParseCityStateLookupResponse
+        extend Dry::Monads::Result::Mixin
+
+        def self.call(request:, response:)
+          parsed_response = ParseJsonResponse.call(
+            request: request,
+            response: response,
+            expected_root_key: 'XAVResponse'
+          )
+          parsed_response.bind do |city_state_lookup_response|
+            if city_state_lookup_response['XAVResponse'].keys.include?('NoCandidatesIndicator')
+              Failure(
+                FriendlyShipping::ApiFailure.new(
+                  "No candidates found.",
+                  original_request: request,
+                  original_response: response
+                )
+              )
+            else
+              candidate = city_state_lookup_response.dig('XAVResponse', 'Candidate').first
+              Success(
+                FriendlyShipping::ApiResult.new(
+                  Physical::Location.new(
+                    city: candidate.dig('AddressKeyFormat', 'PoliticalDivision2'),
+                    region: candidate.dig('AddressKeyFormat', 'PoliticalDivision1'),
+                    country: candidate.dig('AddressKeyFormat', 'CountryCode'),
+                    zip: candidate.dig('AddressKeyFormat', 'PostcodePrimaryLow')
+                  ),
+                  original_request: request,
+                  original_response: response
+                )
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/ups_json/city_state_lookup/known_zip.yml
+++ b/spec/cassettes/ups_json/city_state_lookup/known_zip.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/api/addressvalidation/v2/1
+    body:
+      encoding: UTF-8
+      string: '{"XAVRequest":{"RegionalRequestIndicator":"1","AddressKeyFormat":[{"PostcodePrimaryLow":"10017","CountryCode":"US"}]}}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (darwin23 x86_64) ruby/3.3.5p100
+      Authorization:
+      - Bearer %ACCESS_TOKEN%
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '118'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Max-Age:
+      - '600'
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Bkndtransid:
+      - '0000000009f5mP6k0v5GzR'
+      Referrer-Policy:
+      - same-origin
+      - same-origin
+      Content-Type:
+      - application/json;charset=UTF-8
+      X-Request-Id:
+      - 4abbc421-04e7-469f-836e-d08781b7e624
+      Content-Length:
+      - '1270'
+      Expires:
+      - Fri, 13 Sep 2024 14:55:43 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 13 Sep 2024 14:55:43 GMT
+      Connection:
+      - keep-alive
+      Ak-Grn-1:
+      - 0.66c83017.1726239343.80a98199
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"XAVResponse":{"Response":{"ResponseStatus":{"Code":"1", "Description":"Success"}},
+        "AmbiguousAddressIndicator":"", "Candidate":[{"AddressKeyFormat":{"PoliticalDivision2":"NEW
+        YORK", "PoliticalDivision1":"NY", "PostcodePrimaryLow":"10017", "Region":"NEW
+        YORK NY 10017", "CountryCode":"US"}}, {"AddressKeyFormat":{"PoliticalDivision2":"GRAND
+        CENTRAL", "PoliticalDivision1":"NY", "PostcodePrimaryLow":"10017", "Region":"GRAND
+        CENTRAL NY 10017", "CountryCode":"US"}}, {"AddressKeyFormat":{"PoliticalDivision2":"NYC",
+        "PoliticalDivision1":"NY", "PostcodePrimaryLow":"10017", "Region":"NYC NY
+        10017", "CountryCode":"US"}}, {"AddressKeyFormat":{"PoliticalDivision2":"MANHATTAN",
+        "PoliticalDivision1":"NY", "PostcodePrimaryLow":"10017", "Region":"MANHATTAN
+        NY 10017", "CountryCode":"US"}}, {"AddressKeyFormat":{"PoliticalDivision2":"NY",
+        "PoliticalDivision1":"NY", "PostcodePrimaryLow":"10017", "Region":"NY NY 10017",
+        "CountryCode":"US"}}, {"AddressKeyFormat":{"PoliticalDivision2":"NEW YORK
+        CITY", "PoliticalDivision1":"NY", "PostcodePrimaryLow":"10017", "Region":"NEW
+        YORK CITY NY 10017", "CountryCode":"US"}}, {"AddressKeyFormat":{"PoliticalDivision2":"NY
+        CITY", "PoliticalDivision1":"NY", "PostcodePrimaryLow":"10017", "Region":"NY
+        CITY NY 10017", "CountryCode":"US"}}]}}'
+  recorded_at: Fri, 13 Sep 2024 14:55:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/ups_json/city_state_lookup/unknown_zip.yml
+++ b/spec/cassettes/ups_json/city_state_lookup/unknown_zip.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://wwwcie.ups.com/api/addressvalidation/v2/1
+    body:
+      encoding: UTF-8
+      string: '{"XAVRequest":{"RegionalRequestIndicator":"1","AddressKeyFormat":[{"PostcodePrimaryLow":"00000","CountryCode":"US"}]}}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (darwin23 x86_64) ruby/3.3.5p100
+      Authorization:
+      - Bearer %ACCESS_TOKEN%
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '118'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - wwwcie.ups.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Max-Age:
+      - '600'
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Bkndtransid:
+      - '0000000009f5mPgVvV3Fd2'
+      Referrer-Policy:
+      - same-origin
+      - same-origin
+      Content-Type:
+      - application/json;charset=UTF-8
+      X-Request-Id:
+      - 4b16b921-82cc-4d62-9283-7994c2707022
+      Content-Length:
+      - '113'
+      Expires:
+      - Fri, 13 Sep 2024 14:55:44 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 13 Sep 2024 14:55:44 GMT
+      Connection:
+      - keep-alive
+      Ak-Grn-1:
+      - 0.66c83017.1726239343.80a989ce
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"XAVResponse":{"Response":{"ResponseStatus":{"Code":"1", "Description":"Success"}},
+        "NoCandidatesIndicator":""}}'
+  recorded_at: Fri, 13 Sep 2024 14:55:44 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/ups_json/city_state_lookup.json
+++ b/spec/fixtures/ups_json/city_state_lookup.json
@@ -1,0 +1,76 @@
+{
+  "XAVResponse": {
+    "Response": {
+      "ResponseStatus": {
+        "Code": "1",
+        "Description": "Success"
+      }
+    },
+    "AmbiguousAddressIndicator": "",
+    "Candidate": [
+      {
+        "AddressKeyFormat": {
+          "PoliticalDivision2": "NEW YORK",
+          "PoliticalDivision1": "NY",
+          "PostcodePrimaryLow": "10017",
+          "Region": "NEW YORK NY 10017",
+          "CountryCode": "US"
+        }
+      },
+      {
+        "AddressKeyFormat": {
+          "PoliticalDivision2": "GRAND CENTRAL",
+          "PoliticalDivision1": "NY",
+          "PostcodePrimaryLow": "10017",
+          "Region": "GRAND CENTRAL NY 10017",
+          "CountryCode": "US"
+        }
+      },
+      {
+        "AddressKeyFormat": {
+          "PoliticalDivision2": "NYC",
+          "PoliticalDivision1": "NY",
+          "PostcodePrimaryLow": "10017",
+          "Region": "NYC NY 10017",
+          "CountryCode": "US"
+        }
+      },
+      {
+        "AddressKeyFormat": {
+          "PoliticalDivision2": "MANHATTAN",
+          "PoliticalDivision1": "NY",
+          "PostcodePrimaryLow": "10017",
+          "Region": "MANHATTAN NY 10017",
+          "CountryCode": "US"
+        }
+      },
+      {
+        "AddressKeyFormat": {
+          "PoliticalDivision2": "NY",
+          "PoliticalDivision1": "NY",
+          "PostcodePrimaryLow": "10017",
+          "Region": "NY NY 10017",
+          "CountryCode": "US"
+        }
+      },
+      {
+        "AddressKeyFormat": {
+          "PoliticalDivision2": "NEW YORK CITY",
+          "PoliticalDivision1": "NY",
+          "PostcodePrimaryLow": "10017",
+          "Region": "NEW YORK CITY NY 10017",
+          "CountryCode": "US"
+        }
+      },
+      {
+        "AddressKeyFormat": {
+          "PoliticalDivision2": "NY CITY",
+          "PoliticalDivision1": "NY",
+          "PostcodePrimaryLow": "10017",
+          "Region": "NY CITY NY 10017",
+          "CountryCode": "US"
+        }
+      }
+    ]
+  }
+}

--- a/spec/friendly_shipping/services/ups_json/generate_city_state_lookup_payload_spec.rb
+++ b/spec/friendly_shipping/services/ups_json/generate_city_state_lookup_payload_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::UpsJson::GenerateCityStateLookupPayload do
+  subject(:call) { described_class.call(location:) }
+
+  let(:location) { FactoryBot.build(:physical_location, zip: "12345") }
+
+  it 'returns a hash with the required fields' do
+    xav_request = call[:XAVRequest]
+    expect(xav_request[:RegionalRequestIndicator]).to eq("1")
+    expect(xav_request[:AddressKeyFormat]).to be_a(Array)
+    expect(xav_request[:AddressKeyFormat].size).to eq(1)
+    expect(xav_request[:AddressKeyFormat].first[:PostcodePrimaryLow]).to eq("12345")
+    expect(xav_request[:AddressKeyFormat].first[:CountryCode]).to eq("US")
+  end
+end

--- a/spec/friendly_shipping/services/ups_json/parse_city_state_lookup_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_json/parse_city_state_lookup_response_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::UpsJson::ParseCityStateLookupResponse do
+  subject(:call) { described_class.call(request:, response:) }
+
+  let(:request) { FriendlyShipping::Request.new(url: "http://www.example.com", debug: true) }
+  let(:response) { double(body: response_body, headers: {}) }
+  let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "ups_json", "city_state_lookup.json")) }
+
+  it 'returns location with city and state' do
+    location = call.value!.data
+    expect(location).to be_a(Physical::Location)
+    expect(location.city).to eq("NEW YORK")
+    expect(location.region).to eq(location.country.subregions.coded("NY"))
+    expect(location.zip).to eq("10017")
+    expect(location.country).to eq(Carmen::Country.coded("US"))
+  end
+end


### PR DESCRIPTION
Given a zip code, this endpoint can be used to look up the city and state associated with that zip code.