### PR TITLE
Add canonical LTL carrier SCAC data and catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- `Carrier`: Add a first-class `scac` attribute (Standard Carrier Alpha Code).
+- Add `FriendlyShipping::LTLCarriers`, a canonical catalog of the LTL carriers freight brokers (e.g. Reconex) rate-shop, keyed by SCAC. Each entry is a `Carrier` carrying its full list of SCACs (`data[:scacs]`) and a tracking-URL template. Provides `LTLCarriers.all`, `LTLCarriers.find_by_scac`, and `LTLCarriers.tracking_url_for`.
+- R+L: Add a `CARRIER` constant (SCAC `RLCA`) and a `carriers` method returning it, matching the other freight services.
+- TForce Freight: Add SCAC `UPGF` to the `CARRIER` constant.
 - R+L: Add `BOLHandlingUnitsSerializer` and `handling_units_serializer` option on `BOLOptions`. When set, the create-BOL request sends `HandlingUnits` (with each structure's packages nested as `Items`) instead of the top-level `Items` array. `RL::StructureOptions` now accepts a `handling_unit:` symbol mapping to R+L unit type codes (PLT, SKD, BOX, TOTE, etc., default `:pallet`).
 - R+L: Deprecate `structures_serializer` and the top-level `Items` output in favor of `handling_units_serializer`. The default will flip in a future release.
 - TForce Freight: Add `get_documents` to retrieve documents (BOL, claims, delivery receipt, invoice, weight certificate) for an existing shipment by PRO number via the Documents API. Returns an array of `ShipmentDocument`. Categories are specified as friendly symbols (e.g. `:bill_of_lading`). Success/failure is determined from `summary.responseStatus.code` because the Documents API returns HTTP 200 even for errors.

--- a/lib/friendly_shipping.rb
+++ b/lib/friendly_shipping.rb
@@ -25,6 +25,7 @@ loader.inflector.inflect(
   "generate_create_bol_request_hash" => "GenerateCreateBOLRequestHash",
   "parse_xml_response" => "ParseXMLResponse",
   "usps_ship" => "USPSShip",
+  "ltl_carriers" => "LTLCarriers",
   "shipping_methods" => "SHIPPING_METHODS"
 )
 loader.setup

--- a/lib/friendly_shipping/carrier.rb
+++ b/lib/friendly_shipping/carrier.rb
@@ -12,6 +12,9 @@ module FriendlyShipping
     # @return [String] the carrier's unique code
     attr_reader :code
 
+    # @return [String, nil] the carrier's SCAC (Standard Carrier Alpha Code)
+    attr_reader :scac
+
     # @return [Array<ShippingMethod>] the shipping methods available on this carrier
     attr_reader :shipping_methods
 
@@ -24,13 +27,15 @@ module FriendlyShipping
     # @param id [Integer, String] a unique identifier for this carrier
     # @param name [String] the carrier's name
     # @param code [String] the carrier's unique code
+    # @param scac [String] the carrier's SCAC (Standard Carrier Alpha Code)
     # @param shipping_methods [Array<ShippingMethod>] the shipping methods available on this carrier
     # @param balance [Float] the remaining balance for this carrier
     # @param data [Hash] additional data related to this carrier
-    def initialize(id: nil, name: nil, code: nil, shipping_methods: [], balance: nil, data: {})
+    def initialize(id: nil, name: nil, code: nil, scac: nil, shipping_methods: [], balance: nil, data: {})
       @id = id
       @name = name
       @code = code
+      @scac = scac
       @shipping_methods = shipping_methods
       @balance = balance
       @data = data

--- a/lib/friendly_shipping/ltl_carriers.rb
+++ b/lib/friendly_shipping/ltl_carriers.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module FriendlyShipping
+  # A canonical catalog of the LTL (less-than-truckload) carriers that freight
+  # brokers such as {Services::Reconex} rate-shop, keyed by SCAC (Standard
+  # Carrier Alpha Code).
+  #
+  # Each entry is a {Carrier} whose first-class {Carrier#scac} is the carrier's
+  # primary SCAC. Because a single carrier can report more than one SCAC (FedEx
+  # Freight reports two: one for Priority and one for Economy), every SCAC the
+  # carrier may report is listed in `data[:scacs]`. Lookups match against that
+  # full list.
+  #
+  # `data[:tracking_url_template]` uses `:tracking` as the placeholder for the
+  # PRO/tracking number, matching the convention used by tracking-code renderers.
+  module LTLCarriers
+    # All known LTL carriers, one entry per carrier.
+    #
+    # Carriers that friendly_shipping has a dedicated service for are referenced
+    # from that service's canonical `CARRIER` constant, so they are defined in
+    # exactly one place. The remaining carriers have no dedicated service and are
+    # defined here.
+    #
+    # @return [Array<Carrier>]
+    ALL = [
+      Services::RL::CARRIER,
+      Services::TForceFreight::CARRIER,
+      Carrier.new(
+        id: "saia",
+        name: "SAIA",
+        scac: "SAIA",
+        data: {
+          scacs: ["SAIA"],
+          tracking_url_template: "https://www.saiasecure.com/tracing/n_manifest.asp?link=y&pro=:tracking"
+        }
+      ),
+      Carrier.new(
+        id: "fedex_freight",
+        name: "FedEx Freight",
+        scac: "FXFE",
+        data: {
+          scacs: ["FXFE", "FXNL"],
+          tracking_url_template: "https://www.fedexfreight.com/fedextrack/?trknbr=:tracking"
+        }
+      ),
+      Carrier.new(
+        id: "southeastern_freight_lines",
+        name: "Southeastern Freight Lines",
+        scac: "SEFL",
+        data: {
+          scacs: ["SEFL"],
+          tracking_url_template: "https://www.sefl.com/webconnect/tracing?Type=PN&RefNum1=:tracking"
+        }
+      ),
+      Carrier.new(
+        id: "xpo",
+        name: "XPO",
+        scac: "CNWY",
+        data: {
+          scacs: ["CNWY"],
+          tracking_url_template: "https://ext-web.ltl-xpo.com/public-app/shipments?referenceNumber=:tracking"
+        }
+      )
+    ].freeze
+
+    class << self
+      # @return [Array<Carrier>] all known LTL carriers
+      def all
+        ALL
+      end
+
+      # Finds the carrier that reports the given SCAC.
+      #
+      # @param scac [String, nil] a SCAC (case-insensitive)
+      # @return [Carrier, nil] the matching carrier, or nil if none reports the SCAC
+      def find_by_scac(scac)
+        return nil if scac.nil?
+
+        normalized = scac.upcase
+        ALL.find { |carrier| carrier.data[:scacs].include?(normalized) }
+      end
+
+      # Builds a tracking URL for the given SCAC and PRO/tracking number.
+      #
+      # @param scac [String, nil] a SCAC (case-insensitive)
+      # @param tracking [String] the PRO/tracking number
+      # @return [String, nil] the tracking URL, or nil when the SCAC is unknown
+      #   or the carrier has no tracking URL template
+      def tracking_url_for(scac, tracking:)
+        template = find_by_scac(scac)&.data&.[](:tracking_url_template)
+        return nil if template.nil?
+
+        template.gsub(":tracking", tracking.to_s)
+      end
+    end
+  end
+end

--- a/lib/friendly_shipping/services/rl.rb
+++ b/lib/friendly_shipping/services/rl.rb
@@ -34,6 +34,20 @@ module FriendlyShipping
         transit_times: "TransitTimes"
       }.freeze
 
