### PR TITLE
Add UPS surcharge code 495 to money hash parser

### DIFF
--- a/lib/friendly_shipping/services/ups_json/parse_money_hash.rb
+++ b/lib/friendly_shipping/services/ups_json/parse_money_hash.rb
@@ -105,6 +105,7 @@ module FriendlyShipping
           "470" => "COMMITTED DELIVERY WINDOW",
           "480" => "SECURITY SURCHARGE",
           "492" => "CUSTOMER TRANSACTION FEE",
+          "495" => "EXTENDED AREA SURCHARGE",
           "500" => "SHIPMENT COD",
           "510" => "LIFT GATE FOR PICKUP",
           "511" => "LIFT GATE FOR DELIVERY",


### PR DESCRIPTION
This code represents the Extended Area Surcharge.