### PR TITLE
Reconex: omit falsy action attributes

### DIFF
--- a/lib/friendly_shipping/services/reconex/serialize_create_load_request.rb
+++ b/lib/friendly_shipping/services/reconex/serialize_create_load_request.rb
@@ -29,10 +29,10 @@ module FriendlyShipping
           def serialize_action(options)
             {
               accountId: options.account_id,
-              rate: options.rate,
-              book: options.scac,
-              proNumber: options.pro_number_requested,
-              dispatch: options.dispatch,
+              rate: options.rate.presence,
+              book: options.scac.presence,
+              proNumber: options.pro_number_requested.presence,
+              dispatch: options.dispatch.presence,
               errorEmailNotification: options.error_email
             }
           end

--- a/spec/friendly_shipping/services/reconex/serialize_create_load_request_spec.rb
+++ b/spec/friendly_shipping/services/reconex/serialize_create_load_request_spec.rb
@@ -141,6 +141,22 @@ RSpec.describe FriendlyShipping::Services::Reconex::SerializeCreateLoadRequest d
     it { is_expected.to include(proNumber: true) }
     it { is_expected.to include(dispatch: true) }
     it { is_expected.to include(errorEmailNotification: "errors@widgets.com") }
+
+    context "when rate, proNumber, and dispatch are false" do
+      let(:options) do
+        FriendlyShipping::Services::Reconex::LoadOptions.new(
+          account_id: 1140,
+          scac: "UPGF",
+          origin_dock_type: "BusinessWithDock",
+          structure_options: structure_options
+        )
+      end
+
+      it { is_expected.not_to have_key(:rate) }
+      it { is_expected.not_to have_key(:proNumber) }
+      it { is_expected.not_to have_key(:dispatch) }
+      it { is_expected.to include(book: "UPGF") }
+    end
   end
 
   describe "loadDetails" do

--- a/spec/friendly_shipping/services/reconex/serialize_update_load_request_spec.rb
+++ b/spec/friendly_shipping/services/reconex/serialize_update_load_request_spec.rb
@@ -159,5 +159,9 @@ RSpec.describe FriendlyShipping::Services::Reconex::SerializeUpdateLoadRequest d
     it "omits book from action" do
       expect(call[:action]).not_to have_key(:book)
     end
+
+    it "omits rate from action" do
+      expect(call[:action]).not_to have_key(:rate)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Uses `.presence` on `rate`, `book`, `proNumber`, and `dispatch` in `serialize_action` so that `nil` and `false` values become `nil` and are stripped by `deep_compact`
- Prevents Reconex from interpreting a re-sent `book` with SCAC as a duplicate booking request, which was triggering error emails
- Adds test coverage for the omission behavior in both create and update serializers

## Test plan

- [x] Existing specs pass (84 examples, 0 failures)
- [x] Verify create load requests omit `rate`, `proNumber`, `dispatch` when not explicitly set
- [x] Verify update load requests with SCAC omitted no longer trigger duplicate booking errors