+      # The R+L Carriers carrier. This is the canonical definition referenced by
+      # {FriendlyShipping::LTLCarriers}.
+      CARRIER = FriendlyShipping::Carrier.new(
+        id: 'rl',
+        name: 'R+L Carriers',
+        code: 'rl',
+        scac: 'RLCA',
+        shipping_methods: SHIPPING_METHODS,
+        data: {
+          scacs: ['RLCA'],
+          tracking_url_template: 'https://www.rlcarriers.com/freight/shipping/shipment-tracing?pro=:tracking&docType=PRO'
+        }
+      )
+
       # @param [String] api_key the API key for this carrier
       # @param [Boolean] test whether to use test API endpoints
       # @param [HttpClient] client the HTTP client to use for requests
@@ -43,6 +57,11 @@ module FriendlyShipping
 
         error_handler = ApiErrorHandler.new(api_error_class: RL::ApiError)
         @client = client || HttpClient.new(error_handler: error_handler)
+      end
+
+      # @return [Success<Array<Carrier>>] the carriers for this service
+      def carriers
+        Success([CARRIER])
       end
 
       # Create an LTL Bill of Lading (BOL) and schedule a pickup with R+L Carriers.

--- a/lib/friendly_shipping/services/tforce_freight.rb
+++ b/lib/friendly_shipping/services/tforce_freight.rb
@@ -16,12 +16,18 @@ module FriendlyShipping
       # @return [HttpClient] the HTTP client
       attr_reader :client
 
