### PR TITLE
Use Zeitwerk to load FriendlyShipping

### DIFF
--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -2,33 +2,31 @@
 
 require "physical"
 require "money"
+require "dry/monads"
+require "restclient"
 
 # Explicitly configure the default rounding mode to avoid deprecation warnings
 Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
 
-require "friendly_shipping/version"
-require "friendly_shipping/inflections"
-require "friendly_shipping/request"
-require "friendly_shipping/response"
-require "friendly_shipping/carrier"
-require "friendly_shipping/shipping_method"
-require "friendly_shipping/structure_options"
-require "friendly_shipping/label"
-require "friendly_shipping/rate"
-require "friendly_shipping/api_result"
-require "friendly_shipping/api_failure"
-require "friendly_shipping/access_token"
+require "zeitwerk"
 
-require 'friendly_shipping/services/rl'
-require "friendly_shipping/services/ship_engine"
-require 'friendly_shipping/services/ship_engine_ltl'
-require "friendly_shipping/services/tforce_freight"
-require "friendly_shipping/services/ups"
-require "friendly_shipping/services/ups_freight"
-require "friendly_shipping/services/ups_json"
-require "friendly_shipping/services/usps"
-require "friendly_shipping/services/usps_international"
-require "friendly_shipping/services/usps_ship"
+loader = Zeitwerk::Loader.for_gem
+loader.inflector.inflect(
+  "rl" => "RL",
+  "parse_create_bol_response" => "ParseCreateBOLResponse",
+  "parse_print_bol_response" => "ParsePrintBOLResponse",
+  "serialize_create_bol_request" => "SerializeCreateBOLRequest",
+  "bol_structures_serializer" => "BOLStructuresSerializer",
+  "bol_packages_serializer" => "BOLPackagesSerializer",
+  "bol_options" => "BOLOptions",
+  "ship_engine_ltl" => "ShipEngineLTL",
+  "tforce_freight" => "TForceFreight",
+  "generate_create_bol_request_hash" => "GenerateCreateBOLRequestHash",
+  "parse_xml_response" => "ParseXMLResponse",
+  "usps_ship" => "USPSShip",
+  "shipping_methods" => "SHIPPING_METHODS"
+)
+loader.setup
 
 module FriendlyShipping
 end

--- a/lib/friendly_shipping/api_error_handler.rb
+++ b/lib/friendly_shipping/api_error_handler.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/api_error'
-
 module FriendlyShipping
   # Handles API errors by wrapping them in an API error class ({ApiError} by default) which
   # is then wrapped in an {ApiResult} (along with the original API request and response).

--- a/lib/friendly_shipping/http_client.rb
+++ b/lib/friendly_shipping/http_client.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-require 'rest-client'
-
-require 'friendly_shipping/api_failure'
-require 'friendly_shipping/api_error_handler'
-
 module FriendlyShipping
   # A façade for `RestClient` which constructs requests, wraps responses in `Dry::Monad`
   # results, and calls the API error handler with failures.

--- a/lib/friendly_shipping/label.rb
+++ b/lib/friendly_shipping/label.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/types'
-
 module FriendlyShipping
   # Base class for a shipping label returned by a carrier API.
   class Label

--- a/lib/friendly_shipping/services/rl.rb
+++ b/lib/friendly_shipping/services/rl.rb
@@ -1,23 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-require 'friendly_shipping/http_client'
-require 'friendly_shipping/services/rl/api_error'
-require 'friendly_shipping/services/rl/parse_create_bol_response'
-require 'friendly_shipping/services/rl/parse_invoice_response'
-require 'friendly_shipping/services/rl/parse_print_bol_response'
-require 'friendly_shipping/services/rl/parse_print_shipping_labels_response'
-require 'friendly_shipping/services/rl/parse_rate_quote_response'
-require 'friendly_shipping/services/rl/parse_transit_times_response'
-require 'friendly_shipping/services/rl/serialize_create_bol_request'
-require 'friendly_shipping/services/rl/serialize_location'
-require 'friendly_shipping/services/rl/serialize_rate_quote_request'
-require 'friendly_shipping/services/rl/serialize_transit_times_request'
-require 'friendly_shipping/services/rl/rate_quote_options'
-require 'friendly_shipping/services/rl/bol_options'
-require 'friendly_shipping/services/rl/structure_options'
-require 'friendly_shipping/services/rl/package_options'
-require 'friendly_shipping/services/rl/item_options'
+require "json"
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/rl/api_error.rb
+++ b/lib/friendly_shipping/services/rl/api_error.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/api_error'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/bol_options.rb
+++ b/lib/friendly_shipping/services/rl/bol_options.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/rl/shipment_options'
-require 'friendly_shipping/services/rl/bol_structures_serializer'
-require 'friendly_shipping/services/rl/bol_packages_serializer'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/item_options.rb
+++ b/lib/friendly_shipping/services/rl/item_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/item_options'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/package_options.rb
+++ b/lib/friendly_shipping/services/rl/package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/package_options'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/parse_create_bol_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_create_bol_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'friendly_shipping/services/rl/shipment_information'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/parse_invoice_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_invoice_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'friendly_shipping/services/rl/shipment_document'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/parse_print_bol_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_print_bol_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'friendly_shipping/services/rl/shipment_document'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/parse_print_shipping_labels_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_print_shipping_labels_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'friendly_shipping/services/rl/shipment_document'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/parse_rate_quote_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_rate_quote_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'friendly_shipping/services/rl/shipping_methods'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/parse_transit_times_response.rb
+++ b/lib/friendly_shipping/services/rl/parse_transit_times_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'friendly_shipping/services/rl/shipping_methods'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/rate_quote_options.rb
+++ b/lib/friendly_shipping/services/rl/rate_quote_options.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/rl/shipment_options'
-require 'friendly_shipping/services/rl/rate_quote_structures_serializer'
-require 'friendly_shipping/services/rl/rate_quote_packages_serializer'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/rl/shipment_options.rb
+++ b/lib/friendly_shipping/services/rl/shipment_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/shipment_options'
-
 module FriendlyShipping
   module Services
     class RL

