### PR TITLE
Support HandlingUnits in R+L create BOL request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- R+L: Add `BOLHandlingUnitsSerializer` and `handling_units_serializer` option on `BOLOptions`. When set, the create-BOL request sends `HandlingUnits` (with each structure's packages nested as `Items`) instead of the top-level `Items` array. `RL::StructureOptions` now accepts a `handling_unit:` symbol mapping to R+L unit type codes (PLT, SKD, BOX, TOTE, etc., default `:pallet`).
+- R+L: Deprecate `structures_serializer` and the top-level `Items` output in favor of `handling_units_serializer`. The default will flip in a future release.
+
 ## [0.10.4] - 2025-08-14
 - Upgrade `physical` dependency to `~> 0.6`
 

--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -18,6 +18,7 @@ loader.inflector.inflect(
   "serialize_create_bol_request" => "SerializeCreateBOLRequest",
   "bol_structures_serializer" => "BOLStructuresSerializer",
   "bol_packages_serializer" => "BOLPackagesSerializer",
+  "bol_handling_units_serializer" => "BOLHandlingUnitsSerializer",
   "bol_options" => "BOLOptions",
   "ship_engine_ltl" => "ShipEngineLTL",
   "tforce_freight" => "TForceFreight",

--- a/lib/friendly_shipping/services/rl/bol_handling_units_serializer.rb
+++ b/lib/friendly_shipping/services/rl/bol_handling_units_serializer.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class RL
+      # Serializes handling units for R+L BOL API requests. Each {Physical::Structure}
+      # in the shipment becomes one HandlingUnit with its container dimensions and
+      # the packages it contains serialized as nested Items.
+      class BOLHandlingUnitsSerializer
+        # @param structures [Array<Physical::Structure>] the structures to serialize
+        # @param options [BOLOptions] options for the serialization
+        # @return [Array<Hash>] the serialized handling units
+        def self.call(structures:, options:)
+          structures.map do |structure|
+            structure_options = options.options_for_structure(structure)
+            {
+              UnitType: structure_options.handling_unit_code,
+              Dimensions: dimensions(structure),
+              Items: items(structure, structure_options)
+            }.compact
+          end
+        end
+
+        # @param structure [Physical::Structure]
+        # @return [Array<Hash>, nil] dimensions array or nil if any dimension is zero/infinite
+        def self.dimensions(structure)
+          values = structure.dimensions.map(&:value)
+          return if values.any? { |v| v.zero? || v.infinite? }
+
+          [{
+            Count: 1,
+            Length: structure.length.convert_to(:inches).value.to_f.round(2).to_s,
+            Width: structure.width.convert_to(:inches).value.to_f.round(2).to_s,
+            Height: structure.height.convert_to(:inches).value.to_f.round(2).to_s
+          }]
+        end
+        private_class_method :dimensions
+
+        # @param structure [Physical::Structure]
+        # @param structure_options [StructureOptions]
+        # @return [Array<Hash>]
+        def self.items(structure, structure_options)
+          structure.packages.map do |package|
+            package_options = structure_options.options_for_package(package)
+            {
+              IsHazmat: false,
+              Pieces: 1,
+              PackageType: "BOX",
+              NMFCItemNumber: package_options.nmfc_primary_code,
+              NMFCSubNumber: package_options.nmfc_sub_code,
+              Class: package_options.freight_class,
+              Weight: package.weight.convert_to(:pounds).value.ceil,
+              Description: package.description.presence || "Commodities"
+            }.compact
+          end
+        end
+        private_class_method :items
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/rl/bol_options.rb
+++ b/lib/friendly_shipping/services/rl/bol_options.rb
@@ -26,11 +26,18 @@ module FriendlyShipping
         # @return [Boolean] whether to generate universal PRO number
         attr_reader :generate_universal_pro
 
-        # @return [Callable] the structures serializer
+        # @return [Callable]
+        # @deprecated Use {#handling_units_serializer} instead. Sending top-level
+        #   `Items` will be removed in a future release in favor of `HandlingUnits`.
         attr_reader :structures_serializer
 
+        # @return [Callable, nil] the handling units serializer. When set, the
+        #   serialized request sends `HandlingUnits` in place of the top-level `Items`.
+        #   This will become the default in a future release.
+        attr_reader :handling_units_serializer
+
         # @return [Callable]
-        # @deprecated Use {#structures_serializer} instead.
+        # @deprecated Use {#handling_units_serializer} instead.
         attr_reader :packages_serializer
 
         # @param pickup_time_window [Range]
@@ -42,8 +49,14 @@ module FriendlyShipping
         # @param generate_universal_pro [Boolean]
         # @param structures_serializer [Callable] a callable that takes structures
         #   and an options object to create an Array of item hashes per the R+L Carriers docs
+        #   (DEPRECATED: use `handling_units_serializer` instead)
+        # @param handling_units_serializer [Callable, nil] a callable that takes structures
+        #   and an options object to create an Array of HandlingUnit hashes per the R+L Carriers docs.
+        #   When provided, the request sends `HandlingUnits` instead of the top-level `Items` array.
+        #   This will become the default in a future release.
         # @param packages_serializer [Callable] a callable that takes packages
-        #   and an options object to create an Array of item hashes per the R+L Carriers docs (DEPRECATED: use `structures_serializer` instead)
+        #   and an options object to create an Array of item hashes per the R+L Carriers docs
+        #   (DEPRECATED: use `handling_units_serializer` instead)
         # @param kwargs [Hash]
         # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this shipment
         # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
@@ -55,6 +68,7 @@ module FriendlyShipping
           reference_numbers: {},
           additional_service_codes: [],
           structures_serializer: BOLStructuresSerializer,
+          handling_units_serializer: nil,
           packages_serializer: BOLPackagesSerializer,
           generate_universal_pro: false,
           **kwargs
@@ -66,6 +80,7 @@ module FriendlyShipping
           @reference_numbers = reference_numbers
           @additional_service_codes = additional_service_codes
           @structures_serializer = structures_serializer
+          @handling_units_serializer = handling_units_serializer
           @packages_serializer = packages_serializer
           @generate_universal_pro = generate_universal_pro
           validate_additional_service_codes!

--- a/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
+++ b/lib/friendly_shipping/services/rl/serialize_create_bol_request.rb
@@ -17,6 +17,7 @@ module FriendlyShipping
                 Consignee: SerializeLocation.call(shipment.destination),
                 BillTo: SerializeLocation.call(shipment.origin),
                 Items: serialize_items(shipment, options),
+                HandlingUnits: serialize_handling_units(shipment, options),
                 DeclaredValue: serialize_declared_value(options.declared_value),
                 SpecialInstructions: options.special_instructions,
                 ReferenceNumbers: serialize_reference_numbers(options.reference_numbers),
@@ -31,14 +32,28 @@ module FriendlyShipping
 
           # @param shipment [Physical::Shipment] the shipment with items to serialize
           # @param options [BOLOptions] options for the items to be serialized
-          # @return [Hash]
+          # @return [Array<Hash>, nil] the serialized items, or nil when sending handling units instead
           def serialize_items(shipment, options)
             if options.packages_serializer
-              warn "[DEPRECATION] `packages_serializer` is deprecated.  Please use `structures_serializer` instead."
+              warn "[DEPRECATION] `packages_serializer` is deprecated.  Please use `handling_units_serializer` instead."
               options.packages_serializer.call(packages: shipment.packages, options: options)
+            elsif options.handling_units_serializer
+              nil
             else
+              warn "[DEPRECATION] Sending top-level `Items` via `structures_serializer` is deprecated. " \
+                   "Pass `handling_units_serializer: BOLHandlingUnitsSerializer` to send `HandlingUnits` instead. " \
+                   "This will become the default in a future release."
               options.structures_serializer.call(structures: shipment.structures, options: options)
             end
+          end
+
+          # @param shipment [Physical::Shipment] the shipment with handling units to serialize
+          # @param options [BOLOptions] options for the handling units to be serialized
+          # @return [Array<Hash>, nil] the serialized handling units, or nil when the option is not configured
+          def serialize_handling_units(shipment, options)
+            return unless options.handling_units_serializer
+
+            options.handling_units_serializer.call(structures: shipment.structures, options: options)
           end
 
           # @param declared_value [Numeric] the declared value to serialize

--- a/lib/friendly_shipping/services/rl/structure_options.rb
+++ b/lib/friendly_shipping/services/rl/structure_options.rb
@@ -4,7 +4,53 @@ module FriendlyShipping
   module Services
     class RL
       class StructureOptions < FriendlyShipping::StructureOptions
-        def initialize(**kwargs)
+        # Maps friendly names to R+L handling unit types.
+        HANDLING_UNIT_TYPES = {
+          skid: "SKD",
+          box: "BOX",
+          bag: "BAG",
+          bar: "BAR",
+          bin: "BIN",
+          bundle: "BNDL",
+          unit: "UNIT",
+          basket: "BSKT",
+          bulk: "BULK",
+          carboy: "CARBOY",
+          coil: "COIL",
+          crate: "CRT",
+          carton: "CTN",
+          cylinder: "CYL",
+          drum: "DRM",
+          gaylord: "GAY",
+          ibc: "IBC",
+          jerrycan: "JER",
+          loose: "LSE",
+          multi_bag: "MLBG",
+          non_standard: "NSTD",
+          pail: "PAIL",
+          piggyback: "PIG",
+          pallet: "PLT",
+          rack: "RACK",
+          reel: "REEL",
+          roll: "ROLL",
+          stack: "STK",
+          truckload: "TL",
+          tank: "TANK",
+          tote: "TOTE",
+          cpt: "CPT",
+          dac: "DAC"
+        }.freeze
+
+        # @return [String] the R+L handling unit code (e.g., "PLT", "SKD")
+        attr_reader :handling_unit_code
+
+        # @param handling_unit [Symbol] how this shipment is divided (see {HANDLING_UNIT_TYPES})
+        # @param kwargs [Hash]
+        # @option kwargs [Object] :structure_id unique identifier for this set of options
+        # @option kwargs [Array<PackageOptions>] :package_options the options for packages in this structure
+        # @option kwargs [Class] :package_options_class the class to use for package options when none are provided
+        def initialize(handling_unit: :pallet, **kwargs)
+          @handling_unit_code = HANDLING_UNIT_TYPES.fetch(handling_unit)
           super(**kwargs.reverse_merge(package_options_class: PackageOptions))
         end
       end

--- a/spec/friendly_shipping/services/rl/bol_handling_units_serializer_spec.rb
+++ b/spec/friendly_shipping/services/rl/bol_handling_units_serializer_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::RL::BOLHandlingUnitsSerializer do
+  subject do
+    described_class.call(
+      structures: [pallet_1, pallet_2],
+      options: options
+    )
+  end
+
+  let(:pickup_time_window) do
+    Time.parse("2023-08-01 09:00:00 UTC")..Time.parse("2023-08-01 17:00:00 UTC")
+  end
+
+  let(:options) do
+    FriendlyShipping::Services::RL::BOLOptions.new(
+      pickup_time_window: pickup_time_window,
+      structure_options: [
+        FriendlyShipping::Services::RL::StructureOptions.new(
+          structure_id: "pallet 1",
+          handling_unit: :pallet,
+          package_options: [
+            FriendlyShipping::Services::RL::PackageOptions.new(
+              package_id: "package 1",
+              nmfc_primary_code: "87700",
+              nmfc_sub_code: "07",
+              freight_class: "92.5"
+            )
+          ]
+        ),
+        FriendlyShipping::Services::RL::StructureOptions.new(
+          structure_id: "pallet 2",
+          handling_unit: :skid,
+          package_options: [
+            FriendlyShipping::Services::RL::PackageOptions.new(
+              package_id: "package 2",
+              nmfc_primary_code: "87700",
+              nmfc_sub_code: "07",
+              freight_class: "92.5"
+            )
+          ]
+        )
+      ]
+    )
+  end
+
+  let(:pallet_1) do
+    FactoryBot.build(
+      :physical_structure,
+      id: "pallet 1",
+      container: FactoryBot.build(
+        :physical_pallet,
+        dimensions: [
+          Measured::Length(48, :in),
+          Measured::Length(40, :in),
+          Measured::Length(60, :in)
+        ]
+      ),
+      packages: [package_1]
+    )
+  end
+
+  let(:pallet_2) do
+    FactoryBot.build(
+      :physical_structure,
+      id: "pallet 2",
+      container: FactoryBot.build(
+        :physical_pallet,
+        dimensions: [
+          Measured::Length(48, :in),
+          Measured::Length(40, :in),
+          Measured::Length(48, :in)
+        ]
+      ),
+      packages: [package_2]
+    )
+  end
+
+  let(:package_1) do
+    FactoryBot.build(
+      :physical_package,
+      id: "package 1",
+      description: "Tumblers",
+      items: [
+        Physical::Item.new(
+          weight: Measured::Weight(10.53, :lb)
+        )
+      ]
+    )
+  end
+
+  let(:package_2) do
+    FactoryBot.build(
+      :physical_package,
+      id: "package 2",
+      description: "Wicks",
+      items: [
+        Physical::Item.new(
+          weight: Measured::Weight(1.06, :lb)
+        )
+      ]
+    )
+  end
+
+  it "serializes one handling unit per structure with nested Items" do
+    is_expected.to eq(
+      [
+        {
+          UnitType: "PLT",
+          Dimensions: [{
+            Count: 1,
+            Length: "48.0",
+            Width: "40.0",
+            Height: "60.0"
+          }],
+          Items: [{
+            IsHazmat: false,
+            Pieces: 1,
+            PackageType: "BOX",
+            NMFCItemNumber: "87700",
+            NMFCSubNumber: "07",
+            Class: "92.5",
+            Weight: 11,
+            Description: "Tumblers"
+          }]
+        },
+        {
+          UnitType: "SKD",
+          Dimensions: [{
+            Count: 1,
+            Length: "48.0",
+            Width: "40.0",
+            Height: "48.0"
+          }],
+          Items: [{
+            IsHazmat: false,
+            Pieces: 1,
+            PackageType: "BOX",
+            NMFCItemNumber: "87700",
+            NMFCSubNumber: "07",
+            Class: "92.5",
+            Weight: 2,
+            Description: "Wicks"
+          }]
+        }
+      ]
+    )
+  end
+
+  context "when a structure has zero dimensions" do
+    let(:pallet_1) do
+      FactoryBot.build(
+        :physical_structure,
+        id: "pallet 1",
+        container: FactoryBot.build(
+          :physical_pallet,
+          dimensions: [
+            Measured::Length(0, :in),
+            Measured::Length(0, :in),
+            Measured::Length(0, :in)
+          ]
+        ),
+        packages: [package_1]
+      )
+    end
+
+    it "omits the Dimensions key for that handling unit" do
+      expect(subject.first).not_to have_key(:Dimensions)
+      expect(subject.first[:UnitType]).to eq("PLT")
+    end
+  end
+end

--- a/spec/friendly_shipping/services/rl/bol_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/bol_options_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe FriendlyShipping::Services::RL::BOLOptions do
     :additional_service_codes,
     :generate_universal_pro,
     :packages_serializer,
-    :structures_serializer
+    :structures_serializer,
+    :handling_units_serializer
   ].each do |attr|
     it { is_expected.to respond_to(attr) }
   end
@@ -63,6 +64,23 @@ RSpec.describe FriendlyShipping::Services::RL::BOLOptions do
     subject { options.packages_serializer }
 
     it { is_expected.to eq(FriendlyShipping::Services::RL::BOLPackagesSerializer) }
+  end
+
+  describe "#handling_units_serializer" do
+    subject { options.handling_units_serializer }
+
+    it { is_expected.to be_nil }
+
+    context "when set" do
+      let(:options) do
+        described_class.new(
+          pickup_time_window: 1.hour.ago..1.hour.from_now,
+          handling_units_serializer: FriendlyShipping::Services::RL::BOLHandlingUnitsSerializer
+        )
+      end
+
+      it { is_expected.to eq(FriendlyShipping::Services::RL::BOLHandlingUnitsSerializer) }
+    end
   end
 
   describe "validate additional service codes" do

--- a/spec/friendly_shipping/services/rl/serialize_create_bol_request_spec.rb
+++ b/spec/friendly_shipping/services/rl/serialize_create_bol_request_spec.rb
@@ -215,6 +215,53 @@ RSpec.describe FriendlyShipping::Services::RL::SerializeCreateBOLRequest do
     it { is_expected.to_not have_key(:PickupRequest) }
   end
 
+  describe "with handling_units_serializer" do
+    let(:options) do
+      FriendlyShipping::Services::RL::BOLOptions.new(
+        pickup_time_window: pickup_time_window,
+        pickup_instructions: "Pickup instructions",
+        reference_numbers: { shipper_number: "A4234592" },
+        structure_options: [
+          FriendlyShipping::Services::RL::StructureOptions.new(
+            structure_id: "pallet 1",
+            handling_unit: :pallet,
+            package_options: [
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 1",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07",
+                freight_class: "92.5"
+              )
+            ]
+          ),
+          FriendlyShipping::Services::RL::StructureOptions.new(
+            structure_id: "structure 2",
+            handling_unit: :skid,
+            package_options: [
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 2",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07",
+                freight_class: "92.5"
+              )
+            ]
+          )
+        ],
+        packages_serializer: nil,
+        handling_units_serializer: FriendlyShipping::Services::RL::BOLHandlingUnitsSerializer
+      )
+    end
+
+    let(:serialized_handling_units) do
+      options.handling_units_serializer.call(structures: shipment.structures, options: options)
+    end
+
+    it "sends HandlingUnits in place of Items" do
+      expect(subject[:BillOfLading]).to include(HandlingUnits: serialized_handling_units)
+      expect(subject[:BillOfLading]).not_to have_key(:Items)
+    end
+  end
+
   describe "deprecated packages behavior" do
     # TODO: Remove when packages_serializer is removed
 

