### PR TITLE
Surface UPS customs invoice on `UpsJson::Label#data`

### DIFF
--- a/lib/friendly_shipping/services/ups_json/parse_labels_response.rb
+++ b/lib/friendly_shipping/services/ups_json/parse_labels_response.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'base64'
+
 module FriendlyShipping
   module Services
     class UpsJson
@@ -22,8 +24,9 @@ module FriendlyShipping
 
           def build_labels(labels_result)
             shipment_result = labels_result["ShipmentResponse"]["ShipmentResults"]
+            customs_form = build_customs_form(shipment_result)
 
-            Array.wrap(shipment_result["PackageResults"]).map do |package|
+            Array.wrap(shipment_result["PackageResults"]).map.with_index do |package, index|
               cost_breakdown = build_cost_breakdown(package)
               package_cost = cost_breakdown.values.any? ? cost_breakdown.values.sum : nil
 
@@ -39,7 +42,8 @@ module FriendlyShipping
                 data: {
                   cost_breakdown: cost_breakdown,
                   negotiated_rate: get_negotiated_rate(shipment_result),
-                  customer_context: labels_result["ShipmentResponse"]["Response"]["TransactionReference"]["CustomerContext"]
+                  customer_context: labels_result["ShipmentResponse"]["Response"]["TransactionReference"]["CustomerContext"],
+                  customs_form: (customs_form if index.zero?)
                 }.compact
               )
             end
@@ -63,6 +67,22 @@ module FriendlyShipping
           def get_negotiated_rate(shipment_result)
             negotiated_total_hash = shipment_result.dig("NegotiatedRateCharges", "TotalCharge")
             ParseMoneyHash.call(negotiated_total_hash, "TotalCharge")&.last
+          end
+
+          def build_customs_form(shipment_result)
+            form = shipment_result["Form"]
+            return nil unless form
+
+            image = form["Image"]
+            graphic = image && image["GraphicImage"]
+            return nil unless graphic
+
+            {
+              code: form["Code"],
+              description: form["Description"],
+              format: image.dig("ImageFormat", "Code"),
+              binary: Base64.decode64(graphic)
+            }
           end
         end
       end

--- a/spec/friendly_shipping/services/ups_json_spec.rb
+++ b/spec/friendly_shipping/services/ups_json_spec.rb
@@ -369,6 +369,7 @@ RSpec.describe FriendlyShipping::Services::UpsJson do
       expect(first_label.shipment_cost).to eq(Money.new(4796, 'USD'))
       expect(first_label.data[:negotiated_rate]).to eq(Money.new(4748, 'USD'))
       expect(first_label.data[:customer_context]).to eq('request-id-12345')
+      expect(first_label.data).not_to have_key(:customs_form)
     end
 
     context 'with SurePost' do
@@ -503,9 +504,16 @@ RSpec.describe FriendlyShipping::Services::UpsJson do
 
       it 'returns labels along with the response', vcr: { cassette_name: "ups_json/labels/international_paperless" } do
         expect(subject).to be_a(Dry::Monads::Result)
-        expect(subject.value!.data.length).to eq(2)
-        expect(subject.value!.data.map(&:tracking_number)).to be_present
-        expect(subject.value!.data.map(&:label_format).first).to eq("ZPL")
+        labels = subject.value!.data
+        expect(labels.length).to eq(2)
+        expect(labels.map(&:tracking_number)).to be_present
+        expect(labels.map(&:label_format).first).to eq("ZPL")
+
+        customs_form = labels.first.data[:customs_form]
+        expect(customs_form).to include(code: "01", format: "PDF")
+        expect(customs_form[:description]).to be_present
+        expect(customs_form[:binary]).to start_with("%PDF")
+        expect(labels.last.data).not_to have_key(:customs_form)
       end
 
       context 'when shipping to Puerto Rico' do
@@ -525,10 +533,13 @@ RSpec.describe FriendlyShipping::Services::UpsJson do
 
         it 'returns labels along with the response', vcr: { cassette_name: "ups_json/labels/international_puerto_rico" } do
           expect(subject).to be_a(Dry::Monads::Result)
-          expect(subject.value!.data.length).to eq(2)
-          expect(subject.value!.data.map(&:tracking_number)).to be_present
-          expect(subject.value!.data.map(&:label_data).first.length).to eq(5685)
-          expect(subject.value!.data.map(&:label_format).first).to eq("ZPL")
+          labels = subject.value!.data
+          expect(labels.length).to eq(2)
+          expect(labels.map(&:tracking_number)).to be_present
+          expect(labels.map(&:label_data).first.length).to eq(5685)
+          expect(labels.map(&:label_format).first).to eq("ZPL")
+          expect(labels.first.data[:customs_form]).to be_present
+          expect(labels.last.data).not_to have_key(:customs_form)
         end
       end
     end


### PR DESCRIPTION
When `paperless_invoice: true` is passed to `LabelOptions`, UPS returns a base64-encoded PDF of the international forms (customs invoice) on `ShipmentResults`. `ParseLabelsResponse` was silently dropping it; downstream consumers had to re-parse the raw response to get at it.

This patch exposes the decoded payload on `Label#data[:customs_form]` as `{ code:, description:, format:, binary: }`. The form is shipment-scoped (one per response), so it's attached to the first label only — duplicating a multi-MB PDF across N packages would be wasteful.

I also added `require 'base64'` at the top of the file. The existing `build_labels` already used `Base64.decode64` and was only working because earlier specs loaded `base64` transitively. The same latent fragility exists in `ups_json.rb`; happy to fix in a follow-up.

A few decisions I'd appreciate input on:

- **Naming**: `customs_form` vs `international_form` vs `commercial_invoice`. Code "01" covers more than just commercial invoice, so I went with `customs_form`.
- **`data:` hash vs first-class reader**: followed the existing convention (`negotiated_rate`, `customer_context` live in `data:`), but a top-level `Label#customs_form` reader would be friendlier.
- **`:binary` (decoded) vs raw base64**: decoding mirrors `label_data`. Could also expose the raw string if useful.