-      # The TForce Freight carrier
+      # The TForce Freight carrier. This is the canonical definition referenced by
+      # {FriendlyShipping::LTLCarriers}.
       CARRIER = FriendlyShipping::Carrier.new(
         id: 'tforce_freight',
         name: 'TForce Freight',
         code: 'tforce_freight-freight',
-        shipping_methods: SHIPPING_METHODS
+        scac: 'UPGF',
+        shipping_methods: SHIPPING_METHODS,
+        data: {
+          scacs: ['UPGF'],
+          tracking_url_template: 'https://www.tforcefreight.com/ltl/apps/Tracking?proNumbers=:tracking'
+        }
       )
 
       # The base URL for TForce API requests

--- a/spec/friendly_shipping/carrier_spec.rb
+++ b/spec/friendly_shipping/carrier_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe FriendlyShipping::Carrier do
   it { is_expected.to respond_to :id }
   it { is_expected.to respond_to :name }
   it { is_expected.to respond_to :code }
+  it { is_expected.to respond_to :scac }
   it { is_expected.to respond_to :shipping_methods }
   it { is_expected.to respond_to :balance }
   it { is_expected.to respond_to :data }

--- a/spec/friendly_shipping/ltl_carriers_spec.rb
+++ b/spec/friendly_shipping/ltl_carriers_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FriendlyShipping::LTLCarriers do
+  describe ".all" do
+    subject(:carriers) { described_class.all }
+
+    it { is_expected.to all(be_a(FriendlyShipping::Carrier)) }
+
+    it "includes the expected carriers" do
+      expect(carriers.map(&:name)).to contain_exactly(
+        "R+L Carriers",
+        "TForce Freight",
+        "SAIA",
+        "FedEx Freight",
+        "Southeastern Freight Lines",
+        "XPO"
+      )
+    end
+  end
+
+  describe ".find_by_scac" do
+    it "resolves confirmed SCACs to the right carrier" do
+      expect(described_class.find_by_scac("RLCA").name).to eq("R+L Carriers")
+      expect(described_class.find_by_scac("UPGF").name).to eq("TForce Freight")
+      expect(described_class.find_by_scac("SAIA").name).to eq("SAIA")
+    end
+
+    it "resolves every SCAC of a multi-SCAC carrier" do
+      expect(described_class.find_by_scac("FXFE").name).to eq("FedEx Freight")
+      expect(described_class.find_by_scac("FXNL").name).to eq("FedEx Freight")
+    end
+
+    it "is case-insensitive" do
+      expect(described_class.find_by_scac("rlca").name).to eq("R+L Carriers")
+    end
+
+    it "returns nil for an unknown SCAC" do
+      expect(described_class.find_by_scac("NOPE")).to be_nil
+    end
+
+    it "returns nil for a nil SCAC" do
+      expect(described_class.find_by_scac(nil)).to be_nil
+    end
+  end
+
+  describe ".tracking_url_for" do
+    it "interpolates the tracking number for a carrier with a template" do
+      expect(described_class.tracking_url_for("SEFL", tracking: "123")).to eq(
+        "https://www.sefl.com/webconnect/tracing?Type=PN&RefNum1=123"
+      )
+    end
+
+    it "resolves multi-SCAC carriers by any of their SCACs" do
+      expect(described_class.tracking_url_for("FXNL", tracking: "456")).to eq(
+        "https://www.fedexfreight.com/fedextrack/?trknbr=456"
+      )
+    end
+
+    it "is case-insensitive" do
+      expect(described_class.tracking_url_for("cnwy", tracking: "789")).to eq(
+        "https://ext-web.ltl-xpo.com/public-app/shipments?referenceNumber=789"
+      )
+    end
+
+    it "builds URLs for the carriers with a dedicated service" do
+      expect(described_class.tracking_url_for("RLCA", tracking: "123")).to eq(
+        "https://www.rlcarriers.com/freight/shipping/shipment-tracing?pro=123&docType=PRO"
+      )
+      expect(described_class.tracking_url_for("UPGF", tracking: "123")).to eq(
+        "https://www.tforcefreight.com/ltl/apps/Tracking?proNumbers=123"
+      )
+      expect(described_class.tracking_url_for("SAIA", tracking: "123")).to eq(
+        "https://www.saiasecure.com/tracing/n_manifest.asp?link=y&pro=123"
+      )
+    end
+
+    it "returns nil for an unknown SCAC" do
+      expect(described_class.tracking_url_for("NOPE", tracking: "123")).to be_nil
+    end
+  end
+end