--- a/lib/friendly_shipping/services/ship_engine.rb
+++ b/lib/friendly_shipping/services/ship_engine.rb
@@ -1,25 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-require 'friendly_shipping/http_client'
-require 'friendly_shipping/services/ship_engine/api_error'
-require 'friendly_shipping/services/ship_engine/parse_carrier_response'
-require 'friendly_shipping/services/ship_engine/serialize_address_validation_request'
-require 'friendly_shipping/services/ship_engine/serialize_label_shipment'
-require 'friendly_shipping/services/ship_engine/serialize_rate_estimate_request'
-require 'friendly_shipping/services/ship_engine/serialize_rates_request'
-require 'friendly_shipping/services/ship_engine/serialize_address_residential_indicator'
-require 'friendly_shipping/services/ship_engine/parse_address_validation_response'
-require 'friendly_shipping/services/ship_engine/parse_label_response'
-require 'friendly_shipping/services/ship_engine/parse_void_response'
-require 'friendly_shipping/services/ship_engine/parse_rate_estimates_response'
-require 'friendly_shipping/services/ship_engine/parse_rates_response'
-require 'friendly_shipping/services/ship_engine/rate_estimates_options'
-require 'friendly_shipping/services/ship_engine/rates_item_options'
-require 'friendly_shipping/services/ship_engine/rates_package_options'
-require 'friendly_shipping/services/ship_engine/rates_options'
-require 'friendly_shipping/services/ship_engine/label_options'
-require 'friendly_shipping/services/ship_engine/label_package_options'
+require "json"
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/ship_engine/api_error.rb
+++ b/lib/friendly_shipping/services/ship_engine/api_error.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/api_error'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/label_item_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_item_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/item_options'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/label_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_options.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/shipment_options'
-require 'friendly_shipping/services/ship_engine/label_customs_options'
-require 'friendly_shipping/services/ship_engine/customs_items_serializer'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/label_package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/label_package_options.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/package_options'
-require 'friendly_shipping/services/ship_engine/label_item_options'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/parse_address_validation_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_address_validation_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/parse_carrier_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_carrier_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/parse_label_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_label_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/parse_rate_estimates_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_rate_estimates_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/parse_rates_response.rb
+++ b/lib/friendly_shipping/services/ship_engine/parse_rates_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rate_estimates_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/shipment_options'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/rates_item_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_item_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/item_options'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/rates_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/shipment_options'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine/rates_package_options.rb
+++ b/lib/friendly_shipping/services/ship_engine/rates_package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_freight/rates_item_options'
-
 module FriendlyShipping
   module Services
     class ShipEngine

--- a/lib/friendly_shipping/services/ship_engine_ltl.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-require 'friendly_shipping/http_client'
-require 'friendly_shipping/services/ship_engine_ltl/api_error'
-require 'friendly_shipping/services/ship_engine_ltl/parse_carrier_response'
-require 'friendly_shipping/services/ship_engine_ltl/parse_quote_response'
-require 'friendly_shipping/services/ship_engine_ltl/serialize_packages'
-require 'friendly_shipping/services/ship_engine_ltl/serialize_quote_request'
-require 'friendly_shipping/services/ship_engine_ltl/serialize_structures'
-require 'friendly_shipping/services/ship_engine_ltl/shipment_options'
-require 'friendly_shipping/services/ship_engine_ltl/quote_options'
-require 'friendly_shipping/services/ship_engine_ltl/structure_options'
-require 'friendly_shipping/services/ship_engine_ltl/package_options'
-require 'friendly_shipping/services/ship_engine_ltl/item_options'
+require "json"
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/ship_engine_ltl/parse_carrier_response.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/parse_carrier_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module FriendlyShipping
   module Services
     class ShipEngineLTL

--- a/lib/friendly_shipping/services/ship_engine_ltl/parse_quote_response.rb
+++ b/lib/friendly_shipping/services/ship_engine_ltl/parse_quote_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module FriendlyShipping
   module Services
     class ShipEngineLTL

--- a/lib/friendly_shipping/services/tforce_freight.rb
+++ b/lib/friendly_shipping/services/tforce_freight.rb
@@ -1,32 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-require 'friendly_shipping/http_client'
-require 'friendly_shipping/services/tforce_freight/access_token'
-require 'friendly_shipping/services/tforce_freight/shipping_methods'
-require 'friendly_shipping/services/tforce_freight/shipment_document'
-require 'friendly_shipping/services/tforce_freight/shipment_information'
-require 'friendly_shipping/services/tforce_freight/shipment_options'
-require 'friendly_shipping/services/tforce_freight/rates_options'
-require 'friendly_shipping/services/tforce_freight/structure_options'
-require 'friendly_shipping/services/tforce_freight/package_options'
-require 'friendly_shipping/services/tforce_freight/rates_package_options'
-require 'friendly_shipping/services/tforce_freight/item_options'
-require 'friendly_shipping/services/tforce_freight/rates_item_options'
-require 'friendly_shipping/services/tforce_freight/pickup_options'
-require 'friendly_shipping/services/tforce_freight/bol_options'
-require 'friendly_shipping/services/tforce_freight/document_options'
-require 'friendly_shipping/services/tforce_freight/parse_rates_response'
-require 'friendly_shipping/services/tforce_freight/parse_pickup_response'
-require 'friendly_shipping/services/tforce_freight/parse_create_bol_response'
-require 'friendly_shipping/services/tforce_freight/parse_shipment_document'
-require 'friendly_shipping/services/tforce_freight/generate_rates_request_hash'
-require 'friendly_shipping/services/tforce_freight/generate_pickup_request_hash'
-require 'friendly_shipping/services/tforce_freight/generate_create_bol_request_hash'
-require 'friendly_shipping/services/tforce_freight/generate_handling_units_hash'
-require 'friendly_shipping/services/tforce_freight/generate_reference_hash'
-require 'friendly_shipping/services/tforce_freight/generate_document_options_hash'
-require 'friendly_shipping/services/tforce_freight/api_error'
+require "json"
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/tforce_freight/api_error.rb
+++ b/lib/friendly_shipping/services/tforce_freight/api_error.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/api_error'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_create_bol_request_hash.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/tforce_freight/generate_location_hash'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/generate_pickup_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_pickup_request_hash.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/tforce_freight/generate_location_hash'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/generate_rates_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_rates_request_hash.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/tforce_freight/generate_location_hash'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/package_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/tforce_freight/rates_item_options'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_create_bol_response.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/rate'
-require 'friendly_shipping/api_result'
-require 'friendly_shipping/services/tforce_freight/shipping_methods'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/parse_rates_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_rates_response.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/rate'
-require 'friendly_shipping/api_result'
-require 'friendly_shipping/services/tforce_freight/shipping_methods'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/parse_shipment_document.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_shipment_document.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_freight/shipment_document'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/rates_item_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_item_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/tforce_freight/item_options'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/rates_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_options.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/tforce_freight/rates_package_options'
-require 'friendly_shipping/services/tforce_freight/generate_commodity_information'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/rates_package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/tforce_freight/package_options'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/tforce_freight/shipment_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/shipment_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/shipment_options'
-
 module FriendlyShipping
   module Services
     class TForceFreight

