### PR TITLE
Parse SCAC from Reconex `GetLoadInfo` response

### DIFF
--- a/lib/friendly_shipping/services/reconex/load_info.rb
+++ b/lib/friendly_shipping/services/reconex/load_info.rb
@@ -14,6 +14,9 @@ module FriendlyShipping
         # @return [String, nil] the carrier booked (SCAC or name)
         attr_reader :carrier_booked
 
+        # @return [String, nil] the SCAC code
+        attr_reader :scac
+
         # @return [String, nil] the PRO number
         attr_reader :pro_number
 
@@ -96,6 +99,7 @@ module FriendlyShipping
           load_id: nil,
           ship_date: nil,
           carrier_booked: nil,
+          scac: nil,
           pro_number: nil,
           confirmation_number: nil,
           tracking_link: nil,
@@ -126,6 +130,7 @@ module FriendlyShipping
           @load_id = load_id
           @ship_date = ship_date
           @carrier_booked = carrier_booked
+          @scac = scac
           @pro_number = pro_number
           @confirmation_number = confirmation_number
           @tracking_link = tracking_link

--- a/lib/friendly_shipping/services/reconex/parse_load_info_response.rb
+++ b/lib/friendly_shipping/services/reconex/parse_load_info_response.rb
@@ -57,6 +57,7 @@ module FriendlyShipping
               load_id: detail["loadID"],
               ship_date: detail["shipDate"],
               carrier_booked: detail["carrierBooked"],
+              scac: detail["scac"],
               pro_number: detail["proNumber"],
               confirmation_number: detail["confirmationNumber"],
               tracking_link: detail["trackingLink"],

--- a/spec/fixtures/reconex/load_info/success.json
+++ b/spec/fixtures/reconex/load_info/success.json
@@ -4,6 +4,7 @@
       "loadID": 2763982,
       "shipDate": "2021-09-03T00:00:00",
       "carrierBooked": "SAIA",
+      "scac": "SAIA",
       "proNumber": "10237787450",
       "confirmationNumber": "41567552",
       "trackingLink": "http://www.saia.com/Tracing/AjaxProstatusByPro.aspx?nh=N&Pro=10237787450",

--- a/spec/friendly_shipping/services/reconex/parse_load_info_response_spec.rb
+++ b/spec/friendly_shipping/services/reconex/parse_load_info_response_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe FriendlyShipping::Services::Reconex::ParseLoadInfoResponse do
         expect(load_info.carrier_booked).to eq("SAIA")
       end
 
+      it "has the correct scac" do
+        expect(load_info.scac).to eq("SAIA")
+      end
+
       it "has the correct pro_number" do
         expect(load_info.pro_number).to eq("10237787450")
       end


### PR DESCRIPTION
Adds a `scac` attribute to `LoadInfo` and parses it from the `getLoadInfo` API response alongside the existing `carrier_booked` field. The fixture and spec are updated accordingly.