### PR TITLE
Group related commodities in R+L BOL handling units

### DIFF
--- a/lib/friendly_shipping/services/rl/bol_handling_units_serializer.rb
+++ b/lib/friendly_shipping/services/rl/bol_handling_units_serializer.rb
@@ -40,17 +40,27 @@ module FriendlyShipping
         # @param structure_options [StructureOptions]
         # @return [Array<Hash>]
         def self.items(structure, structure_options)
-          structure.packages.map do |package|
+          groups = structure.packages.group_by do |package|
             package_options = structure_options.options_for_package(package)
+            [
+              package.description.presence || "Commodities",
+              package_options.freight_class,
+              package_options.nmfc_primary_code,
+              package_options.nmfc_sub_code
+            ]
+          end
+
+          groups.map do |(description, freight_class, nmfc_primary_code, nmfc_sub_code), packages|
+            weight = packages.sum { |package| package.weight.convert_to(:pounds).value }.ceil
             {
               IsHazmat: false,
-              Pieces: 1,
+              Pieces: packages.size,
               PackageType: "BOX",
-              NMFCItemNumber: package_options.nmfc_primary_code,
-              NMFCSubNumber: package_options.nmfc_sub_code,
-              Class: package_options.freight_class,
-              Weight: package.weight.convert_to(:pounds).value.ceil,
-              Description: package.description.presence || "Commodities"
+              NMFCItemNumber: nmfc_primary_code,
+              NMFCSubNumber: nmfc_sub_code,
+              Class: freight_class,
+              Weight: weight,
+              Description: description
             }.compact
           end
         end

--- a/spec/friendly_shipping/services/rl/bol_handling_units_serializer_spec.rb
+++ b/spec/friendly_shipping/services/rl/bol_handling_units_serializer_spec.rb
@@ -171,4 +171,223 @@ RSpec.describe FriendlyShipping::Services::RL::BOLHandlingUnitsSerializer do
       expect(subject.first[:UnitType]).to eq("PLT")
     end
   end