--- a/lib/friendly_shipping/services/ups.rb
+++ b/lib/friendly_shipping/services/ups.rb
@@ -1,28 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-require 'friendly_shipping/http_client'
-require 'friendly_shipping/services/ups/serialize_access_request'
-require 'friendly_shipping/services/ups/serialize_city_state_lookup_request'
-require 'friendly_shipping/services/ups/serialize_address_validation_request'
-require 'friendly_shipping/services/ups/serialize_rating_service_selection_request'
-require 'friendly_shipping/services/ups/serialize_shipment_accept_request'
-require 'friendly_shipping/services/ups/serialize_shipment_confirm_request'
-require 'friendly_shipping/services/ups/serialize_time_in_transit_request'
-require 'friendly_shipping/services/ups/serialize_void_shipment_request'
-require 'friendly_shipping/services/ups/parse_address_validation_response'
-require 'friendly_shipping/services/ups/parse_address_classification_response'
-require 'friendly_shipping/services/ups/parse_city_state_lookup_response'
-require 'friendly_shipping/services/ups/parse_rate_response'
-require 'friendly_shipping/services/ups/parse_shipment_confirm_response'
-require 'friendly_shipping/services/ups/parse_shipment_accept_response'
-require 'friendly_shipping/services/ups/parse_time_in_transit_response'
-require 'friendly_shipping/services/ups/parse_void_shipment_response'
-require 'friendly_shipping/services/ups/shipping_methods'
-require 'friendly_shipping/services/ups/label'
-require 'friendly_shipping/services/ups/label_options'
-require 'friendly_shipping/services/ups/rate_estimate_options'
-require 'friendly_shipping/services/ups/timing_options'
+require 'nokogiri'
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/ups/label_item_options.rb
+++ b/lib/friendly_shipping/services/ups/label_item_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/item_options'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups/label_options.rb
+++ b/lib/friendly_shipping/services/ups/label_options.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups/label_package_options'
-require 'friendly_shipping/services/ups/label_billing_options'
-
 module FriendlyShipping
   module Services
     # Option container for a generating UPS labels for a shipment

--- a/lib/friendly_shipping/services/ups/label_package_options.rb
+++ b/lib/friendly_shipping/services/ups/label_package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups/label_item_options'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_rate_response.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups/parse_xml_response'
-require 'friendly_shipping/services/ups/parse_money_element'
-require 'friendly_shipping/services/ups/parse_modifier_element'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups/parse_shipment_accept_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_shipment_accept_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-require 'friendly_shipping/services/ups/parse_money_element'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups/parse_shipment_confirm_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_shipment_confirm_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups/parse_void_shipment_response.rb
+++ b/lib/friendly_shipping/services/ups/parse_void_shipment_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/ups/rate_estimate_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups/rate_estimate_package_options'
-
 module FriendlyShipping
   module Services
     # Option container for rating a shipment via UPS

--- a/lib/friendly_shipping/services/ups/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/ups/rate_estimate_package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups/label_item_options'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups/serialize_access_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_access_request.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_rating_service_selection_request.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-require 'friendly_shipping/services/ups/serialize_address_snippet'
-require 'friendly_shipping/services/ups/serialize_package_node'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
+++ b/lib/friendly_shipping/services/ups/serialize_shipment_confirm_request.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups/serialize_shipment_address_snippet'
-require 'friendly_shipping/services/ups/serialize_package_node'
-
 module FriendlyShipping
   module Services
     class Ups

