### PR TITLE
Add UPS Worldwide Economy shipping method

### DIFF
--- a/lib/friendly_shipping/services/ups_json/shipping_methods.rb
+++ b/lib/friendly_shipping/services/ups_json/shipping_methods.rb
@@ -32,6 +32,12 @@ module FriendlyShipping
         ['US', 'international', 'UPS Worldwide Expedited®', '08'],
         ['US', 'international', 'UPS Worldwide Express Plus®', '54'],
         ['US', 'international', 'UPS Worldwide Saver', '65'],
+        # Worldwide Economy resolves for rates only (matched by service code). It is not
+        # returned by the Time in Transit API, so these names are never matched against a
+        # serviceLevelDescription and are display-only. DDU (17) and DDP (72) differ only
+        # in duty handling. See ParseTimingsResponse for the name-based timings match.
+        ['US', 'international', 'UPS Worldwide Economy DDU', '17'],
+        ['US', 'international', 'UPS Worldwide Economy DDP', '72'],
         ['US', 'domestic', 'UPS 2nd Day Air®', '02'],
         ['US', 'domestic', 'UPS 2nd Day Air A.M.', '59'],
         ['US', 'domestic', 'UPS 3 Day Select®', '12'],

--- a/spec/friendly_shipping/services/ups_json_spec.rb
+++ b/spec/friendly_shipping/services/ups_json_spec.rb
@@ -25,6 +25,35 @@ RSpec.describe FriendlyShipping::Services::UpsJson do
         expect(shipping_method.international? || shipping_method.domestic?).to be true
       end
     end
+
+    describe 'UPS Worldwide Economy' do
+      subject(:worldwide_economy) do
+        described_class::SHIPPING_METHODS.select { |sm| sm.name.include?('Worldwide Economy') }
+      end
+
+      it 'includes both DDU and DDP variants' do
+        expect(worldwide_economy.map(&:name)).to contain_exactly(
+          'UPS Worldwide Economy DDU',
+          'UPS Worldwide Economy DDP'
+        )
+      end
+
+      it 'maps DDU to service code 17 and DDP to service code 72' do
+        codes = worldwide_economy.to_h { |sm| [sm.name, sm.service_code] }
+        expect(codes).to eq(
+          'UPS Worldwide Economy DDU' => '17',
+          'UPS Worldwide Economy DDP' => '72'
+        )
+      end
+
+      it 'is an international US-origin service' do
+        worldwide_economy.each do |sm|
+          expect(sm).to be_international
+          expect(sm).not_to be_domestic
+          expect(sm.origin_countries.map(&:code)).to eq(['US'])
+        end
+      end
+    end
   end
 
   describe "#create_access_token" do


### PR DESCRIPTION
Adds UPS Worldwide Economy to the UPS JSON shipping method catalog as two US-origin international services: DDU (Delivery Duty Unpaid, service code 17) and DDP (Delivery Duty Paid, service code 72). Scope is US origin only, matching UPS availability (valid origins are the 48 contiguous states, which the catalog keys as the US country group). Both entries are added to the existing SHIPPING_METHODS array, so they flow through to the carrier and rate/label request payloads automatically. Adds specs asserting both variants are present with the correct service codes and are classified as international US-origin methods.