### PR TITLE
Add TForce Freight `get_documents` service method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - R+L: Add `BOLHandlingUnitsSerializer` and `handling_units_serializer` option on `BOLOptions`. When set, the create-BOL request sends `HandlingUnits` (with each structure's packages nested as `Items`) instead of the top-level `Items` array. `RL::StructureOptions` now accepts a `handling_unit:` symbol mapping to R+L unit type codes (PLT, SKD, BOX, TOTE, etc., default `:pallet`).
 - R+L: Deprecate `structures_serializer` and the top-level `Items` output in favor of `handling_units_serializer`. The default will flip in a future release.
 - TForce Freight: Add `get_documents` to retrieve documents (BOL, claims, delivery receipt, invoice, weight certificate) for an existing shipment by PRO number via the Documents API. Returns an array of `ShipmentDocument`. Categories are specified as friendly symbols (e.g. `:bill_of_lading`). Success/failure is determined from `summary.responseStatus.code` because the Documents API returns HTTP 200 even for errors.
+- TForce Freight: Add the `:address_labels_2x3` label type (code `09`) to `DocumentOptions`, matching the current Shipping API manual.
 
 ## [0.10.4] - 2025-08-14
 - Upgrade `physical` dependency to `~> 0.6`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 - R+L: Add `BOLHandlingUnitsSerializer` and `handling_units_serializer` option on `BOLOptions`. When set, the create-BOL request sends `HandlingUnits` (with each structure's packages nested as `Items`) instead of the top-level `Items` array. `RL::StructureOptions` now accepts a `handling_unit:` symbol mapping to R+L unit type codes (PLT, SKD, BOX, TOTE, etc., default `:pallet`).
 - R+L: Deprecate `structures_serializer` and the top-level `Items` output in favor of `handling_units_serializer`. The default will flip in a future release.
+- TForce Freight: Add `get_documents` to retrieve documents (BOL, claims, delivery receipt, invoice, weight certificate) for an existing shipment by PRO number via the Documents API. Returns an array of `ShipmentDocument`. Categories are specified as friendly symbols (e.g. `:bill_of_lading`). Success/failure is determined from `summary.responseStatus.code` because the Documents API returns HTTP 200 even for errors.
 
 ## [0.10.4] - 2025-08-14
 - Upgrade `physical` dependency to `~> 0.6`

--- a/lib/friendly_shipping/services/tforce_freight.rb
+++ b/lib/friendly_shipping/services/tforce_freight.rb
@@ -31,7 +31,8 @@ module FriendlyShipping
       RESOURCES = {
         rates: '/rating/getRate',
         create_pickup: '/pickup/request',
-        create_bol: '/shipping/bol/create'
+        create_bol: '/shipping/bol/create',
+        documents: '/documents/pro'
       }.freeze
 
       # @param access_token [AccessToken] the access token
@@ -141,6 +142,22 @@ module FriendlyShipping
 
         client.post(request).fmap do |response|
           ParseCreateBOLResponse.call(response: response, request: request)
+        end
+      end
+
+      # Get documents (BOL, invoice, delivery receipt, etc.) for an existing shipment by PRO number.
+      # @see https://developer.tforcefreight.com/api-details#api=Images-api-cie-v1&operation=getDocumentsByPro API documentation
+      #
+      # @param pro_number [String] the 9-digit PRO number for which to get documents
+      # @param document_categories [Array<Symbol>] the categories to retrieve (see {GenerateDocumentsRequestHash::DOCUMENT_CATEGORIES})
+      # @param debug [Boolean] whether to append debug information to the API result
+      # @return [Result<ApiResult<Array<ShipmentDocument>>>] the documents returned from TForce encoded in a `ApiResult` object
+      def get_documents(pro_number, document_categories:, debug: false)
+        documents_request_hash = GenerateDocumentsRequestHash.call(pro: pro_number, document_categories: document_categories)
+        request = build_request(:documents, documents_request_hash, debug)
+
+        client.post(request).bind do |response|
+          ParseDocumentsResponse.call(response: response, request: request)
         end
       end
 

--- a/lib/friendly_shipping/services/tforce_freight/document_options.rb
+++ b/lib/friendly_shipping/services/tforce_freight/document_options.rb
@@ -50,7 +50,8 @@ module FriendlyShipping
           address_labels_2x1: "05",
           address_labels_2x2: "06",
           thermal_labels_4x6: "07",
-          thermal_labels_4x8: "08"
+          thermal_labels_4x8: "08",
+          address_labels_2x3: "09"
         }.freeze
 
         # @param type [Symbol] the document type (see [DOCUMENT_TYPES])

--- a/lib/friendly_shipping/services/tforce_freight/generate_documents_request_hash.rb
+++ b/lib/friendly_shipping/services/tforce_freight/generate_documents_request_hash.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      # Generates a request hash for getting documents by PRO number.
+      class GenerateDocumentsRequestHash
+        # Maps friendly names to TForce document category codes.
+        DOCUMENT_CATEGORIES = {
+          bill_of_lading: "BOL",
+          claims: "CLM",
+          delivery_receipt: "DR",
+          invoice: "INVC",
+          weight_certificate: "WGHT"
+        }.freeze
+
+        class << self
+          # @param pro [String] the 9-digit PRO number
+          # @param document_categories [Array<Symbol>] the categories to retrieve (see {DOCUMENT_CATEGORIES})
+          # @return [Hash]
+          def call(pro:, document_categories:)
+            {
+              pro: pro,
+              documentCategories: document_categories.map { |category| DOCUMENT_CATEGORIES.fetch(category) }
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/tforce_freight/parse_documents_response.rb
+++ b/lib/friendly_shipping/services/tforce_freight/parse_documents_response.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module FriendlyShipping
+  module Services
+    class TForceFreight
+      # Parses a get documents by PRO response into an `ApiResult`.
+      class ParseDocumentsResponse
+        extend Dry::Monads::Result::Mixin
+
+        # Maps document category codes to friendly names.
+        REVERSE_DOCUMENT_CATEGORIES = GenerateDocumentsRequestHash::DOCUMENT_CATEGORIES.map(&:reverse_each).to_h(&:to_a)
+
+        # The response status code that indicates success. The Documents API returns
+        # HTTP 200 even for errors, so success must be determined from the body.
+        SUCCESS_CODE = "1"
+
+        class << self
+          # @param request [Request] the original request
+          # @param response [RestClient::Response] the response to parse
+          # @return [Result<ApiResult<Array<ShipmentDocument>>>] the parsed documents on success,
+          #   or a failure containing the error message
+          def call(request:, response:)
+            json = JSON.parse(response.body)
+            status_code = json.dig("summary", "responseStatus", "code")
+
+            unless status_code == SUCCESS_CODE
+              message = json.dig("summary", "responseStatus", "message")
+              return Failure(
+                ApiResult.new(
+                  [status_code, message].compact.join(": "),
+                  original_request: request,
+                  original_response: response
+                )
+              )
+            end
+
+            documents = json.fetch("detail", []).compact.map do |detail|
+              category = detail["category"]
+              ShipmentDocument.new(
+                document_type: REVERSE_DOCUMENT_CATEGORIES.fetch(category, category),
+                document_format: :pdf,
+                status: detail.dig("detailStatus", "documentStatus"),
+                binary: Base64.decode64(detail["data"])
+              )
+            end
+
+            Success(
+              ApiResult.new(
+                documents,
+                original_request: request,
+                original_response: response
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/tforce_freight/documents/success.yml
+++ b/spec/cassettes/tforce_freight/documents/success.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.tforcefreight.com/documents/pro?api-version=v1
+    body:
+      encoding: UTF-8
+      string: '{"pro":"123456789","documentCategories":["BOL"]}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (darwin25 arm64) ruby/4.0.3p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer %ACCESS_TOKEN%
+      Content-Length:
+      - '48'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - api.tforcefreight.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache,no-store,must-revalidate,max-age=0,no-cache="set-cookie"
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '412'
+      Content-Type:
+      - application/json
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1;mode=block
+      Request-Context:
+      - appId=cid-v1:00000000-0000-0000-0000-000000000000
+      Date:
+      - Tue, 30 Jun 2026 15:03:13 GMT
+    body:
+      encoding: UTF-8
+      string: '{"summary":{"responseStatus":{"code":"1","message":"Success"},"transactionReference":{"transactionId":"00000000-0000-0000-0000-000000000000"}},"detail":[{"detailStatus":{"code":"1","message":"Success","documentStatus":"Active"},"documentType":{"name":"BOL","description":"Bill
+        of Lading"},"id":"REDACTED","documentSize":106162,"updateDate":"REDACTED","category":"BOL","data":"JVBERi1yZWRhY3RlZCBmb3IgVkNSCg=="}]}'
+  recorded_at: Tue, 30 Jun 2026 15:03:14 GMT
+recorded_with: VCR 6.4.0

--- a/spec/fixtures/tforce_freight/documents/failure.json
+++ b/spec/fixtures/tforce_freight/documents/failure.json
@@ -1,0 +1,14 @@
+{
+  "summary": {
+    "responseStatus": {
+      "code": "IMG_000201",
+      "message": "MyLTL Enrollment is required"
+    },
+    "transactionReference": {
+      "transactionId": "00000000-0000-0000-0000-000000000000"
+    }
+  },
+  "detail": [
+    null
+  ]
+}

--- a/spec/fixtures/tforce_freight/documents/success.json
+++ b/spec/fixtures/tforce_freight/documents/success.json
@@ -1,0 +1,45 @@
+{
+  "summary": {
+    "responseStatus": {
+      "code": "1",
+      "message": "Success"
+    },
+    "transactionReference": {
+      "transactionId": "d84d46e3-342f-4794-a64e-1a0f3ef2e1b0"
+    }
+  },
+  "detail": [
+    {
+      "detailStatus": {
+        "code": "1",
+        "message": "Success",
+        "documentStatus": "Active"
+      },
+      "documentType": {
+        "name": "OSD",
+        "description": "OS&D"
+      },
+      "id": "493315",
+      "documentSize": 17400,
+      "updateDate": "2018-11-16T15:01:04-05:00",
+      "category": "CLM",
+      "data": "JVBERi0xLjQK"
+    },
+    {
+      "detailStatus": {
+        "code": "1",
+        "message": "Success",
+        "documentStatus": "Active"
+      },
+      "documentType": {
+        "name": "BOL",
+        "description": "Bill Of Lading"
+      },
+      "id": "548489",
+      "documentSize": 92016,
+      "updateDate": "2022-02-23T08:11:44-05:00",
+      "category": "BOL",
+      "data": "JVBERi0xLjQK"
+    }
+  ]
+}

--- a/spec/friendly_shipping/services/tforce_freight/document_options_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/document_options_spec.rb
@@ -20,4 +20,12 @@ RSpec.describe FriendlyShipping::Services::TForceFreight::DocumentOptions do
     expect(options.thermal_code).to eq("01")
     expect(options.label_type_code).to eq("07")
   end
+
+  context "with the 2x3 address label type" do
+    subject(:options) { described_class.new(label_type: :address_labels_2x3) }
+
+    it "returns the expected label type code" do
+      expect(options.label_type_code).to eq("09")
+    end
+  end
 end

--- a/spec/friendly_shipping/services/tforce_freight/generate_documents_request_hash_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/generate_documents_request_hash_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::GenerateDocumentsRequestHash do
+  describe ".call" do
+    subject(:call) { described_class.call(pro: pro, document_categories: document_categories) }
+
+    let(:pro) { "885728922" }
+    let(:document_categories) { [:bill_of_lading] }
+
+    it "passes the PRO number through" do
+      expect(call[:pro]).to eq("885728922")
+    end
+
+    it "maps friendly category names to codes" do
+      expect(call[:documentCategories]).to eq(["BOL"])
+    end
+
+    context "with multiple categories" do
+      let(:document_categories) { %i[bill_of_lading claims delivery_receipt invoice weight_certificate] }
+
+      it "maps each category to its code" do
+        expect(call[:documentCategories]).to eq(%w[BOL CLM DR INVC WGHT])
+      end
+    end
+
+    context "with an unknown category" do
+      let(:document_categories) { [:nope] }
+
+      it "raises a KeyError" do
+        expect { call }.to raise_error(KeyError)
+      end
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight/parse_documents_response_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight/parse_documents_response_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::Services::TForceFreight::ParseDocumentsResponse do
+  describe ".call" do
+    subject(:call) { described_class.call(request: nil, response: response) }
+
+    let(:response) { double(body: response_body) }
+
+    context "with a successful response" do
+      let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "tforce_freight", "documents", "success.json")) }
+
+      it { is_expected.to be_success }
+
+      it "returns an array of shipment documents" do
+        documents = call.value!.data
+        expect(documents).to be_a(Array)
+        expect(documents.size).to eq(2)
+        expect(documents).to all(be_a(FriendlyShipping::Services::TForceFreight::ShipmentDocument))
+      end
+
+      it "has the right data" do
+        document_1 = call.value!.data[0]
+        expect(document_1.document_type).to eq(:claims)
+        expect(document_1.document_format).to eq(:pdf)
+        expect(document_1.status).to eq("Active")
+        expect(document_1.binary).to start_with("%PDF-")
+
+        document_2 = call.value!.data[1]
+        expect(document_2.document_type).to eq(:bill_of_lading)
+        expect(document_2.document_format).to eq(:pdf)
+        expect(document_2.status).to eq("Active")
+        expect(document_2.binary).to start_with("%PDF-")
+      end
+    end
+
+    context "with an error response (HTTP 200 with an error code in the body)" do
+      let(:response_body) { File.read(File.join(gem_root, "spec", "fixtures", "tforce_freight", "documents", "failure.json")) }
+
+      it { is_expected.to be_failure }
+
+      it "surfaces the response status code and message" do
+        expect(call.failure.to_s).to eq("IMG_000201: MyLTL Enrollment is required")
+      end
+    end
+  end
+end

--- a/spec/friendly_shipping/services/tforce_freight_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight_spec.rb
@@ -531,4 +531,25 @@ RSpec.describe FriendlyShipping::Services::TForceFreight do
       end
     end
   end
+
+  describe "#get_documents" do
+    subject(:get_documents) { service.get_documents(pro_number, document_categories: document_categories) }
+
+    let(:pro_number) { "123456789" }
+    let(:document_categories) { [:bill_of_lading] }
+
+    context "with a valid request", vcr: { cassette_name: "tforce_freight/documents/success" } do
+      it { is_expected.to be_success }
+
+      it "returns the documents" do
+        documents = get_documents.value!.data
+        expect(documents).to be_a(Array)
+        expect(documents).to all(be_a(FriendlyShipping::Services::TForceFreight::ShipmentDocument))
+
+        document = documents.first
+        expect(document.document_format).to eq(:pdf)
+        expect(document.binary).to start_with("%PDF-")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds a `get_documents` method to the TForce Freight service for retrieving documents (BOL, claims, delivery receipt, invoice, weight certificate) for an existing shipment by PRO number, via the TForce Documents API (`POST /documents/pro`). Also adds the `09` address-label type that was missing from `DocumentOptions`.

```ruby
result = service.get_documents("735742641", document_categories: [:bill_of_lading])
documents = result.value!.data # => [#<ShipmentDocument document_type: :bill_of_lading, document_format: :pdf, ...>]
```

## Commits (reviewable in order)

1. **Add TForce Freight get_documents for retrieving documents by PRO** - the request generator (`GenerateDocumentsRequestHash`, friendly category symbols mapped to API codes), response parser (`ParseDocumentsResponse`), service wiring, unit specs, and fixtures.
2. **Add get_documents integration spec with recorded VCR cassette** - integration coverage recorded against production. The token is filtered and the PDF binary / id / update date were redacted before committing.
3. **Add TForce Freight 2x3 address label type** - adds `:address_labels_2x3` (code `09`), which is in the current Shipping API manual but was missing from `DocumentOptions::LABEL_TYPE_CODES`.

## Notes

- The Documents API returns **HTTP 200 even for errors** (e.g. `IMG_000201` "MyLTL Enrollment is required"), so the parser inspects `summary.responseStatus.code` to return a `Success`/`Failure` rather than relying on HTTP status, and tolerates `null` entries in the `detail` array.
- Categories map to the API's short codes: `:bill_of_lading` -> `BOL`, `:claims` -> `CLM`, `:delivery_receipt` -> `DR`, `:invoice` -> `INVC`, `:weight_certificate` -> `WGHT`. Per the TForce manuals there is no shipping-label category in the Documents API; labels are only returned by `create_bol`.

## Testing

- `bundle exec rspec spec/friendly_shipping/services/tforce_freight_spec.rb spec/friendly_shipping/services/tforce_freight/` - 139 examples, 0 failures
- `bundle exec rubocop` on all changed files - no offenses