+
+  context "when a structure has multiple packages sharing description, class, and NMFC codes" do
+    let(:options) do
+      FriendlyShipping::Services::RL::BOLOptions.new(
+        pickup_time_window: pickup_time_window,
+        structure_options: [
+          FriendlyShipping::Services::RL::StructureOptions.new(
+            structure_id: "pallet 1",
+            handling_unit: :pallet,
+            package_options: [
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 1a",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07",
+                freight_class: "92.5"
+              ),
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 1b",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07",
+                freight_class: "92.5"
+              ),
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 1c",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07",
+                freight_class: "92.5"
+              )
+            ]
+          ),
+          FriendlyShipping::Services::RL::StructureOptions.new(
+            structure_id: "pallet 2",
+            handling_unit: :skid,
+            package_options: [
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 2",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07",
+                freight_class: "92.5"
+              )
+            ]
+          )
+        ]
+      )
+    end
+
+    let(:pallet_1) do
+      FactoryBot.build(
+        :physical_structure,
+        id: "pallet 1",
+        container: FactoryBot.build(
+          :physical_pallet,
+          dimensions: [
+            Measured::Length(48, :in),
+            Measured::Length(40, :in),
+            Measured::Length(60, :in)
+          ]
+        ),
+        packages: [
+          FactoryBot.build(
+            :physical_package,
+            id: "package 1a",
+            description: "Tumblers",
+            items: [Physical::Item.new(weight: Measured::Weight(10.53, :lb))]
+          ),
+          FactoryBot.build(
+            :physical_package,
+            id: "package 1b",
+            description: "Tumblers",
+            items: [Physical::Item.new(weight: Measured::Weight(10.53, :lb))]
+          ),
+          FactoryBot.build(
+            :physical_package,
+            id: "package 1c",
+            description: "Tumblers",
+            items: [Physical::Item.new(weight: Measured::Weight(10.53, :lb))]
+          )
+        ]
+      )
+    end
+
+    it "collapses the packages into a single Item with the summed pieces and weight" do
+      expect(subject.first[:Items]).to eq(
+        [{
+          IsHazmat: false,
+          Pieces: 3,
+          PackageType: "BOX",
+          NMFCItemNumber: "87700",
+          NMFCSubNumber: "07",
+          Class: "92.5",
+          Weight: 33,
+          Description: "Tumblers"
+        }]
+      )
+    end
+
+    it "keeps a distinct commodity on a different structure as its own handling unit" do
+      expect(subject.last[:Items]).to eq(
+        [{
+          IsHazmat: false,
+          Pieces: 1,
+          PackageType: "BOX",
+          NMFCItemNumber: "87700",
+          NMFCSubNumber: "07",
+          Class: "92.5",
+          Weight: 2,
+          Description: "Wicks"
+        }]
+      )
+    end
+  end
+
+  context "when a structure mixes a shared commodity with a distinct one" do
+    let(:options) do
+      FriendlyShipping::Services::RL::BOLOptions.new(
+        pickup_time_window: pickup_time_window,
+        structure_options: [
+          FriendlyShipping::Services::RL::StructureOptions.new(
+            structure_id: "pallet 1",
+            handling_unit: :pallet,
+            package_options: [
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 1a",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07",
+                freight_class: "92.5"
+              ),
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 1b",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07",
+                freight_class: "92.5"
+              ),
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 1c",
+                nmfc_primary_code: "49880",
+                nmfc_sub_code: "01",
+                freight_class: "100"
+              )
+            ]
+          ),
+          FriendlyShipping::Services::RL::StructureOptions.new(
+            structure_id: "pallet 2",
+            handling_unit: :skid,
+            package_options: [
+              FriendlyShipping::Services::RL::PackageOptions.new(
+                package_id: "package 2",
+                nmfc_primary_code: "87700",
+                nmfc_sub_code: "07",
+                freight_class: "92.5"
+              )
+            ]
+          )
+        ]
+      )
+    end
+
+    let(:pallet_1) do
+      FactoryBot.build(
+        :physical_structure,
+        id: "pallet 1",
+        container: FactoryBot.build(
+          :physical_pallet,
+          dimensions: [
+            Measured::Length(48, :in),
+            Measured::Length(40, :in),
+            Measured::Length(60, :in)
+          ]
+        ),
+        packages: [
+          FactoryBot.build(
+            :physical_package,
+            id: "package 1a",
+            description: "Tumblers",
+            items: [Physical::Item.new(weight: Measured::Weight(10.53, :lb))]
+          ),
+          FactoryBot.build(
+            :physical_package,
+            id: "package 1b",
+            description: "Tumblers",
+            items: [Physical::Item.new(weight: Measured::Weight(10.53, :lb))]
+          ),
+          FactoryBot.build(
+            :physical_package,
+            id: "package 1c",
+            description: "Wicks",
+            items: [Physical::Item.new(weight: Measured::Weight(1.06, :lb))]
+          )
+        ]
+      )
+    end
+
+    it "emits two Items with pieces counts of 2 and 1" do
+      expect(subject.first[:Items]).to eq(
+        [
+          {
+            IsHazmat: false,
+            Pieces: 2,
+            PackageType: "BOX",
+            NMFCItemNumber: "87700",
+            NMFCSubNumber: "07",
+            Class: "92.5",
+            Weight: 22,
+            Description: "Tumblers"
+          },
+          {
+            IsHazmat: false,
+            Pieces: 1,
+            PackageType: "BOX",
+            NMFCItemNumber: "49880",
+            NMFCSubNumber: "01",
+            Class: "100",
+            Weight: 2,
+            Description: "Wicks"
+          }
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
- `BOLHandlingUnitsSerializer` now groups packages within each structure by `(description, freight_class, nmfc_primary_code, nmfc_sub_code)` and emits one `Item` per group with `Pieces: group.size` and summed `Weight` (ceiled to pounds).
- Restores the behavior of the deprecated `BOLStructuresSerializer` so printed R+L BOLs show a single `N/BOX` row per commodity per pallet instead of N separate `1/BOX` rows.
- Grouping stays scoped per-structure: the same commodity on two pallets remains two HandlingUnits, each with one Item.