### PR TITLE
Return errors in ApiFailures for USPS timings, UPS json parsing

### DIFF
--- a/lib/friendly_shipping/api_error.rb
+++ b/lib/friendly_shipping/api_error.rb
@@ -6,11 +6,13 @@ module FriendlyShipping
     # @return [RestClient::Exception] the cause of the error
     attr_reader :cause
 
-    # @param cause [RestClient::Exception] the cause of the error
+    # @param cause [RestClient::Exception, nil] the cause of the error
     # @param message [String] optional descriptive message
     def initialize(cause, message = nil)
+      raise ArgumentError, "Must provide either a cause or a message" if cause.nil? && message.nil?
+
       @cause = cause
-      super(message || cause.message)
+      super(message || cause&.message)
     end
   end
 end

--- a/lib/friendly_shipping/services/ups_json/parse_json_response.rb
+++ b/lib/friendly_shipping/services/ups_json/parse_json_response.rb
@@ -6,6 +6,7 @@ module FriendlyShipping
       class ParseJsonResponse
         extend Dry::Monads::Result::Mixin
         SUCCESSFUL_RESPONSE_STATUS_CODE = '1'
+        UNEXPECTED_ROOT_KEY_STRING = 'Empty or unexpected root key'
 
         class << self
           def call(request:, response:, expected_root_key:)
@@ -15,23 +16,29 @@ module FriendlyShipping
             # UPS may return a 2xx status code on an unsuccessful request and include the error description in
             # the response headers, which we will consider a failure
             if api_error_message.present?
-              wrap_failure(api_error_message, request, response)
+              wrap_failure(api_error(api_error_message), request, response)
             elsif response_body.nil? || response_body.keys.first != expected_root_key
-              wrap_failure('Empty or unexpected root key', request, response)
+              wrap_failure(api_error(UNEXPECTED_ROOT_KEY_STRING), request, response)
             else
               Success(response_body)
             end
           rescue JSON::ParserError => e
             # when the response is not valid JSON(?!), the error description in the header is more descriptive
-            wrap_failure(api_error_message || e, request, response)
+            return wrap_failure(api_error(api_error_message), request, response) if api_error_message
+
+            wrap_failure(e, request, response)
           end
 
           private
 
-          def wrap_failure(failure, request, response)
+          def api_error(message)
+            FriendlyShipping::ApiError.new(nil, message)
+          end
+
+          def wrap_failure(error, request, response)
             Failure(
               FriendlyShipping::ApiFailure.new(
-                failure,
+                error,
                 original_request: request,
                 original_response: response
               )

--- a/lib/friendly_shipping/services/usps_ship/parse_timings_response.rb
+++ b/lib/friendly_shipping/services/usps_ship/parse_timings_response.rb
@@ -36,15 +36,13 @@ module FriendlyShipping
             end.compact
 
             if timings.empty?
-              failure("No timings were returned. Is the destination zip correct?", request, response)
+              failure(api_error("No timings were returned. Is the destination zip correct?"), request, response)
             else
               success(timings, request, response)
             end
           rescue JSON::ParserError => e
-            failure(e.message, request, response)
+            failure(e, request, response)
           end
-
-          private
 
           # @param timings [Array<Timing>]
           # @param request [Request]
@@ -60,18 +58,24 @@ module FriendlyShipping
             )
           end
 
-          # @param message [String]
+          # @param error [JSON::ParserError, FriendlyShipping::ApiError]
           # @param request [Request]
           # @param response [Response]
-          # @return [Failure<ApiFailure<String>>]
-          def failure(message, request, response)
+          # @return [Failure<ApiFailure>]
+          def failure(error, request, response)
             Failure(
               ApiFailure.new(
-                message,
+                error,
                 original_request: request,
                 original_response: response
               )
             )
+          end
+
+          private
+
+          def api_error(message)
+            FriendlyShipping::ApiError.new(nil, message)
           end
         end
       end

--- a/spec/friendly_shipping/api_error_spec.rb
+++ b/spec/friendly_shipping/api_error_spec.rb
@@ -19,4 +19,24 @@ RSpec.describe FriendlyShipping::ApiError do
       it { is_expected.to eq("oops") }
     end
   end