--- a/lib/friendly_shipping/services/ups_freight.rb
+++ b/lib/friendly_shipping/services/ups_freight.rb
@@ -1,26 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-require 'friendly_shipping/http_client'
-require 'friendly_shipping/services/ups_freight/shipping_methods'
-require 'friendly_shipping/services/ups_freight/rates_options'
-require 'friendly_shipping/services/ups_freight/label_options'
-require 'friendly_shipping/services/ups_freight/rates_structure_options'
-require 'friendly_shipping/services/ups_freight/rates_package_options'
-require 'friendly_shipping/services/ups_freight/rates_item_options'
-require 'friendly_shipping/services/ups_freight/label_structure_options'
-require 'friendly_shipping/services/ups_freight/label_package_options'
-require 'friendly_shipping/services/ups_freight/label_item_options'
-require 'friendly_shipping/services/ups_freight/label_document_options'
-require 'friendly_shipping/services/ups_freight/label_email_options'
-require 'friendly_shipping/services/ups_freight/label_pickup_options'
-require 'friendly_shipping/services/ups_freight/label_delivery_options'
-require 'friendly_shipping/services/ups_freight/pickup_request_options'
-require 'friendly_shipping/services/ups_freight/parse_freight_label_response'
-require 'friendly_shipping/services/ups_freight/parse_freight_rate_response'
-require 'friendly_shipping/services/ups_freight/generate_freight_rate_request_hash'
-require 'friendly_shipping/services/ups_freight/generate_freight_ship_request_hash'
-require 'friendly_shipping/services/ups_freight/api_error'
+require "json"
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/ups_freight/api_error.rb
+++ b/lib/friendly_shipping/services/ups_freight/api_error.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/api_error'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash.rb
+++ b/lib/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_freight/generate_location_hash'
-require 'friendly_shipping/services/ups_freight/generate_pickup_request_hash'
-require 'friendly_shipping/services/ups_freight/generate_handling_units_hash'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_freight/generate_freight_ship_request_hash.rb
+++ b/lib/friendly_shipping/services/ups_freight/generate_freight_ship_request_hash.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_freight/generate_location_hash'
-require 'friendly_shipping/services/ups_freight/generate_reference_hash'
-require 'friendly_shipping/services/ups_freight/generate_document_options_hash'
-require 'friendly_shipping/services/ups_freight/generate_email_options_hash'
-require 'friendly_shipping/services/ups_freight/generate_pickup_options_hash'
-require 'friendly_shipping/services/ups_freight/generate_delivery_options_hash'
-require 'friendly_shipping/services/ups_freight/generate_handling_units_hash'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_freight/parse_freight_label_response.rb
+++ b/lib/friendly_shipping/services/ups_freight/parse_freight_label_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_freight/parse_shipment_document'
-require 'friendly_shipping/services/ups_freight/shipment_information'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_freight/parse_freight_rate_response.rb
+++ b/lib/friendly_shipping/services/ups_freight/parse_freight_rate_response.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/rate'
-require 'friendly_shipping/api_result'
-require 'friendly_shipping/services/ups_freight/shipping_methods'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_freight/parse_shipment_document.rb
+++ b/lib/friendly_shipping/services/ups_freight/parse_shipment_document.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_freight/shipment_document'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_freight/rates_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_options.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_freight/shipment_options'
-require 'friendly_shipping/services/ups_freight/rates_package_options'
-require 'friendly_shipping/services/ups_freight/generate_commodity_information'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_freight/rates_package_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_freight/rates_item_options'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_freight/rates_structure_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/rates_structure_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_freight/rates_package_options'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_freight/shipment_options.rb
+++ b/lib/friendly_shipping/services/ups_freight/shipment_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/shipment_options'
-
 module FriendlyShipping
   module Services
     class UpsFreight

--- a/lib/friendly_shipping/services/ups_json.rb
+++ b/lib/friendly_shipping/services/ups_json.rb
@@ -1,30 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/monads'
-require 'friendly_shipping/http_client'
-require 'friendly_shipping/services/ups_json/access_token'
-require 'friendly_shipping/services/ups_json/api_error'
-require 'friendly_shipping/services/ups_json/generate_address_classification_payload'
-require 'friendly_shipping/services/ups_json/generate_city_state_lookup_payload'
-require 'friendly_shipping/services/ups_json/generate_labels_payload'
-require 'friendly_shipping/services/ups_json/generate_rates_payload'
-require 'friendly_shipping/services/ups_json/generate_timings_payload'
-require 'friendly_shipping/services/ups_json/label'
-require 'friendly_shipping/services/ups_json/label_options'
-require 'friendly_shipping/services/ups_json/parse_address_classification_response'
-require 'friendly_shipping/services/ups_json/parse_city_state_lookup_response'
-require 'friendly_shipping/services/ups_json/parse_json_response'
-require 'friendly_shipping/services/ups_json/parse_labels_response'
-require 'friendly_shipping/services/ups_json/parse_money_hash'
-require 'friendly_shipping/services/ups_json/parse_rate_modifier_hash'
-require 'friendly_shipping/services/ups_json/parse_rates_response'
-require 'friendly_shipping/services/ups_json/parse_timings_response'
-require 'friendly_shipping/services/ups_json/parse_void_response'
-require 'friendly_shipping/services/ups_json/rates_item_options'
-require 'friendly_shipping/services/ups_json/rates_package_options'
-require 'friendly_shipping/services/ups_json/rates_options'
-require 'friendly_shipping/services/ups_json/shipping_methods'
-require 'friendly_shipping/services/ups_json/timings_options'
+require "json"
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/ups_json/api_error.rb
+++ b/lib/friendly_shipping/services/ups_json/api_error.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/api_error'
-
 module FriendlyShipping
   module Services
     class UpsJson

--- a/lib/friendly_shipping/services/ups_json/generate_labels_payload.rb
+++ b/lib/friendly_shipping/services/ups_json/generate_labels_payload.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_json/generate_address_hash'
-require 'friendly_shipping/services/ups_json/generate_package_hash'
-
 module FriendlyShipping
   module Services
     class UpsJson

--- a/lib/friendly_shipping/services/ups_json/generate_rates_payload.rb
+++ b/lib/friendly_shipping/services/ups_json/generate_rates_payload.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_json/generate_address_hash'
-require 'friendly_shipping/services/ups_json/generate_package_hash'
-
 module FriendlyShipping
   module Services
     class UpsJson

--- a/lib/friendly_shipping/services/ups_json/label_item_options.rb
+++ b/lib/friendly_shipping/services/ups_json/label_item_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/item_options'
-
 module FriendlyShipping
   module Services
     class UpsJson

--- a/lib/friendly_shipping/services/ups_json/label_options.rb
+++ b/lib/friendly_shipping/services/ups_json/label_options.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_json/label_package_options'
-require 'friendly_shipping/services/ups_json/label_billing_options'
-
 module FriendlyShipping
   module Services
     # Option container for a generating UPS labels for a shipment

--- a/lib/friendly_shipping/services/ups_json/label_package_options.rb
+++ b/lib/friendly_shipping/services/ups_json/label_package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_json/label_item_options'
-
 module FriendlyShipping
   module Services
     class UpsJson