--- a/spec/friendly_shipping/services/rl_spec.rb
+++ b/spec/friendly_shipping/services/rl_spec.rb
@@ -19,6 +19,25 @@ RSpec.describe FriendlyShipping::Services::RL do
     it { expect(client.error_handler.api_error_class).to eq(FriendlyShipping::Services::RL::ApiError) }
   end
 
+  describe "#carriers" do
+    subject(:carriers) { service.carriers.value! }
+
+    it "has only one carrier with five shipping methods" do
+      expect(carriers.length).to eq(1)
+      expect(carriers.first.scac).to eq("RLCA")
+      expect(carriers.first.shipping_methods.map(&:service_code)).to contain_exactly(
+        "STD", "GSDS", "GSAM", "GSHW", "EXPD"
+      )
+      expect(carriers.first.shipping_methods.map(&:name)).to contain_exactly(
+        "Standard Service",
+        "Guaranteed Service",
+        "Guaranteed AM Service",
+        "Guaranteed Hourly Window Service",
+        "Expedited Service"
+      )
+    end
+  end
+
   let(:shipment) do
     FactoryBot.build(
       :physical_shipment,

--- a/spec/friendly_shipping/services/tforce_freight_spec.rb
+++ b/spec/friendly_shipping/services/tforce_freight_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe FriendlyShipping::Services::TForceFreight do
 
     it "has only one carrier with four shipping methods" do
       expect(carriers.length).to eq(1)
+      expect(carriers.first.scac).to eq("UPGF")
       expect(carriers.first.shipping_methods.map(&:service_code)).to contain_exactly(
         "308", "309", "334", "349"
       )


### PR DESCRIPTION
Makes friendly_shipping the canonical source of LTL carrier to SCAC data so consumers can stop hardcoding their own carrier/SCAC/tracking-URL maps. Adds a first-class `scac` attribute to `Carrier`, gives R+L a `CARRIER` constant (SCAC `RLCA`) plus a `carriers` method and adds SCAC `UPGF` to the TForce Freight carrier. Introduces `FriendlyShipping::LTLCarriers`, a catalog of the LTL carriers freight brokers (e.g. Reconex) rate-shop keyed by SCAC, where each entry is a `Carrier` carrying its full list of SCACs (`data[:scacs]`) and a tracking-URL template, with `find_by_scac` and `tracking_url_for` lookups. Carriers that have a dedicated service (R+L, TForce) are referenced from that service's `CARRIER` constant so each carrier is defined in exactly one place.