--- a/spec/friendly_shipping/services/rl/structure_options_spec.rb
+++ b/spec/friendly_shipping/services/rl/structure_options_spec.rb
@@ -9,4 +9,30 @@ RSpec.describe FriendlyShipping::Services::RL::StructureOptions do
     let(:default_class) { FriendlyShipping::Services::RL::PackageOptions }
     let(:required_attrs) { { structure_id: "structure" } }
   end
+
+  describe "#handling_unit_code" do
+    subject(:handling_unit_code) { options.handling_unit_code }
+
+    it { is_expected.to eq("PLT") }
+
+    context "with handling_unit: :skid" do
+      let(:options) { described_class.new(structure_id: "structure", handling_unit: :skid) }
+
+      it { is_expected.to eq("SKD") }
+    end
+
+    context "with handling_unit: :tote" do
+      let(:options) { described_class.new(structure_id: "structure", handling_unit: :tote) }
+
+      it { is_expected.to eq("TOTE") }
+    end
+
+    context "with an invalid handling unit" do
+      it "raises KeyError" do
+        expect do
+          described_class.new(structure_id: "structure", handling_unit: :bogus)
+        end.to raise_error(KeyError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Adds opt-in `handling_units_serializer` option to `RL::BOLOptions`. When configured, `SerializeCreateBOLRequest` emits a top-level `HandlingUnits` array (one entry per `Physical::Structure`) with nested `Items` in place of the top-level `Items` array, matching the R+L API schema.
- Adds `RL::BOLHandlingUnitsSerializer` which builds each handling unit with `UnitType`, `Dimensions` (in inches, omitted when zero/infinite), and nested `Items` from the structure's packages.
- Extends `RL::StructureOptions` with a `handling_unit:` symbol param mapping to the 33 valid R+L unit type codes (PLT, SKD, BOX, TOTE, etc.), defaulting to `:pallet`.
- Mirrors what TForce already does, so calling code can stop sending top-level `Items` and instead send handling units with their own nested `Items`.