--- a/lib/friendly_shipping/services/ups_json/rates_item_options.rb
+++ b/lib/friendly_shipping/services/ups_json/rates_item_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/item_options'
-
 module FriendlyShipping
   module Services
     class UpsJson

--- a/lib/friendly_shipping/services/ups_json/rates_options.rb
+++ b/lib/friendly_shipping/services/ups_json/rates_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups_json/rates_package_options'
-
 module FriendlyShipping
   module Services
     # Option container for rating a shipment via UPS

--- a/lib/friendly_shipping/services/usps.rb
+++ b/lib/friendly_shipping/services/usps.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/http_client'
-require 'friendly_shipping/services/usps/shipping_methods'
-require 'friendly_shipping/services/usps/serialize_address_validation_request'
-require 'friendly_shipping/services/usps/serialize_city_state_lookup_request'
-require 'friendly_shipping/services/usps/serialize_rate_request'
-require 'friendly_shipping/services/usps/serialize_time_in_transit_request'
-require 'friendly_shipping/services/usps/parse_address_validation_response'
-require 'friendly_shipping/services/usps/parse_city_state_lookup_response'
-require 'friendly_shipping/services/usps/parse_rate_response'
-require 'friendly_shipping/services/usps/parse_time_in_transit_response'
-require 'friendly_shipping/services/usps/timing_options'
-require 'friendly_shipping/services/usps/rate_estimate_options'
+require 'nokogiri'
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/usps/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_rate_response.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/usps/parse_xml_response'
-require 'friendly_shipping/services/usps/parse_package_rate'
-require 'friendly_shipping/services/usps/choose_package_rate'
-
 module FriendlyShipping
   module Services
     class Usps

--- a/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
+++ b/lib/friendly_shipping/services/usps/parse_time_in_transit_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/usps/parse_xml_response'
-require 'friendly_shipping/timing'
-
 module FriendlyShipping
   module Services
     class Usps

--- a/lib/friendly_shipping/services/usps/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/usps/rate_estimate_package_options'
-
 module FriendlyShipping
   module Services
     # Option container for rating a shipment via USPS

--- a/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps/rate_estimate_package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups/rate_estimate_package_options'
-
 module FriendlyShipping
   module Services
     # Options for one package when rating

--- a/lib/friendly_shipping/services/usps/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps/serialize_rate_request.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/usps/machinable_package'
-
 module FriendlyShipping
   module Services
     class Usps

--- a/lib/friendly_shipping/services/usps_international.rb
+++ b/lib/friendly_shipping/services/usps_international.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/http_client'
-require 'friendly_shipping/services/usps_international/shipping_methods'
-require 'friendly_shipping/services/usps_international/serialize_rate_request'
-require 'friendly_shipping/services/usps_international/parse_rate_response'
-require 'friendly_shipping/services/usps_international/rate_estimate_options'
+require 'nokogiri'
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/usps_international/parse_rate_response.rb
+++ b/lib/friendly_shipping/services/usps_international/parse_rate_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/usps/parse_xml_response'
-require 'friendly_shipping/services/usps_international/parse_package_rate'
-
 module FriendlyShipping
   module Services
     class UspsInternational

--- a/lib/friendly_shipping/services/usps_international/rate_estimate_options.rb
+++ b/lib/friendly_shipping/services/usps_international/rate_estimate_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/usps_international/rate_estimate_package_options'
-
 module FriendlyShipping
   module Services
     # Option container for rating a shipment via USPS

--- a/lib/friendly_shipping/services/usps_international/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps_international/rate_estimate_package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups/rate_estimate_package_options'
-
 module FriendlyShipping
   module Services
     # Options for one package when rating

--- a/lib/friendly_shipping/services/usps_international/serialize_rate_request.rb
+++ b/lib/friendly_shipping/services/usps_international/serialize_rate_request.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/usps/machinable_package'
-
 module FriendlyShipping
   module Services
     class UspsInternational

--- a/lib/friendly_shipping/services/usps_ship.rb
+++ b/lib/friendly_shipping/services/usps_ship.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/http_client'
-
-require 'friendly_shipping/services/usps_ship/access_token'
-require 'friendly_shipping/services/usps_ship/api_error'
-require 'friendly_shipping/services/usps_ship/shipping_methods'
-
-require 'friendly_shipping/services/usps_ship/rate_estimate_options'
-require 'friendly_shipping/services/usps_ship/rate_estimate_package_options'
-require 'friendly_shipping/services/usps_ship/timing_options'
-
-require 'friendly_shipping/services/usps_ship/serialize_rate_estimates_request'
-require 'friendly_shipping/services/usps_ship/machinable_package'
-
-require 'friendly_shipping/services/usps_ship/parse_rate_estimates_response'
-require 'friendly_shipping/services/usps_ship/parse_timings_response'
+require 'nokogiri'
 
 module FriendlyShipping
   module Services

--- a/lib/friendly_shipping/services/usps_ship/api_error.rb
+++ b/lib/friendly_shipping/services/usps_ship/api_error.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/api_error'
-
 module FriendlyShipping
   module Services
     class USPSShip

--- a/lib/friendly_shipping/services/usps_ship/parse_timings_response.rb
+++ b/lib/friendly_shipping/services/usps_ship/parse_timings_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/timing'
-
 module FriendlyShipping
   module Services
     class USPSShip

--- a/lib/friendly_shipping/services/usps_ship/rate_estimate_package_options.rb
+++ b/lib/friendly_shipping/services/usps_ship/rate_estimate_package_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/ups/rate_estimate_package_options'
-
 module FriendlyShipping
   module Services
     class USPSShip

--- a/lib/friendly_shipping/services/usps_ship/serialize_rate_estimates_request.rb
+++ b/lib/friendly_shipping/services/usps_ship/serialize_rate_estimates_request.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'friendly_shipping/services/usps/machinable_package'
-
 module FriendlyShipping
   module Services
     class USPSShip

