### PR TITLE
Extract `AccessToken` parent class

### DIFF
--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -17,6 +17,7 @@ require "friendly_shipping/label"
 require "friendly_shipping/rate"
 require "friendly_shipping/api_result"
 require "friendly_shipping/api_failure"
+require "friendly_shipping/access_token"
 
 require 'friendly_shipping/services/rl'
 require "friendly_shipping/services/ship_engine"

--- a/lib/friendly_shipping/access_token.rb
+++ b/lib/friendly_shipping/access_token.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  # Represents an access token returned by a carrier.
+  class AccessToken
+    # @return [Integer] the token's expiration
+    attr_reader :expires_in
+
+    # @return [String] the raw token
+    attr_reader :raw_token
+
+    # @param expires_in [Integer] the token's expiration
+    def initialize(expires_in:, raw_token:)
+      @expires_in = expires_in
+      @raw_token = raw_token
+    end
+
+    # Decodes and returns the raw token (only applicable to JWT tokens).
+    # @return [Array<Hash>] the decoded token
+    def decoded_token
+      @_decoded_token = JWT.decode(raw_token, nil, false)
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/access_token.rb
+++ b/lib/friendly_shipping/services/tforce_freight/access_token.rb
@@ -7,35 +7,20 @@ module FriendlyShipping
     class TForceFreight
       # Represents an access token returned by TForce Freight. The access token can be
       # used to make API requests. Once it expires, a new token must be created.
-      class AccessToken
+      class AccessToken < FriendlyShipping::AccessToken
         # @return [String] the token's type
         attr_reader :token_type
-
-        # @return [Integer] the token's expiration
-        attr_reader :expires_in
 
         # @return [Integer] the token's extended expiration
         attr_reader :ext_expires_in
 
-        # @return [String] the raw JWT token
-        attr_reader :raw_token
-
         # @param token_type [String] the token's type (typically "Bearer")
-        # @param expires_in [Integer] the token's expiration
         # @param ext_expires_in [Integer] the token's extended expiration (only applicable during a service outage)
         # @see https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/675 Service Outage Resiliency Support
-        # @param raw_token [String] the raw JWT token
-        def initialize(token_type:, expires_in:, ext_expires_in:, raw_token:)
+        def initialize(token_type:, ext_expires_in:, **other_kwargs)
           @token_type = token_type
-          @expires_in = expires_in
           @ext_expires_in = ext_expires_in
-          @raw_token = raw_token
-        end
-
-        # Decodes and returns the raw JWT token.
-        # @return [Array<Hash>] the decoded token
-        def decoded_token
-          @_decoded_token = JWT.decode(raw_token, nil, false)
+          super(**other_kwargs)
         end
       end
     end

--- a/lib/friendly_shipping/services/ups_json/access_token.rb
+++ b/lib/friendly_shipping/services/ups_json/access_token.rb
@@ -5,23 +5,14 @@ module FriendlyShipping
     class UpsJson
       # Represents an access token returned by UPS. The access token can be used to make API requests.
       # Once it expires, a new token must be created.
-      class AccessToken
-        # @return [Integer] the token's expiration
-        attr_reader :expires_in
-
+      class AccessToken < FriendlyShipping::AccessToken
         # @return [Integer] the epoch time in ms when the token was issued
         attr_reader :issued_at
 
-        # @return [String] the raw JWT token
-        attr_reader :raw_token
-
-        # @param expires_in [Integer] the token's expiration
         # @param issued_at [Integer] the time the token was issued at
-        # @param raw_token [String] the raw JWT token
-        def initialize(expires_in:, issued_at:, raw_token:)
-          @expires_in = expires_in
+        def initialize(issued_at:, **other_kwargs)
           @issued_at = issued_at
-          @raw_token = raw_token
+          super(**other_kwargs)
         end
       end
     end

--- a/lib/friendly_shipping/services/usps_ship/access_token.rb
+++ b/lib/friendly_shipping/services/usps_ship/access_token.rb
@@ -7,29 +7,14 @@ module FriendlyShipping
     class USPSShip
       # Represents an access token returned by USPS Ship. The access token can be
       # used to make API requests. Once it expires, a new token must be created.
-      class AccessToken
+      class AccessToken < FriendlyShipping::AccessToken
         # @return [String] the token's type
         attr_reader :token_type
 
-        # @return [Integer] the token's expiration
-        attr_reader :expires_in
-
-        # @return [String] the raw JWT token
-        attr_reader :raw_token
-
         # @param token_type [String] the token's type (typically "Bearer")
-        # @param expires_in [Integer] the token's expiration
-        # @param raw_token [String] the raw JWT token
-        def initialize(token_type:, expires_in:, raw_token:)
+        def initialize(token_type:, **other_kwargs)
           @token_type = token_type
-          @expires_in = expires_in
-          @raw_token = raw_token
-        end
-
-        # Decodes and returns the raw JWT token.
-        # @return [Array<Hash>] the decoded token
-        def decoded_token
-          @_decoded_token = JWT.decode(raw_token, nil, false)
+          super(**other_kwargs)
         end
       end
     end

--- a/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
+++ b/spec/friendly_shipping/services/usps/choose_package_rate_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FriendlyShipping::Services::Usps::ChoosePackageRate do
   let(:xml) { File.read(File.join(gem_root, 'spec', 'fixtures', 'usps', 'usps_rates_api_response.xml')) }
   let(:rate_nodes) { Nokogiri::XML(xml).xpath('//Postage') }
   let(:rates) { rate_nodes.map { |node| FriendlyShipping::Services::Usps::ParsePackageRate.call(node, package, package_options) } }
-  let(:package_options) { FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(**properties.merge(package_id: package_id)) }
+  let(:package_options) { FriendlyShipping::Services::Usps::RateEstimatePackageOptions.new(package_id: package_id, **properties) }
   subject { described_class.call(shipping_method, rates, package_options) }
 
   it { is_expected.to be_a(FriendlyShipping::Rate) }

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -6,9 +6,8 @@ require 'friendly_shipping/services/usps/rate_estimate_package_options'
 RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
   subject(:options) do
     described_class.new(
-      **kwargs.merge(
-        package_id: package_id
-      )
+      package_id: package_id,
+      **kwargs
     )
   end
 

--- a/spec/support/shared_examples/overrideable_package_options_class.rb
+++ b/spec/support/shared_examples/overrideable_package_options_class.rb
@@ -9,7 +9,8 @@ RSpec.shared_examples "overrideable package options class" do
     context "when a custom class is passed" do
       let(:options) do
         described_class.new(
-          **required_attrs.merge(package_options_class: FriendlyShipping::PackageOptions)
+          package_options_class: FriendlyShipping::PackageOptions,
+          **required_attrs
         )
       end
 

--- a/spec/support/shared_examples/overrideable_structure_options_class.rb
+++ b/spec/support/shared_examples/overrideable_structure_options_class.rb
@@ -9,7 +9,8 @@ RSpec.shared_examples "overrideable structure options class" do
     context "when a custom class is passed" do
       let(:options) do
         described_class.new(
-          **required_attrs.merge(structure_options_class: FriendlyShipping::StructureOptions)
+          structure_options_class: FriendlyShipping::StructureOptions,
+          **required_attrs
         )
       end
 


### PR DESCRIPTION
This DRYs up the carrier-specific access token classes.