+
+  describe "#initialize" do
+    context "with no cause or message" do
+      it "raises an ArgumentError" do
+        expect { described_class.new(nil) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with cause but no message" do
+      subject { described_class.new(error).message }
+
+      it { is_expected.to eq("oops") }
+    end
+
+    context "with message but no cause" do
+      subject { described_class.new(nil, "yikes").message }
+
+      it { is_expected.to eq("yikes") }
+    end
+  end
 end

--- a/spec/friendly_shipping/services/ups_json/parse_json_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_json/parse_json_response_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe FriendlyShipping::Services::UpsJson::ParseJsonResponse do
       it "returns failure" do
         failure = call.failure
         expect(failure).to be_a(FriendlyShipping::ApiFailure)
-        expect(failure.data).to eq("Empty or unexpected root key")
+        expect(failure.data).to be_a(FriendlyShipping::ApiError)
+        expect(failure.data.message).to eq(described_class::UNEXPECTED_ROOT_KEY_STRING)
         expect(failure.original_request).to eq(request)
         expect(failure.original_response).to eq(response)
       end
@@ -40,7 +41,8 @@ RSpec.describe FriendlyShipping::Services::UpsJson::ParseJsonResponse do
       it "returns failure" do
         failure = call.failure
         expect(failure).to be_a(FriendlyShipping::ApiFailure)
-        expect(failure.data).to eq("Some error")
+        expect(failure.data).to be_a(FriendlyShipping::ApiError)
+        expect(failure.data.message).to eq("Some error")
         expect(failure.original_request).to eq(request)
         expect(failure.original_response).to eq(response)
       end
@@ -55,7 +57,8 @@ RSpec.describe FriendlyShipping::Services::UpsJson::ParseJsonResponse do
       it "returns failure with the errordescription" do
         failure = call.failure
         expect(failure).to be_a(FriendlyShipping::ApiFailure)
-        expect(failure.data).to eq("It almost worked")
+        expect(failure.data).to be_a(FriendlyShipping::ApiError)
+        expect(failure.data.message).to eq( "It almost worked")
         expect(failure.original_request).to eq(request)
         expect(failure.original_response).to eq(response)
       end
@@ -71,7 +74,8 @@ RSpec.describe FriendlyShipping::Services::UpsJson::ParseJsonResponse do
     it "returns failure" do
       failure = call.failure
       expect(failure).to be_a(FriendlyShipping::ApiFailure)
-      expect(failure.data).to eq("Some error")
+      expect(failure.data).to be_a(FriendlyShipping::ApiError)
+      expect(failure.data.message).to eq("Some error")
       expect(failure.original_request).to eq(request)
       expect(failure.original_response).to eq(response)
     end

--- a/spec/friendly_shipping/services/usps_ship/parse_timings_response_spec.rb
+++ b/spec/friendly_shipping/services/usps_ship/parse_timings_response_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe FriendlyShipping::Services::USPSShip::ParseTimingsResponse do
 
   # USPS returns a successful response (with a blank delivery estimate) even if the destination
   # zip code is invalid. We handle this response as a failure in the parser.
-  #
   context "with invalid destination zip code response" do
     let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "usps_ship", "timings", "invalid_dest_zip.json")) }
 
@@ -49,7 +48,8 @@ RSpec.describe FriendlyShipping::Services::USPSShip::ParseTimingsResponse do
     it "returns failure" do
       failure = call.failure
       expect(failure).to be_a(FriendlyShipping::ApiFailure)
-      expect(failure.data).to eq("No timings were returned. Is the destination zip correct?")
+      expect(failure.data).to be_a(FriendlyShipping::ApiError)
+      expect(failure.data.message).to eq("No timings were returned. Is the destination zip correct?")
       expect(failure.original_request).to eq(request)
       expect(failure.original_response).to eq(response)
     end
@@ -63,7 +63,8 @@ RSpec.describe FriendlyShipping::Services::USPSShip::ParseTimingsResponse do
     it "returns failure" do
       failure = call.failure
       expect(failure).to be_a(FriendlyShipping::ApiFailure)
-      expect(failure.data).to eq("unexpected token at 'malformed json'")
+      expect(failure.data).to be_a(JSON::ParserError)
+      expect(failure.data.message).to eq("unexpected token at 'malformed json'")
       expect(failure.original_request).to eq(request)
       expect(failure.original_response).to eq(response)
     end


### PR DESCRIPTION
This makes the error response a bit more uniform. Where CandleScience handles these failures, we expect ApiFailures to wrap an exception, but in several cases its just a string. This was resulting in some errors not being reported to our bug tracking service.