--- a/spec/friendly_shipping/http_client_spec.rb
+++ b/spec/friendly_shipping/http_client_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/http_client'
 
 RSpec.describe FriendlyShipping::HttpClient do
   let(:response) { double }

--- a/spec/friendly_shipping/item_options_spec.rb
+++ b/spec/friendly_shipping/item_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/item_options'
 
 RSpec.describe FriendlyShipping::ItemOptions do
   subject { described_class.new(item_id: 'my_item_id') }

--- a/spec/friendly_shipping/package_options_spec.rb
+++ b/spec/friendly_shipping/package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/package_options'
 
 RSpec.describe FriendlyShipping::PackageOptions do
   subject { described_class.new(package_id: 'my_package_id') }

--- a/spec/friendly_shipping/services/rl/package_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/rl/package_options'
 
 RSpec.describe FriendlyShipping::Services::RL::PackageOptions do
   subject(:options) { described_class.new(package_id: "package") }

--- a/spec/friendly_shipping/services/rl/shipment_document_spec.rb
+++ b/spec/friendly_shipping/services/rl/shipment_document_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/rl/shipment_document'
 
 RSpec.describe FriendlyShipping::Services::RL::ShipmentDocument do
   subject(:shipment_document) do

--- a/spec/friendly_shipping/services/rl/shipment_information_spec.rb
+++ b/spec/friendly_shipping/services/rl/shipment_information_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/rl/shipment_information'
 
 RSpec.describe FriendlyShipping::Services::RL::ShipmentInformation do
   subject do

--- a/spec/friendly_shipping/services/ship_engine/label_customs_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_customs_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ship_engine/label_customs_options'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::LabelCustomsOptions do
   subject(:options) { described_class.new }

--- a/spec/friendly_shipping/services/ship_engine/label_item_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_item_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ship_engine/label_item_options'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::LabelItemOptions do
   subject(:options) { described_class.new(item_id: "123") }

--- a/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_options_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ship_engine/label_options'
-require 'friendly_shipping/services/ship_engine/label_customs_options'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::LabelOptions do
   subject(:options) { described_class.new(shipping_method: double) }

--- a/spec/friendly_shipping/services/ship_engine/label_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/label_package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ship_engine/label_package_options'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::LabelPackageOptions do
   subject(:options) { described_class.new(package_id: "package") }

--- a/spec/friendly_shipping/services/ship_engine/rates_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ship_engine/rates_package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ship_engine/label_package_options'
 
 RSpec.describe FriendlyShipping::Services::ShipEngine::RatesPackageOptions do
   subject(:options) { described_class.new(package_id: "package") }

--- a/spec/friendly_shipping/services/tforce_freight/generate_location_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_location_hash_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/tforce_freight/generate_location_hash'
 
 RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateLocationHash do
   describe ".call" do

--- a/spec/friendly_shipping/services/tforce_freight/generate_rates_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_rates_request_hash_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/tforce_freight/generate_rates_request_hash'
 
 RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateRatesRequestHash do
   describe ".call" do

--- a/spec/friendly_shipping/services/tforce_freight/parse_rates_response_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/parse_rates_response_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/tforce_freight/parse_rates_response'
 
 RSpec.describe FriendlyShipping::Services::TForceFreight::ParseRatesResponse do
   describe ".call" do

--- a/spec/friendly_shipping/services/tforce_freight_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/tforce_freight'
 
 RSpec.describe FriendlyShipping::Services::TForceFreight do
   subject(:service) { described_class.new(access_token: access_token, test: false) }

--- a/spec/friendly_shipping/services/ups/label_billing_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_billing_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/label_billing_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::LabelBillingOptions do
   subject { described_class.new }

--- a/spec/friendly_shipping/services/ups/label_item_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_item_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/label_item_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::LabelItemOptions do
   subject { described_class.new(item_id: nil) }

--- a/spec/friendly_shipping/services/ups/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/label_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::LabelOptions do
   subject(:options) { described_class.new(shipping_method: double, shipper_number: double) }

--- a/spec/friendly_shipping/services/ups/label_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/label_package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/label_package_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::LabelPackageOptions do
   subject(:options) { described_class.new(package_id: 'package') }

--- a/spec/friendly_shipping/services/ups/parse_shipment_accept_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_shipment_accept_response_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/parse_shipment_accept_response'
 
 RSpec.describe FriendlyShipping::Services::Ups::ParseShipmentAcceptResponse do
   include Dry::Monads[:result]

--- a/spec/friendly_shipping/services/ups/parse_shipment_confirm_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_shipment_confirm_response_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/parse_shipment_confirm_response'
 
 RSpec.describe FriendlyShipping::Services::Ups::ParseShipmentConfirmResponse do
   include Dry::Monads[:result]

--- a/spec/friendly_shipping/services/ups/parse_time_in_transit_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_time_in_transit_response_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/parse_time_in_transit_response'
 
 RSpec.describe FriendlyShipping::Services::Ups::ParseTimeInTransitResponse do
   include Dry::Monads[:result]

--- a/spec/friendly_shipping/services/ups/parse_void_shipment_response_spec.rb
+++ b/spec/friendly_shipping/services/ups/parse_void_shipment_response_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/parse_void_shipment_response'
 
 RSpec.describe FriendlyShipping::Services::Ups::ParseVoidShipmentResponse do
   include Dry::Monads[:result]

--- a/spec/friendly_shipping/services/ups/rate_estimate_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/rate_estimate_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/rate_estimate_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::RateEstimateOptions do
   subject(:options) { described_class.new(shipper_number: 'SECRET') }

--- a/spec/friendly_shipping/services/ups/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/rate_estimate_package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/rate_estimate_package_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::RateEstimatePackageOptions do
   subject(:options) { described_class.new(package_id: 'my_package_id') }

--- a/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_rating_service_selection_request_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/rate_estimate_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::SerializeRatingServiceSelectionRequest do
   let(:origin) { FactoryBot.build(:physical_location) }

--- a/spec/friendly_shipping/services/ups/serialize_shipment_accept_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_accept_request_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/serialize_shipment_accept_request'
 
 RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentAcceptRequest do
   let(:options) do

--- a/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_shipment_confirm_request_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/serialize_shipment_confirm_request'
 
 RSpec.describe FriendlyShipping::Services::Ups::SerializeShipmentConfirmRequest do
   let(:origin) do

--- a/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_time_in_transit_request_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/serialize_time_in_transit_request'
-require 'friendly_shipping/services/ups/timing_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::SerializeTimeInTransitRequest do
   let(:origin) do

--- a/spec/friendly_shipping/services/ups/serialize_void_shipment_request_spec.rb
+++ b/spec/friendly_shipping/services/ups/serialize_void_shipment_request_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/serialize_void_shipment_request'
 
 RSpec.describe FriendlyShipping::Services::Ups::SerializeVoidShipmentRequest do
   let(:label) { FriendlyShipping::Label.new(tracking_number: '1ZTRACKING') }

--- a/spec/friendly_shipping/services/ups/timings_options_spec.rb
+++ b/spec/friendly_shipping/services/ups/timings_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups/timing_options'
 
 RSpec.describe FriendlyShipping::Services::Ups::TimingOptions do
   subject { described_class.new }

--- a/spec/friendly_shipping/services/ups_freight/generate_delivery_options_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_delivery_options_hash_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/generate_delivery_options_hash'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateDeliveryOptionsHash do
   subject { described_class.call(delivery_options: delivery_options) }

--- a/spec/friendly_shipping/services/ups_freight/generate_document_options_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_document_options_hash_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/label_document_options'
-require 'friendly_shipping/services/ups_freight/generate_document_options_hash'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateDocumentOptionsHash do
   let(:document_options) { FriendlyShipping::Services::UpsFreight::LabelDocumentOptions.new }

--- a/spec/friendly_shipping/services/ups_freight/generate_email_options_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_email_options_hash_spec.rb
@@ -3,8 +3,6 @@
 # frozen_string_literal true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/label_email_options'
-require 'friendly_shipping/services/ups_freight/generate_email_options_hash'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateEmailOptionsHash do
   let(:email_options) do

--- a/spec/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_freight_rate_request_hash_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/generate_freight_rate_request_hash'
-require 'friendly_shipping/services/ups_freight/rates_options'
-require 'friendly_shipping/services/ups_freight/pickup_request_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateFreightRateRequestHash do
   subject(:full_request) { JSON.parse(described_class.call(shipment: shipment, options: options).to_json) }

--- a/spec/friendly_shipping/services/ups_freight/generate_freight_ship_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_freight_ship_request_hash_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/generate_freight_ship_request_hash'
-require 'friendly_shipping/services/ups_freight/label_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateFreightShipRequestHash do
   subject(:full_request) { JSON.parse(described_class.call(shipment: shipment, options: options).to_json) }

--- a/spec/friendly_shipping/services/ups_freight/generate_location_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_location_hash_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/generate_location_hash'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateLocationHash do
   let(:location) do

--- a/spec/friendly_shipping/services/ups_freight/generate_pickup_options_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_pickup_options_hash_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/generate_pickup_options_hash'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::GeneratePickupOptionsHash do
   subject { described_class.call(pickup_options: pickup_options) }

--- a/spec/friendly_shipping/services/ups_freight/generate_pickup_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_pickup_request_hash_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/generate_pickup_request_hash'
-require 'friendly_shipping/services/ups_freight/pickup_request_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::GeneratePickupRequestHash do
   subject { described_class.call(pickup_request_options: pickup_request_options) }

--- a/spec/friendly_shipping/services/ups_freight/generate_reference_hash_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/generate_reference_hash_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/generate_reference_hash'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::GenerateReferenceHash do
   let(:reference_numbers) do

--- a/spec/friendly_shipping/services/ups_freight/label_delivery_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/label_delivery_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/label_delivery_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::LabelDeliveryOptions do
   subject { described_class.new }

--- a/spec/friendly_shipping/services/ups_freight/label_document_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/label_document_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/label_document_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::LabelDocumentOptions do
   subject { described_class.new }

--- a/spec/friendly_shipping/services/ups_freight/label_email_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/label_email_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/label_email_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::LabelEmailOptions do
   subject do

--- a/spec/friendly_shipping/services/ups_freight/label_item_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/label_item_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/label_item_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::LabelItemOptions do
   subject { described_class.new(item_id: nil) }

--- a/spec/friendly_shipping/services/ups_freight/label_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/label_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/label_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::LabelOptions do
   subject(:label_options) do

--- a/spec/friendly_shipping/services/ups_freight/label_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/label_package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/label_package_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::LabelPackageOptions do
   subject { described_class.new(package_id: nil) }

--- a/spec/friendly_shipping/services/ups_freight/label_pickup_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/label_pickup_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/label_pickup_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::LabelPickupOptions do
   subject { described_class.new }

--- a/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/parse_freight_label_response_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/parse_freight_label_response'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::ParseFreightLabelResponse do
   let(:response_body) { File.read(File.join(gem_root, 'spec', 'fixtures', 'ups_freight', 'labels', 'success.json')) }

--- a/spec/friendly_shipping/services/ups_freight/parse_freight_rate_response_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/parse_freight_rate_response_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/parse_freight_rate_response'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::ParseFreightRateResponse do
   let(:response_body) { File.read(File.join(gem_root, 'spec', 'fixtures', 'ups_freight', 'rate_estimates', 'success.json')) }

--- a/spec/friendly_shipping/services/ups_freight/pickup_request_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/pickup_request_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/pickup_request_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::PickupRequestOptions do
   subject do

--- a/spec/friendly_shipping/services/ups_freight/rates_item_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/rates_item_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/rates_item_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::RatesItemOptions do
   subject(:rates_item_options) { described_class.new(item_id: nil) }

--- a/spec/friendly_shipping/services/ups_freight/rates_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/rates_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/rates_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::RatesOptions do
   subject(:options) do

--- a/spec/friendly_shipping/services/ups_freight/rates_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/rates_package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/rates_package_options'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::RatesPackageOptions do
   subject(:options) { described_class.new(package_id: "package") }

--- a/spec/friendly_shipping/services/ups_freight/shipment_document_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/shipment_document_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/shipment_document'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::ShipmentDocument do
   let(:binary) { double }

--- a/spec/friendly_shipping/services/ups_freight/shipment_information_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight/shipment_information_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight/shipment_information'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight::ShipmentInformation do
   let(:docs) { double }

--- a/spec/friendly_shipping/services/ups_freight_spec.rb
+++ b/spec/friendly_shipping/services/ups_freight_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_freight'
 
 RSpec.describe FriendlyShipping::Services::UpsFreight do
   let(:service) { described_class.new(login: ENV.fetch('UPS_LOGIN', nil), password: ENV.fetch('UPS_PASSWORD', nil), key: ENV.fetch('UPS_KEY', nil)) }

--- a/spec/friendly_shipping/services/ups_json/rates_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_json/rates_options_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_json/rates_options'
-require 'friendly_shipping/services/ups_json/rates_item_options'
 
 RSpec.describe FriendlyShipping::Services::UpsJson::RatesOptions do
   subject(:options) { described_class.new(shipper_number: 'SECRET') }

--- a/spec/friendly_shipping/services/ups_json/rates_package_options_spec.rb
+++ b/spec/friendly_shipping/services/ups_json/rates_package_options_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_json/rates_item_options'
-require 'friendly_shipping/services/ups_json/rates_package_options'
 
 RSpec.describe FriendlyShipping::Services::UpsJson::RatesPackageOptions do
   subject(:options) { described_class.new(package_id: 'my_package_id') }

--- a/spec/friendly_shipping/services/ups_json_spec.rb
+++ b/spec/friendly_shipping/services/ups_json_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/ups_json'
 
 RSpec.describe FriendlyShipping::Services::UpsJson do
   subject(:service) { described_class.new(access_token: ENV.fetch('ACCESS_TOKEN', nil)) }

--- a/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
+++ b/spec/friendly_shipping/services/usps/parse_time_in_transit_response_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps/parse_time_in_transit_response'
 
 RSpec.describe FriendlyShipping::Services::Usps::ParseTimeInTransitResponse do
   let(:response_body) { File.read(File.join(gem_root, 'spec', 'fixtures', 'usps', 'time_in_transit_response.xml')) }

--- a/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimate_package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps/rate_estimate_package_options'
 
 RSpec.describe FriendlyShipping::Services::Usps::RateEstimatePackageOptions do
   subject(:options) do

--- a/spec/friendly_shipping/services/usps/rate_estimates_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/rate_estimates_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps/rate_estimate_options'
 
 RSpec.describe FriendlyShipping::Services::Usps::RateEstimateOptions do
   let(:options) { described_class.new }

--- a/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_rate_request_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps/rate_estimate_options'
 
 RSpec.describe FriendlyShipping::Services::Usps::SerializeRateRequest do
   let(:dimensions) { [10, 21.321539, 24].map { |e| Measured::Length(e, :cm) } }

--- a/spec/friendly_shipping/services/usps/serialize_time_in_transit_request_spec.rb
+++ b/spec/friendly_shipping/services/usps/serialize_time_in_transit_request_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps/serialize_time_in_transit_request'
-require 'friendly_shipping/services/usps/timing_options'
 
 RSpec.describe FriendlyShipping::Services::Usps::SerializeTimeInTransitRequest do
   let(:pickup_date) { Time.parse('2017-01-01 00:15:00 UTC') }

--- a/spec/friendly_shipping/services/usps/timings_options_spec.rb
+++ b/spec/friendly_shipping/services/usps/timings_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps/timing_options'
 
 RSpec.describe FriendlyShipping::Services::Usps::TimingOptions do
   subject { described_class.new }

--- a/spec/friendly_shipping/services/usps_international/rate_estimate_package_options_spec.rb
+++ b/spec/friendly_shipping/services/usps_international/rate_estimate_package_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps_international/rate_estimate_package_options'
 
 RSpec.describe FriendlyShipping::Services::UspsInternational::RateEstimatePackageOptions do
   subject { described_class.new(package_id: package_id) }

--- a/spec/friendly_shipping/services/usps_international/rate_estimates_options_spec.rb
+++ b/spec/friendly_shipping/services/usps_international/rate_estimates_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps/rate_estimate_options'
 
 RSpec.describe FriendlyShipping::Services::UspsInternational::RateEstimateOptions do
   let(:options) { described_class.new }

--- a/spec/friendly_shipping/services/usps_international_spec.rb
+++ b/spec/friendly_shipping/services/usps_international_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps/timing_options'
 
 RSpec.describe FriendlyShipping::Services::UspsInternational do
   subject(:service) { described_class.new(login: ENV.fetch('USPS_LOGIN', nil)) }

--- a/spec/friendly_shipping/services/usps_spec.rb
+++ b/spec/friendly_shipping/services/usps_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/services/usps/timing_options'
 
 RSpec.describe FriendlyShipping::Services::Usps do
   subject(:service) { described_class.new(login: ENV.fetch('USPS_LOGIN', nil)) }

--- a/spec/friendly_shipping/shipment_options_spec.rb
+++ b/spec/friendly_shipping/shipment_options_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/shipment_options'
 
 RSpec.describe FriendlyShipping::ShipmentOptions do
   describe 'Package options' do

--- a/spec/friendly_shipping/timing_spec.rb
+++ b/spec/friendly_shipping/timing_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'friendly_shipping/timing'
 
 RSpec.describe FriendlyShipping::Timing do
   subject do


### PR DESCRIPTION
Currently, FriendlyShipping is a pretty slow gem to load, because all services and their shipping methods are loaded on app startup, regardless if they're being used or not. This sets up Zeitwerk to autoload constants in the project, allowing us to drop all require statements to our own project in the codebase, and speeding up require'ing this gem.